### PR TITLE
feat: 0.4.0 — complete XState v5 config alignment with deprecation path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ The critical execution order is: `main_event_loop` → `microstep` → `main_eve
 
 ---
 
-## Current state (0.3.0 in progress)
+## Current state (0.4.0 in progress)
 
 **Working:**
 - Hierarchical (compound) states
@@ -57,15 +57,29 @@ The critical execution order is: `main_event_loop` → `microstep` → `main_eve
   Driven by a pluggable `Clock`: `SimulatedClock` (deterministic, advance with
   `clock.increment(ms)`) or `ThreadClock` (real wall-clock, the default)
 - SCXML XML import (requires `pip install xstate[scxml]` for JS-cond evaluation)
+- **XState v5 config alignment** (0.4.0):
+  - `guard` is the canonical key for transition conditions; `cond` still works
+    but emits a `DeprecationWarning`
+  - `output` is the canonical key for final-state data; `data` still works but
+    emits a `DeprecationWarning`
+  - `always:` for eventless transitions (alongside the v4 `on: {"": ...}` form)
+  - Single-object handler signatures via keyword-only params:
+    `def guard(*, context, event): ...` (the v5 `({context, event}) =>` shape).
+    The v4 positional styles still work — see the handler-signature note below
+  - `MachineSnapshot` (public alias of `State`) carries `status`
+    (`"active"`/`"done"`/`"error"`), `output`, and `error`; plus `state.matches()`
+    and `state.can(event)`
 
 **Stubbed / incomplete:**
 - Async support (0.5.0 target)
-- `setup()` API + XState v5 handler signatures (0.4.0+ target)
+- `setup()` API (0.6.0+ target)
 - Invoked services / actors (`invoke`) (0.5.0 target)
 
-Handler-signature note: guards/assigners are invoked arity-aware (`()`,
-`(context)`, or `(context, event)`) by `algorithm._invoke`. The XState v5
-single-object signature `({context, event})` is a 0.4.0 target.
+Handler-signature note: guards/assigners are invoked arity-aware by
+`algorithm._invoke`, which supports four calling conventions: `()`, `(context)`,
+`(context, event)` (the v4 positional styles), and keyword-only
+`(*, context, event)` (the v5 single-object style). `error` status plumbing is a
+placeholder until the actor model lands (0.5.0).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xstate"
-version = "0.3.0"
+version = "0.4.0"
 description = "Statecharts and state machines for Python, inspired by XState."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/xstate/state_node.py
+++ b/src/xstate/state_node.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING, Literal
 
 from xstate.action import Action, build_action
@@ -116,6 +117,14 @@ class StateNode:
         self.donedata = (
             config.get("output", config.get("data")) if self.type == "final" else None
         )
+        if self.type == "final" and "data" in config:
+            warnings.warn(
+                "`data` on a final state is deprecated; use `output` "
+                "(XState v5 naming). `data` still works but will be removed "
+                "in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         if config.get("onDone"):
             done_event = f"done.state.{self.id}"

--- a/src/xstate/transition.py
+++ b/src/xstate/transition.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -39,6 +40,13 @@ class Transition:
             if isinstance(config, dict)
             else None
         )
+        if isinstance(config, dict) and "cond" in config:
+            warnings.warn(
+                "`cond` is deprecated; use `guard` (XState v5 naming). "
+                "`cond` still works but will be removed in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         self.in_state = config.get("in", None) if isinstance(config, dict) else None
         self.order = order
 

--- a/tests/test_after.py
+++ b/tests/test_after.py
@@ -118,7 +118,7 @@ def test_after_with_guard(ready, expected):
                 "waiting": {
                     "after": {
                         1000: [
-                            {"target": "go", "cond": lambda ctx, _: ctx["ready"]},
+                            {"target": "go", "guard": lambda ctx, _: ctx["ready"]},
                             {"target": "stay"},
                         ]
                     }

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -95,7 +95,7 @@ def test_guard_callable_blocks_transition():
                     "on": {
                         "OPEN": {
                             "target": "open",
-                            "cond": lambda ctx, ev: ctx["allowed"],
+                            "guard": lambda ctx, ev: ctx["allowed"],
                         }
                     }
                 },
@@ -120,7 +120,7 @@ def test_guard_callable_allows_transition():
                     "on": {
                         "OPEN": {
                             "target": "open",
-                            "cond": lambda ctx, ev: ctx["allowed"],
+                            "guard": lambda ctx, ev: ctx["allowed"],
                         }
                     }
                 },
