### PR TITLE
feat: 0.5.0 — asyncio-native AsyncInterpreter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,8 @@ xstate/
   action.py         Action — entry/exit/transition side effects
   event.py          Event — typed event wrapper
   interpreter.py    Interpreter — synchronous event loop + queue, subscriptions, `after` scheduling
+  async_interpreter.py  AsyncInterpreter — asyncio-native runtime (`async start/send/stop`, awaitable actions)
+  actor.py          Actor model — create_actor, ActorSystem, from_promise/from_callback, invoke reconciliation
   scheduler.py      Clock abstractions (`SimulatedClock` for tests, `ThreadClock` for real time)
   scxml.py          SCXML XML → Machine config converter (requires `scxml` extra for js conds)
 ```
@@ -35,7 +37,7 @@ The critical execution order is: `main_event_loop` → `microstep` → `main_eve
 
 ---
 
-## Current state (0.4.0 in progress)
+## Current state (0.5.0 in progress)
 
 **Working:**
 - Hierarchical (compound) states
@@ -69,11 +71,21 @@ The critical execution order is: `main_event_loop` → `microstep` → `main_eve
   - `MachineSnapshot` (public alias of `State`) carries `status`
     (`"active"`/`"done"`/`"error"`), `output`, and `error`; plus `state.matches()`
     and `state.can(event)`
+- **Actor model** (0.5.0, `from xstate import create_actor`) — `Actor` + `ActorSystem`
+  with `id`/`parent`/`children`, `spawn`, `from_promise`/`from_callback` logic,
+  `send_parent`/`send_to`, and `invoke:` child-actor reconciliation feeding back
+  `done.invoke.<id>` / `error.platform.<id>` (synchronous resolution)
+- **AsyncInterpreter** (0.5.0, `from xstate import interpret_async`) — asyncio-native
+  runtime: `await start()`/`send()`/`stop()`, run-to-completion event queue,
+  **awaitable action callables** (`async def` side effects are awaited), and
+  `after` delayed transitions scheduled on the event loop. The pure transition /
+  guard layer stays synchronous, so `algorithm.py` is shared with the sync runtime
 
 **Stubbed / incomplete:**
-- Async support (0.5.0 target)
+- Async **actors** (`from_promise` coroutine resolution, `from_observable`,
+  `to_promise(actor)`) — the sync actor model and async *interpreter* exist;
+  bridging actors onto the event loop is the remaining 0.5.0 async step
 - `setup()` API (0.6.0+ target)
-- Invoked services / actors (`invoke`) (0.5.0 target)
 
 Handler-signature note: guards/assigners are invoked arity-aware by
 `algorithm._invoke`, which supports four calling conventions: `()`, `(context)`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,8 +50,9 @@ packages = [
 ]
 
 [tool.poetry.group.dev.dependencies]
-pytest = "^7.0"
-pytest-cov = "^4.0"
+pytest = ">=8.4"
+pytest-asyncio = ">=1.0"
+pytest-cov = ">=4.0"
 ruff = ">=0.4"
 mypy = "^1.0"
 
@@ -120,10 +121,12 @@ module = "xstate.state_node"
 disallow_untyped_defs = false
 
 [tool.pytest.ini_options]
-minversion = "7.0"
+minversion = "8.4"
 addopts = "-ra -q"
 testpaths = ["tests"]
 pythonpath = ["src"]
+# `async def test_*` are collected and run without a per-test decorator.
+asyncio_mode = "auto"
 
 [tool.coverage.run]
 source = ["xstate"]

--- a/src/xstate/__init__.py
+++ b/src/xstate/__init__.py
@@ -6,6 +6,7 @@ from xstate.actor import (  # noqa
     from_callback,
     from_promise,
 )
+from xstate.async_interpreter import AsyncInterpreter, interpret_async  # noqa
 from xstate.event import Event, to_event  # noqa
 from xstate.exceptions import (  # noqa
     InvalidConfigError,
@@ -24,6 +25,9 @@ __all__ = [
     # Interpreter
     "interpret",
     "Interpreter",
+    # Async interpreter (v5 / 0.5.0)
+    "interpret_async",
+    "AsyncInterpreter",
     # Actor model (v5)
     "create_actor",
     "Actor",

--- a/src/xstate/async_interpreter.py
+++ b/src/xstate/async_interpreter.py
@@ -1,0 +1,278 @@
+"""Asyncio-native interpreter for running a :class:`~xstate.machine.Machine`.
+
+:class:`AsyncInterpreter` is the ``asyncio`` counterpart of the synchronous
+:class:`~xstate.interpreter.Interpreter`.  It targets the 0.5.0 async milestone:
+running a statechart inside an event loop so it composes with async Python
+(FastAPI, async Django, aiohttp, Celery's async worker, …).
+
+What is and isn't async
+-----------------------
+The *pure* transition computation stays synchronous: ``machine.transition`` is a
+side-effect-free function from ``(state, event)`` to a new state, and guards /
+assigners run inside it.  The async layer wraps only the **runtime**:
+
+* ``await start()`` / ``await send(event)`` / ``await stop()``;
+* a run-to-completion event queue (events sent while one is being processed are
+  queued, never interleaved);
+* **awaitable action callables** — an action that returns a coroutine is
+  awaited, so ``async def`` side effects work transparently;
+* **delayed transitions** (`after`) scheduled on the running event loop via
+  :func:`asyncio.create_task` and cancelled when their state is exited or the
+  service stops.
+
+This boundary mirrors XState, which keeps logic pure and pushes effects to the
+actor/runtime edge.  Keeping guards synchronous means the SCXML algorithm core
+is shared unchanged between the sync and async runtimes.
+
+Example::
+
+    import asyncio
+    from xstate import Machine, interpret_async
+
+    async def main():
+        service = await interpret_async(machine).start()
+        await service.send("LOGIN")
+        print(service.state.value)
+        await service.stop()
+
+    asyncio.run(main())
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Callable
+from typing import Any
+
+from xstate.action import CANCEL_TYPE, SEND_TYPE, Action
+from xstate.event import Event as _Event
+from xstate.interpreter import NOT_STARTED, RUNNING, STOPPED, resolve_delay_ms
+from xstate.machine import Machine
+from xstate.state import State
+
+
+class AsyncSubscription:
+    """Handle returned by :meth:`AsyncInterpreter.subscribe`; call ``unsubscribe``."""
+
+    def __init__(
+        self, interpreter: AsyncInterpreter, listener: Callable[[State], None]
+    ):
+        self._interpreter = interpreter
+        self._listener: Callable[[State], None] | None = listener
+
+    def unsubscribe(self) -> None:
+        if self._listener is not None:
+            self._interpreter._listeners.discard(self._listener)
+            self._listener = None
+
+
+class AsyncInterpreter:
+    """An asyncio-native running instance of a :class:`~xstate.machine.Machine`.
+
+    Lifecycle and messaging are coroutines (``start`` / ``send`` / ``stop``);
+    observation (``subscribe``) and the current ``state`` are synchronous, since
+    snapshots are plain values.  Delayed transitions are scheduled on whichever
+    loop is running when the service is started.
+    """
+
+    machine: Machine
+    state: State
+
+    def __init__(self, machine: Machine):
+        self.machine = machine
+        self.state = machine.initial_state
+        self._status = NOT_STARTED
+        self._listeners: set = set()
+        self._event_queue: list = []
+        self._processing = False
+        # `after`-event name -> asyncio.Task running the delay
+        self._scheduled: dict[str, asyncio.Task] = {}
+        # named `send(..., id=...)` (or the Task itself) -> delayed-send Task
+        self._send_timers: dict[Any, asyncio.Task] = {}
+
+    # -- lifecycle ----------------------------------------------------------
+
+    @property
+    def status(self) -> str:
+        return self._status
+
+    @property
+    def initialized(self) -> bool:
+        return self._status == RUNNING
+
+    async def start(self, initial_state: State | None = None) -> AsyncInterpreter:
+        """Start the service. Idempotent while already running."""
+        if self._status == RUNNING:
+            return self
+        if initial_state is not None:
+            self.state = initial_state
+        self.state.event = _Event("xstate.init")
+        self._status = RUNNING
+        self._sync_delays()
+        await self._execute(self.state)
+        self._notify(self.state)
+        return self
+
+    async def stop(self) -> AsyncInterpreter:
+        """Stop the service: cancel pending timers and drop all listeners."""
+        for task in self._scheduled.values():
+            task.cancel()
+        self._scheduled.clear()
+        for task in self._send_timers.values():
+            task.cancel()
+        self._send_timers.clear()
+        self._listeners.clear()
+        self._event_queue.clear()
+        self._status = STOPPED
+        return self
+
+    # -- events -------------------------------------------------------------
+
+    async def send(self, event: Any) -> State:
+        """Send an event. Events sent during processing are queued (RTC)."""
+        if self._status != RUNNING:
+            # Match XState: events before start / after stop are dropped.
+            return self.state
+
+        self._event_queue.append(event)
+        if self._processing:
+            # Re-entrant send (from an awaited action or a fired timer): the
+            # active drain loop will pick this event up. The stretch between the
+            # queue check and clearing `_processing` contains no `await`, so a
+            # concurrent task cannot slip an event past the drain.
+            return self.state
+
+        self._processing = True
+        try:
+            while self._event_queue:
+                next_event = self._event_queue.pop(0)
+                await self._process(next_event)
+        finally:
+            self._processing = False
+        return self.state
+
+    async def _process(self, event: Any) -> None:
+        next_state = self.machine.transition(self.state, event)
+        next_state.event = self.machine._to_event(event)
+        self.state = next_state
+        self._sync_delays()
+        await self._execute(next_state)
+        self._notify(next_state)
+
+    # -- subscriptions ------------------------------------------------------
+
+    def subscribe(self, listener: Callable[[State], None]) -> AsyncSubscription:
+        """Register a listener called with the current state and on each change.
+
+        Listeners are synchronous observers (as in XState); perform async work
+        inside actions, not subscribers.
+        """
+        self._listeners.add(listener)
+        if self._status == RUNNING:
+            listener(self.state)
+        return AsyncSubscription(self, listener)
+
+    def _notify(self, state: State) -> None:
+        for listener in list(self._listeners):
+            listener(state)
+
+    # -- side effects -------------------------------------------------------
+
+    _ACTION_DISPATCH: dict[str, str] = {
+        SEND_TYPE: "_execute_send",
+        CANCEL_TYPE: "_execute_cancel",
+    }
+
+    async def _execute(self, state: State) -> None:
+        """Run resolved action callables; await any that return a coroutine."""
+        for action in state.actions:
+            if isinstance(action, Action):
+                action_type = action.type
+                method_name = (
+                    self._ACTION_DISPATCH.get(action_type)
+                    if isinstance(action_type, str)
+                    else None
+                )
+                if method_name:
+                    await getattr(self, method_name)(action)
+            elif callable(action):
+                result = action()
+                if inspect.isawaitable(result):
+                    await result
+
+    async def _execute_send(self, action: Action) -> None:
+        event = action.data.get("event")
+        delay = action.data.get("delay")
+        send_id = action.data.get("id")
+        if delay is not None:
+            delay_ms = resolve_delay_ms(
+                self.machine, delay, self.state.context, self.state.event
+            )
+            task = self._schedule(self.send, event, delay_ms)
+            # Key by explicit id when given so cancel() can find it; otherwise key
+            # by the Task itself so stop() can still cancel anonymous sends.
+            self._send_timers[send_id if send_id else task] = task
+        else:
+            await self.send(event)
+
+    async def _execute_cancel(self, action: Action) -> None:
+        send_id = action.data.get("sendid")
+        if send_id:
+            task = self._send_timers.pop(send_id, None)
+            if task is not None:
+                task.cancel()
+
+    # -- delayed transitions ------------------------------------------------
+
+    def _schedule(
+        self, coro_fn: Callable[[Any], Any], arg: Any, delay_ms: float
+    ) -> asyncio.Task:
+        """Create a task that waits ``delay_ms`` then calls ``coro_fn(arg)``."""
+
+        async def _fire() -> None:
+            try:
+                await asyncio.sleep(delay_ms / 1000)
+            except asyncio.CancelledError:
+                return
+            if self._status == RUNNING:
+                await coro_fn(arg)
+
+        return asyncio.create_task(_fire())
+
+    def _sync_delays(self) -> None:
+        """Reconcile scheduled `after` timers with the current configuration.
+
+        Timers for states still active are left running; timers for exited
+        states are cancelled; newly entered states with `after` are scheduled.
+        Each delay fires once per entry (a still-active state is not rescheduled).
+        """
+        wanted: dict[str, object] = {}
+        for node in self.state.configuration:
+            for delay_spec, event_name in getattr(node, "after", []):
+                wanted[event_name] = delay_spec
+
+        # Cancel timers whose state is no longer active.
+        for event_name in list(self._scheduled):
+            if event_name not in wanted:
+                self._scheduled.pop(event_name).cancel()
+
+        # Schedule timers for newly entered delayed transitions.
+        for event_name, delay_spec in wanted.items():
+            if event_name in self._scheduled:
+                continue
+            delay_ms = resolve_delay_ms(
+                self.machine, delay_spec, self.state.context, self.state.event
+            )
+            self._scheduled[event_name] = self._schedule(
+                self.send, event_name, delay_ms
+            )
+
+
+def interpret_async(machine: Machine) -> AsyncInterpreter:
+    """Create an :class:`AsyncInterpreter` for ``machine``.
+
+    The asyncio counterpart of :func:`~xstate.interpreter.interpret`. The service
+    is not started; ``await`` its :meth:`AsyncInterpreter.start`.
+    """
+    return AsyncInterpreter(machine)

--- a/src/xstate/interpreter.py
+++ b/src/xstate/interpreter.py
@@ -41,6 +41,31 @@ RUNNING = "running"
 STOPPED = "stopped"
 
 
+def resolve_delay_ms(
+    machine: Machine, delay_spec: Any, context: Any, event: Any
+) -> float:
+    """Resolve a delay key to milliseconds.
+
+    Numbers are taken as-is; strings are looked up in ``machine.delays`` and may
+    be a number or a ``(context, event) -> number`` callable. Shared by the
+    synchronous :class:`Interpreter` and the asyncio
+    :class:`~xstate.async_interpreter.AsyncInterpreter`.
+    """
+    if isinstance(delay_spec, (int, float)):
+        return float(delay_spec)
+    delay = machine.delays.get(delay_spec)
+    if delay is None:
+        raise UnregisteredImplementationError(
+            f"Delay '{delay_spec}' is not configured. "
+            f"Pass it via Machine(config, delays={{'{delay_spec}': ...}})."
+        )
+    if callable(delay):
+        from xstate.algorithm import _invoke
+
+        return float(_invoke(delay, context, event))
+    return float(delay)
+
+
 class Subscription:
     """Handle returned by :meth:`Interpreter.subscribe`; call ``unsubscribe``."""
 
@@ -231,26 +256,12 @@ class Interpreter:
     # -- delayed transitions ------------------------------------------------
 
     def _resolve_delay(self, delay_spec: Any) -> float:
-        """Resolve a delay key to milliseconds.
-
-        Numbers are taken as-is; strings are looked up in ``machine.delays`` and
-        may be a number or a ``(context, event) -> number`` callable.
-        """
-        if isinstance(delay_spec, (int, float)):
-            return float(delay_spec)
-        delay = self.machine.delays.get(delay_spec)
-        if delay is None:
-            raise UnregisteredImplementationError(
-                f"Delay '{delay_spec}' is not configured. "
-                f"Pass it via Machine(config, delays={{'{delay_spec}': ...}})."
-            )
-        if callable(delay):
-            from xstate.algorithm import _invoke
-
-            return float(
-                _invoke(delay, self.state.context, getattr(self.state, "event", None))
-            )
-        return float(delay)
+        return resolve_delay_ms(
+            self.machine,
+            delay_spec,
+            self.state.context,
+            getattr(self.state, "event", None),
+        )
 
     def _sync_delays(self) -> None:
         """Reconcile scheduled timers with the current configuration.

--- a/tests/test_async_interpreter.py
+++ b/tests/test_async_interpreter.py
@@ -1,0 +1,351 @@
+"""Tests for the asyncio-native AsyncInterpreter (0.5.0).
+
+The pure transition layer is shared with the synchronous interpreter; these
+tests focus on the async runtime: ``await`` lifecycle, run-to-completion under
+cooperative scheduling, awaitable action callables, and event-loop-scheduled
+delayed transitions.
+"""
+
+import asyncio
+
+from xstate import Machine, interpret_async
+from xstate.async_interpreter import AsyncInterpreter
+
+# ---------------------------------------------------------------------------
+# Lifecycle + basic transitions
+# ---------------------------------------------------------------------------
+
+
+def _toggle_machine():
+    return Machine(
+        {
+            "id": "toggle",
+            "initial": "inactive",
+            "states": {
+                "inactive": {"on": {"TOGGLE": "active"}},
+                "active": {"on": {"TOGGLE": "inactive"}},
+            },
+        }
+    )
+
+
+async def test_start_returns_self_and_initial_state():
+    service = await interpret_async(_toggle_machine()).start()
+    assert isinstance(service, AsyncInterpreter)
+    assert service.status == "running"
+    assert service.state.value == "inactive"
+
+
+async def test_send_transitions():
+    service = await interpret_async(_toggle_machine()).start()
+    await service.send("TOGGLE")
+    assert service.state.value == "active"
+    await service.send("TOGGLE")
+    assert service.state.value == "inactive"
+
+
+async def test_send_returns_resulting_state():
+    service = await interpret_async(_toggle_machine()).start()
+    state = await service.send("TOGGLE")
+    assert state.value == "active"
+
+
+async def test_start_is_idempotent():
+    service = await interpret_async(_toggle_machine()).start()
+    await service.start()  # no-op, stays running
+    assert service.status == "running"
+    assert service.state.value == "inactive"
+
+
+async def test_events_dropped_before_start_and_after_stop():
+    service = interpret_async(_toggle_machine())
+    # before start
+    await service.send("TOGGLE")
+    assert service.state.value == "inactive"
+    await service.start()
+    await service.send("TOGGLE")
+    assert service.state.value == "active"
+    await service.stop()
+    assert service.status == "stopped"
+    # after stop
+    await service.send("TOGGLE")
+    assert service.state.value == "active"
+
+
+# ---------------------------------------------------------------------------
+# Awaitable action callables
+# ---------------------------------------------------------------------------
+
+
+async def test_async_action_callable_is_awaited():
+    log: list[str] = []
+
+    async def record():
+        await asyncio.sleep(0)
+        log.append("ran")
+
+    machine = Machine(
+        {
+            "id": "a",
+            "initial": "idle",
+            "states": {
+                "idle": {"on": {"GO": {"target": "active", "actions": [record]}}},
+                "active": {},
+            },
+        }
+    )
+    service = await interpret_async(machine).start()
+    await service.send("GO")
+    assert service.state.value == "active"
+    assert log == ["ran"]
+
+
+async def test_sync_action_callable_still_runs():
+    log: list[str] = []
+    machine = Machine(
+        {
+            "id": "a",
+            "initial": "idle",
+            "states": {
+                "idle": {
+                    "on": {
+                        "GO": {"target": "active", "actions": [lambda: log.append("s")]}
+                    }
+                },
+                "active": {},
+            },
+        }
+    )
+    service = await interpret_async(machine).start()
+    await service.send("GO")
+    assert log == ["s"]
+
+
+async def test_entry_async_action_runs_on_start():
+    log: list[str] = []
+
+    async def on_entry():
+        log.append("entered")
+
+    machine = Machine(
+        {
+            "id": "a",
+            "initial": "idle",
+            "states": {"idle": {"entry": [on_entry]}},
+        }
+    )
+    await interpret_async(machine).start()
+    assert log == ["entered"]
+
+
+# ---------------------------------------------------------------------------
+# Run-to-completion
+# ---------------------------------------------------------------------------
+
+
+async def test_raise_processed_in_same_macrostep():
+    """raise_ queues an internal event handled within machine.transition."""
+    from xstate import raise_
+
+    machine = Machine(
+        {
+            "id": "r",
+            "initial": "a",
+            "states": {
+                "a": {"on": {"GO": {"target": "b", "actions": [raise_("PING")]}}},
+                "b": {"on": {"PING": "c"}},
+                "c": {},
+            },
+        }
+    )
+    service = await interpret_async(machine).start()
+    await service.send("GO")
+    assert service.state.value == "c"
+
+
+async def test_send_action_without_delay_drains_in_rtc():
+    machine = Machine(
+        {
+            "id": "s",
+            "initial": "a",
+            "states": {
+                "a": {"on": {"GO": {"target": "b", "actions": [_send("AUTO")]}}},
+                "b": {"on": {"AUTO": "c"}},
+                "c": {},
+            },
+        }
+    )
+    service = await interpret_async(machine).start()
+    await service.send("GO")
+    assert service.state.value == "c"
+
+
+# ---------------------------------------------------------------------------
+# Delayed transitions (after) scheduled on the event loop
+# ---------------------------------------------------------------------------
+
+
+async def test_after_fires_following_real_delay():
+    machine = Machine(
+        {
+            "id": "t",
+            "initial": "loading",
+            "states": {
+                "loading": {"after": {20: "loaded"}},
+                "loaded": {},
+            },
+        }
+    )
+    service = await interpret_async(machine).start()
+    assert service.state.value == "loading"
+    await asyncio.sleep(0.05)
+    assert service.state.value == "loaded"
+
+
+async def test_after_cancelled_when_state_exits_before_firing():
+    machine = Machine(
+        {
+            "id": "t",
+            "initial": "loading",
+            "states": {
+                "loading": {"after": {50: "timeout"}, "on": {"RESOLVE": "done"}},
+                "timeout": {},
+                "done": {},
+            },
+        }
+    )
+    service = await interpret_async(machine).start()
+    await service.send("RESOLVE")
+    assert service.state.value == "done"
+    await asyncio.sleep(0.08)
+    # The timer was cancelled on exit; it must not knock us out of `done`.
+    assert service.state.value == "done"
+
+
+async def test_stop_cancels_pending_after():
+    machine = Machine(
+        {
+            "id": "t",
+            "initial": "waiting",
+            "states": {"waiting": {"after": {30: "fired"}}, "fired": {}},
+        }
+    )
+    service = await interpret_async(machine).start()
+    await service.stop()
+    await asyncio.sleep(0.05)
+    # Stopped service ignores the fired timer.
+    assert service.state.value == "waiting"
+    assert service.status == "stopped"
+
+
+async def test_named_delay_resolved_from_machine_delays():
+    machine = Machine(
+        {
+            "id": "t",
+            "initial": "a",
+            "states": {"a": {"after": {"SHORT": "b"}}, "b": {}},
+        },
+        delays={"SHORT": 20},
+    )
+    service = await interpret_async(machine).start()
+    await asyncio.sleep(0.05)
+    assert service.state.value == "b"
+
+
+# ---------------------------------------------------------------------------
+# Delayed send + cancel
+# ---------------------------------------------------------------------------
+
+
+async def test_delayed_send_fires_after_delay():
+    machine = Machine(
+        {
+            "id": "s",
+            "initial": "idle",
+            "states": {
+                "idle": {
+                    "on": {
+                        "START": {
+                            "target": "waiting",
+                            "actions": [_send("TIMEOUT", delay=20)],
+                        }
+                    }
+                },
+                "waiting": {"on": {"TIMEOUT": "done"}},
+                "done": {},
+            },
+        }
+    )
+    service = await interpret_async(machine).start()
+    await service.send("START")
+    assert service.state.value == "waiting"
+    await asyncio.sleep(0.05)
+    assert service.state.value == "done"
+
+
+async def test_cancel_prevents_delayed_send():
+    machine = Machine(
+        {
+            "id": "c",
+            "initial": "loading",
+            "states": {
+                "loading": {
+                    "on": {
+                        "START": {
+                            "target": "active",
+                            "actions": [_send("TIMEOUT", delay=30, id="to")],
+                        }
+                    }
+                },
+                "active": {
+                    "on": {
+                        "DONE": {"target": "success", "actions": [_cancel("to")]},
+                        "TIMEOUT": "failed",
+                    }
+                },
+                "success": {},
+                "failed": {},
+            },
+        }
+    )
+    service = await interpret_async(machine).start()
+    await service.send("START")
+    await service.send("DONE")
+    assert service.state.value == "success"
+    await asyncio.sleep(0.05)
+    assert service.state.value == "success"
+
+
+# ---------------------------------------------------------------------------
+# Subscriptions
+# ---------------------------------------------------------------------------
+
+
+async def test_subscribe_notified_on_change_and_unsubscribe():
+    seen: list[str] = []
+    service = await interpret_async(_toggle_machine()).start()
+    sub = service.subscribe(lambda state: seen.append(state.value))
+    # immediate call with current state on subscribe
+    assert seen == ["inactive"]
+    await service.send("TOGGLE")
+    assert seen == ["inactive", "active"]
+    sub.unsubscribe()
+    await service.send("TOGGLE")
+    assert seen == ["inactive", "active"]
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _send(event, *, delay=None, id=None):
+    from xstate import send
+
+    return send(event, delay=delay, id=id)
+
+
+def _cancel(send_id):
+    from xstate import cancel
+
+    return cancel(send_id)


### PR DESCRIPTION
## Summary

Starts the **0.5.0 milestone (actor model / async)** by adding the foundational async primitive: an **`AsyncInterpreter`** that runs a statechart inside an `asyncio` event loop.

The synchronous actor model (`Actor`, `ActorSystem`, `from_promise`/`from_callback`, the parent/child tree, and full `invoke` reconciliation) was already implemented and tested. The genuine 0.5.0 gap was **asyncio** — the largest capability hole, since a blocking runtime is unusable from async Python backends (FastAPI, async Django, aiohttp, async Celery workers).

## Design: async at the runtime edge only

The **pure transition computation stays synchronous**. `machine.transition` remains a side-effect-free `(state, event) -> state` function, and guards / assigners run inside it unchanged. Only the **runtime** is wrapped in coroutines:

- `await start()` / `await send(event)` / `await stop()`
- a run-to-completion event queue (events sent during processing are queued, never interleaved)
- **awaitable action callables** — an action that returns a coroutine is `await`ed, so `async def` side effects work transparently
- **delayed transitions** (`after`) scheduled on the running event loop via `asyncio` tasks, cancelled when their state is exited or the service stops

This is the same logic/effect boundary XState draws, and it has a concrete payoff here: **`algorithm.py` (the W3C SCXML core, under the change-control guardrail) is shared unchanged** between the sync and async interpreters.

## Changes

### `src/xstate/async_interpreter.py` (new)
- `AsyncInterpreter` + `interpret_async(machine)` factory + `AsyncSubscription`
- RTC drain loop documented as race-free: the stretch between the queue check and clearing `_processing` contains no `await`, so a concurrently-fired timer or re-entrant `await send(...)` cannot slip an event past the drain — it is queued and picked up by the active loop (matching the sync interpreter's semantics)
- `after` / delayed-`send` scheduled via `asyncio.create_task`; `cancel` and `stop` cancel the tasks

### `src/xstate/interpreter.py`
- Extracted `resolve_delay_ms(machine, delay_spec, context, event)` as a shared module-level helper; the synchronous `Interpreter._resolve_delay` now delegates to it (DRY across both runtimes). Covered by the existing `after` / delayed-send tests.

### `src/xstate/__init__.py`
- Export `AsyncInterpreter` and `interpret_async`

### `pyproject.toml`
- Add `pytest-asyncio` dev dependency and `asyncio_mode = "auto"` (so `async def test_*` run without per-test decorators)
- Bump pytest floor to `>=8.4` to match the runtime environment and pytest-asyncio 1.x

### `tests/test_async_interpreter.py` (new, 17 tests)
Lifecycle (start idempotency, events dropped before start / after stop), basic transitions, awaitable + sync action callables, entry actions on start, run-to-completion (`raise_`, undelayed `send`), `after` firing after a real delay, `after` cancelled on early state exit, `stop` cancelling pending timers, named delays from `Machine(delays=...)`, delayed `send` + `cancel`, and subscriptions with `unsubscribe`.

### `CLAUDE.md`
- Document `async_interpreter.py` and `actor.py` in the architecture map
- Move the actor model and async interpreter into "Working"; the remaining 0.5.0 step (async *actors*) is listed under "stubbed / incomplete"

## Usage

```python
import asyncio
from xstate import Machine, interpret_async

async def main():
    service = await interpret_async(machine).start()
    await service.send("LOGIN")
    print(service.state.value)
    await service.stop()

asyncio.run(main())
```

## Verification

```
260 passed   (+17 async tests; was 243)   ← clean under -W error::DeprecationWarning
ruff check src/ tests/   ← All checks passed
mypy src/xstate/         ← Success: no issues found in 14 source files
```

Version stays `0.4.0` until the full 0.5.0 set ships.

## Remaining for 0.5.0
Async **actors** — `from_promise` coroutine resolution, `from_observable`, `to_promise(actor)` — bridging the actor layer onto the event loop.


---
_Generated by [Claude Code](https://claude.ai/code/session_01E5AJUvQDU2YYNtWWUD54ML)_