@@ -142,7 +142,7 @@ def test_named_guard_from_registry():
             "states": {
                 "closed": {
                     "on": {
-                        "OPEN": {"target": "open", "cond": "isReady"},
+                        "OPEN": {"target": "open", "guard": "isReady"},
                     }
                 },
                 "open": {},
@@ -165,7 +165,7 @@ def test_guard_uses_event_data():
                     "on": {
                         "OPEN": {
                             "target": "open",
-                            "cond": lambda ctx, ev: ev.data.get("key") == "secret",
+                            "guard": lambda ctx, ev: ev.data.get("key") == "secret",
                         }
                     }
                 },
@@ -186,7 +186,7 @@ def test_missing_named_guard_raises():
             "id": "gate",
             "initial": "closed",
             "states": {
-                "closed": {"on": {"OPEN": {"target": "open", "cond": "nope"}}},
+                "closed": {"on": {"OPEN": {"target": "open", "guard": "nope"}}},
                 "open": {},
             },
         }

--- a/tests/test_raise_send_cancel.py
+++ b/tests/test_raise_send_cancel.py
@@ -273,7 +273,7 @@ def test_done_data_static_dict_available_in_on_done_assign():
                     "states": {
                         "task": {
                             "type": "final",
-                            "data": {"value": 42},
+                            "output": {"value": 42},
                         }
                     },
                     "onDone": {
@@ -306,7 +306,9 @@ def test_done_data_callable_evaluated_with_context():
                     "states": {
                         "work": {
                             "type": "final",
-                            "data": lambda ctx, _: {"product": ctx["multiplier"] * 10},
+                            "output": lambda ctx, _: {
+                                "product": ctx["multiplier"] * 10
+                            },
                         }
                     },
                     "onDone": {
@@ -334,11 +336,11 @@ def test_done_data_available_in_guard():
             "states": {
                 "run": {
                     "initial": "work",
-                    "states": {"work": {"type": "final", "data": {"ok": True}}},
+                    "states": {"work": {"type": "final", "output": {"ok": True}}},
                     "onDone": [
                         {
                             "target": "success",
-                            "cond": lambda ctx, ev: ev.data.get("ok", False),
+                            "guard": lambda ctx, ev: ev.data.get("ok", False),
                         },
                         {"target": "failure"},
                     ],

--- a/tests/test_real_world.py
+++ b/tests/test_real_world.py
@@ -59,7 +59,7 @@ def make_session_machine(saved_token: bool = False):
                         "LOGIN": "authenticating",
                         "AUTO_LOGIN": {
                             "target": "authenticated",
-                            "cond": lambda ctx, _: ctx.get("savedToken", False),
+                            "guard": lambda ctx, _: ctx.get("savedToken", False),
                         },
                     }
                 },
@@ -82,7 +82,7 @@ def make_session_machine(saved_token: bool = False):
                         "FAILURE": [
                             {
                                 "target": "lockedOut",
-                                "cond": lambda ctx, _: (
+                                "guard": lambda ctx, _: (
                                     ctx.get("attempts", 0) + 1 >= MAX_ATTEMPTS
                                 ),
                                 "actions": [
@@ -143,7 +143,7 @@ def make_session_machine(saved_token: bool = False):
                                 "UNLOCK": [
                                     {
                                         "target": "active",
-                                        "cond": lambda ctx, ev: (
+                                        "guard": lambda ctx, ev: (
                                             ev.data.get("pin") == "1234"
                                         ),
                                     }

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -129,7 +129,7 @@ def test_targetless_dict_transition_does_not_crash():
         {
             "id": "m",
             "initial": "idle",
-            "states": {"idle": {"on": {"PING": {"cond": lambda c, e: True}}}},
+            "states": {"idle": {"on": {"PING": {"guard": lambda c, e: True}}}},
         }
     )
     state = machine.initial_state

--- a/tests/test_state_in.py
+++ b/tests/test_state_in.py
@@ -214,7 +214,7 @@ def make_combined():
                                 "GO": {
                                     "target": "a2",
                                     "in": {"b": "b2"},
-                                    "cond": lambda ctx, _: ctx.get("allowed", False),
+                                    "guard": lambda ctx, _: ctx.get("allowed", False),
                                 }
                             }
                         },
@@ -249,7 +249,7 @@ def test_combined_both_must_pass():
                                 "GO": {
                                     "target": "a2",
                                     "in": {"b": "b2"},
-                                    "cond": lambda ctx, _: ctx.get("ok", False),
+                                    "guard": lambda ctx, _: ctx.get("ok", False),
                                 }
                             }
                         },

--- a/tests/test_v5_config.py
+++ b/tests/test_v5_config.py
@@ -7,6 +7,10 @@
 - ``State.matches()`` — helper for checking nested state values
 """
 
+import warnings
+
+import pytest
+
 from xstate import Machine, MachineSnapshot, assign
 
 # ---------------------------------------------------------------------------
@@ -72,55 +76,57 @@ def test_guard_false_falls_through_to_next():
 
 
 def test_cond_still_works_for_backwards_compat():
-    """``cond`` continues to work as a backwards-compatible spelling."""
-    machine = Machine(
-        {
-            "id": "g",
-            "initial": "idle",
-            "context": {"ok": True},
-            "states": {
-                "idle": {
-                    "on": {
-                        "GO": [
-                            {"target": "yes", "cond": lambda ctx, _: ctx["ok"]},
-                            {"target": "no"},
-                        ]
-                    }
+    """``cond`` continues to work, but emits a DeprecationWarning."""
+    with pytest.warns(DeprecationWarning, match="`cond` is deprecated"):
+        machine = Machine(
+            {
+                "id": "g",
+                "initial": "idle",
+                "context": {"ok": True},
+                "states": {
+                    "idle": {
+                        "on": {
+                            "GO": [
+                                {"target": "yes", "cond": lambda ctx, _: ctx["ok"]},
+                                {"target": "no"},
+                            ]
+                        }
+                    },
+                    "yes": {},
+                    "no": {},
                 },
-                "yes": {},
-                "no": {},
-            },
-        }
-    )
+            }
+        )
     state = machine.initial_state
     state = machine.transition(state, "GO")
     assert state.value == "yes"
 
 
 def test_guard_takes_precedence_over_cond_when_both_present():
-    """If both keys appear, ``guard`` wins."""
-    machine = Machine(
-        {
-            "id": "g",
-            "initial": "idle",
-            "states": {
-                "idle": {
-                    "on": {
-                        "GO": [
-                            {
-                                "target": "a",
-                                "guard": lambda *_: True,
-                                "cond": lambda *_: False,
-                            },
-                            {"target": "b"},
-                        ]
-                    }
+    """If both keys appear, ``guard`` wins (and the legacy ``cond`` still warns)."""
+    with pytest.warns(DeprecationWarning, match="`cond` is deprecated"):
+        machine = Machine(
+            {
+                "id": "g",
+                "initial": "idle",
+                "states": {
+                    "idle": {
+                        "on": {
+                            "GO": [
+                                {
+                                    "target": "a",
+                                    "guard": lambda *_: True,
+                                    "cond": lambda *_: False,
+                                },
+                                {"target": "b"},
+                            ]
+                        }
+                    },
+                    "a": {},
+                    "b": {},
                 },
-                "a": {},
-                "b": {},
-            },
-        }
-    )
+            }
+        )
     state = machine.initial_state
     state = machine.transition(state, "GO")
     assert state.value == "a"
@@ -184,29 +190,69 @@ def test_output_on_final_state_reaches_on_done():
 
 
 def test_data_still_works_for_backwards_compat():
-    machine = Machine(
-        {
-            "id": "o",
-            "initial": "work",
-            "context": {"result": None},
-            "states": {
-                "work": {
-                    "initial": "task",
-                    "states": {"task": {"type": "final", "data": {"value": 42}}},
-                    "onDone": {
-                        "target": "done",
-                        "actions": [
-                            assign({"result": lambda ctx, ev: ev.data["value"]})
-                        ],
+    """``data`` on a final state still works, but emits a DeprecationWarning."""
+    with pytest.warns(DeprecationWarning, match="`data` on a final state"):
+        machine = Machine(
+            {
+                "id": "o",
+                "initial": "work",
+                "context": {"result": None},
+                "states": {
+                    "work": {
+                        "initial": "task",
+                        "states": {"task": {"type": "final", "data": {"value": 42}}},
+                        "onDone": {
+                            "target": "done",
+                            "actions": [
+                                assign({"result": lambda ctx, ev: ev.data["value"]})
+                            ],
+                        },
                     },
+                    "done": {},
                 },
-                "done": {},
-            },
-        }
-    )
+            }
+        )
     state = machine.initial_state
     assert state.value == "done"
     assert state.context["result"] == 42
+
+
+def test_guard_does_not_warn():
+    """The canonical ``guard`` spelling must not emit a DeprecationWarning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        Machine(
+            {
+                "id": "g",
+                "initial": "idle",
+                "states": {
+                    "idle": {"on": {"GO": {"target": "a", "guard": lambda *_: True}}},
+                    "a": {},
+                },
+            }
+        )
+
+
+def test_output_does_not_warn():
+    """The canonical ``output`` spelling must not emit a DeprecationWarning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        Machine(
+            {
+                "id": "o",
+                "initial": "work",
+                "states": {
+                    "work": {
+                        "initial": "task",
+                        "states": {
+                            "task": {"type": "final", "output": {"value": 1}}
+                        },
+                        "onDone": "done",
+                    },
+                    "done": {},
+                },
+            }
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Completes the **0.4.0 milestone**: XState v5 config alignment. The v5 features (`guard`, `output`, `always:`, single-object handler signatures, `MachineSnapshot`) were already implemented and tested in earlier commits. This PR adds the **deprecation half** of the `cond→guard` / `data→output` rename so users are actively guided toward v5 naming, and bumps the version to `0.4.0`.

It also includes a prior commit (`fix: address all 6 post-review correctness and hygiene issues`) that resolved code-review findings from the 0.3.0 modernisation.

---

## What changed

### Library (`src/xstate/`)

#### `transition.py`
- `cond` is now deprecated: building a `Transition` with `"cond"` in the config emits a `DeprecationWarning` — "use `guard` (XState v5 naming)". `cond` continues to function.
- `guard` remains the canonical key and is checked first (i.e., `guard` wins when both are present).

#### `state_node.py`
- `data` on a final state is now deprecated: constructing a `StateNode` with `"data"` emits a `DeprecationWarning` — "use `output` (XState v5 naming)". `data` continues to function.
- `output` remains the canonical key.

#### `exceptions.py` (from prior commit)
- `UnregisteredImplementationError` now also subclasses `ValueError` for backwards compatibility with callers that `except ValueError` around guard / delay resolution.

#### `event.py` (from prior commit)
- `data` field on `Event` is excluded from `__hash__` via `field(hash=False)`, fixing a latent `TypeError` when hashing events with dict payloads. `__eq__` still compares `data`, preserving the Python hash/eq contract.

#### `machine.py` (from prior commit)
- `_get_configuration` now raises `InvalidConfigError` for unrecognised dict keys instead of silently dropping them. `state_from({'bogus': 'a'})` now errors rather than returning a wrong `State`.

### Tests (`tests/`)

#### `test_v5_config.py` (29 tests)
- `test_cond_still_works_for_backwards_compat` — now asserts `pytest.warns(DeprecationWarning, match="cond is deprecated")`
- `test_guard_takes_precedence_over_cond_when_both_present` — now asserts the warning fires
- `test_data_still_works_for_backwards_compat` — now asserts `pytest.warns(DeprecationWarning, match="data on a final state")`
- Added `test_guard_does_not_warn` — canonical spelling must never emit a `DeprecationWarning`
- Added `test_output_does_not_warn` — canonical spelling must never emit a `DeprecationWarning`

#### 6 other test files
Migrated incidental `"cond":` → `"guard":` and final-state `"data":` → `"output":` so the suite dogfoods v5 names. The full suite passes cleanly under `-W error::DeprecationWarning` (zero leaked warnings).

### Metadata
- `pyproject.toml`: `0.3.0` → `0.4.0`
- `CLAUDE.md`: moved v5 config items from "stubbed / incomplete" to "Working"; refreshed handler-signature note to document all four calling conventions (`()`, `(context)`, `(context, event)`, `(*, context, event)`); updated dev commands to `mypy src/xstate/` and `ruff check src/ tests/`

---

## v5 alignment status after this PR

| Feature | Status |
|---|---|
| `guard` canonical key (was `cond`) | ✅ implemented + deprecated |
| `output` canonical key for final states (was `data`) | ✅ implemented + deprecated |
| `always:` for eventless transitions | ✅ |
| Single-object handler signatures `(*, context, event)` | ✅ |
| `MachineSnapshot` alias with `status` / `output` / `error` | ✅ |
| `state.matches()` and `state.can(event)` | ✅ |

---

## Verification

```
243 passed, 3 warnings in 0.72s   ← clean under -W error::DeprecationWarning
ruff check src/ tests/             ← All checks passed
mypy src/xstate/                   ← Success: no issues found in 13 source files
```

## Next milestone: 0.5.0 — Actor model
`create_actor`, `from_promise`, `from_callback`, asyncio support, invoked services runtime.


---
_Generated by [Claude Code](https://claude.ai/code/session_01E5AJUvQDU2YYNtWWUD54ML)_