### PR TITLE
feat: 0.5.0 — async actors (coroutine from_promise, from_observable, to_promise)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ The critical execution order is: `main_event_loop` → `microstep` → `main_eve
 
 ---
 
-## Current state (0.5.0 in progress)
+## Current state (0.5.0)
 
 **Working:**
 - Hierarchical (compound) states
@@ -74,7 +74,12 @@ The critical execution order is: `main_event_loop` → `microstep` → `main_eve
 - **Actor model** (0.5.0, `from xstate import create_actor`) — `Actor` + `ActorSystem`
   with `id`/`parent`/`children`, `spawn`, `from_promise`/`from_callback` logic,
   `send_parent`/`send_to`, and `invoke:` child-actor reconciliation feeding back
-  `done.invoke.<id>` / `error.platform.<id>` (synchronous resolution)
+  `done.invoke.<id>` / `error.platform.<id>`
+- **Async actors** (0.5.0) — a coroutine `from_promise` and `from_observable`
+  schedule their work as an `asyncio.Task` and resolve / emit on the event loop
+  (a plain `from_promise` still resolves eagerly); `to_promise(actor)` adapts any
+  actor to an `asyncio.Future`. Async `invoke:` children feed `done.invoke.<id>` /
+  `error.platform.<id>` back to a machine parent once their task settles
 - **AsyncInterpreter** (0.5.0, `from xstate import interpret_async`) — asyncio-native
   runtime: `await start()`/`send()`/`stop()`, run-to-completion event queue,
   **awaitable action callables** (`async def` side effects are awaited), and
@@ -82,10 +87,8 @@ The critical execution order is: `main_event_loop` → `microstep` → `main_eve
   guard layer stays synchronous, so `algorithm.py` is shared with the sync runtime
 
 **Stubbed / incomplete:**
-- Async **actors** (`from_promise` coroutine resolution, `from_observable`,
-  `to_promise(actor)`) — the sync actor model and async *interpreter* exist;
-  bridging actors onto the event loop is the remaining 0.5.0 async step
-- `setup()` API (0.6.0+ target)
+- `setup()` API + composable guards (0.6.0+ target)
+- Persistence / snapshot serialization (0.6.0+ target)
 
 Handler-signature note: guards/assigners are invoked arity-aware by
 `algorithm._invoke`, which supports four calling conventions: `()`, `(context)`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xstate"
-version = "0.4.0"
+version = "0.5.0"
 description = "Statecharts and state machines for Python, inspired by XState."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -73,6 +73,7 @@ ignore = [
 # Test helpers use `input` as a lambda param to match XState's `input` semantics
 "tests/test_actor_logic.py" = ["A006"]
 "tests/test_actor_messaging.py" = ["A006"]
+"tests/test_async_actors.py" = ["A006"]
 "tests/test_invoke.py" = ["A006"]
 
 [tool.ruff.lint.isort]

--- a/src/xstate/__init__.py
+++ b/src/xstate/__init__.py
@@ -4,7 +4,9 @@ from xstate.actor import (  # noqa
     ActorSystem,
     create_actor,
     from_callback,
+    from_observable,
     from_promise,
+    to_promise,
 )
 from xstate.async_interpreter import AsyncInterpreter, interpret_async  # noqa
 from xstate.event import Event, to_event  # noqa
@@ -34,6 +36,8 @@ __all__ = [
     "ActorSystem",
     "from_promise",
     "from_callback",
+    "from_observable",
+    "to_promise",
     # Action creators
     "assign",
     "send",

--- a/src/xstate/actor.py
+++ b/src/xstate/actor.py
@@ -25,14 +25,20 @@ This module provides:
   lifetime of that state, feeding its completion back as ``done.invoke.<id>`` /
   ``error.platform.<id>`` events.
 
-Synchronous-resolution note: this layer runs on the synchronous
-:class:`~xstate.interpreter.Interpreter`.  A :func:`from_promise` actor's
-function is therefore called eagerly on ``start`` and resolves immediately;
-true deferred/asyncio resolution is the remaining 0.5.0 async milestone.
+Sync and async resolution: the machine layer runs on the synchronous
+:class:`~xstate.interpreter.Interpreter`, so a :func:`from_promise` actor with a
+*plain* function is called eagerly on ``start`` and resolves immediately.  A
+:func:`from_promise` actor with an ``async def`` (coroutine) function, and any
+:func:`from_observable` actor, instead schedule their work as an
+:class:`asyncio.Task` on the running event loop and resolve / emit later — so
+they require a running loop (start them inside ``asyncio.run(...)``).
+:func:`to_promise` adapts any actor to an :class:`asyncio.Future` that resolves
+with its ``output`` (or raises its ``error``).
 """
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 from collections.abc import Callable
 from typing import Any, Literal
@@ -74,14 +80,65 @@ class CallbackLogic:
         self.fn = fn
 
 
+class ObservableLogic:
+    """Logic that emits each value from an async iterable.
+
+    Created with :func:`from_observable`.  On start the actor iterates the
+    async iterable returned by ``fn(input)`` (or ``fn`` itself if it is already
+    an async iterable) as an :class:`asyncio.Task`: each value updates the
+    snapshot (``status == "active"`` with ``context`` set to the value and the
+    listeners notified); when the iterable is exhausted the snapshot becomes
+    ``status == "done"`` with ``output`` set to the final value, and if it
+    raises, ``status == "error"``.
+    """
+
+    def __init__(self, fn: Any):
+        self.fn = fn
+
+
 def from_promise(fn: Callable[..., Any]) -> PromiseLogic:
-    """Create promise actor logic from ``fn`` (XState v5 ``fromPromise``)."""
+    """Create promise actor logic from ``fn`` (XState v5 ``fromPromise``).
+
+    ``fn`` may be synchronous (resolves eagerly on start) or an ``async def``
+    coroutine function (resolved on the running event loop).
+    """
     return PromiseLogic(fn)
 
 
 def from_callback(fn: Callable[..., Any]) -> CallbackLogic:
     """Create callback actor logic from ``fn`` (XState v5 ``fromCallback``)."""
     return CallbackLogic(fn)
+
+
+def from_observable(fn: Any) -> ObservableLogic:
+    """Create observable actor logic from ``fn`` (XState v5 ``fromObservable``).
+
+    ``fn`` is a callable returning an async iterable (e.g. an async generator
+    function), or an async iterable directly.  Requires a running event loop.
+    """
+    return ObservableLogic(fn)
+
+
+def _ensure_future(awaitable: Any) -> asyncio.Task:
+    """Schedule *awaitable* on the running loop, with a clear error if none.
+
+    Async actor logic (coroutine ``from_promise`` / ``from_observable``) can
+    only run when an event loop is active; surface that requirement explicitly
+    rather than letting a lower-level ``RuntimeError`` leak.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        # Close the orphaned coroutine so it doesn't emit a "never awaited"
+        # warning when garbage-collected.
+        if inspect.iscoroutine(awaitable):
+            awaitable.close()
+        raise RuntimeError(
+            "Async actor logic (a coroutine from_promise or a from_observable) "
+            "requires a running event loop. Start the actor inside an async "
+            "context, e.g. within asyncio.run(...)."
+        ) from None
+    return asyncio.ensure_future(awaitable)
 
 
 def _call_with_supported_kwargs(fn: Callable[..., Any], **kwargs: Any) -> Any:
@@ -234,11 +291,16 @@ class _MachineBackend:
 
 
 class _PromiseBackend(_ListenerBackend):
-    """Backs an actor with :func:`from_promise` logic."""
+    """Backs an actor with :func:`from_promise` logic.
+
+    A plain function resolves synchronously on :meth:`start`; a coroutine
+    function is scheduled on the event loop and resolves via a done-callback.
+    """
 
     def __init__(self, actor: Actor, logic: PromiseLogic, input: Any):
         super().__init__(actor, input)
         self._fn = logic.fn
+        self._task: asyncio.Task | None = None
 
     def start(self, initial_state: State | None = None) -> None:
         if self._status != NOT_STARTED:
@@ -246,12 +308,33 @@ class _PromiseBackend(_ListenerBackend):
         self._status = RUNNING
         try:
             result = _call_with_supported_kwargs(self._fn, input=self._input)
-            self._snapshot = ActorSnapshot("done", output=result)
         except Exception as exc:  # noqa: BLE001 - surfaced as actor error
             self._snapshot = ActorSnapshot("error", error=exc)
+            self._notify()
+            return
+        if inspect.isawaitable(result):
+            # Defer resolution to the event loop; snapshot stays "active" until
+            # the coroutine completes.
+            self._task = _ensure_future(result)
+            self._task.add_done_callback(self._on_resolved)
+        else:
+            self._snapshot = ActorSnapshot("done", output=result)
+            self._notify()
+
+    def _on_resolved(self, task: asyncio.Task) -> None:
+        if self._status == STOPPED or task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            self._snapshot = ActorSnapshot("error", error=exc)
+        else:
+            self._snapshot = ActorSnapshot("done", output=task.result())
         self._notify()
 
     def stop(self) -> None:
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+        self._task = None
         self._status = STOPPED
         self._listeners.clear()
 
@@ -301,6 +384,63 @@ class _CallbackBackend(_ListenerBackend):
         return self._snapshot
 
 
+class _ObservableBackend(_ListenerBackend):
+    """Backs an actor with :func:`from_observable` logic."""
+
+    def __init__(self, actor: Actor, logic: ObservableLogic, input: Any):
+        super().__init__(actor, input)
+        self._fn = logic.fn
+        self._task: asyncio.Task | None = None
+
+    def start(self, initial_state: State | None = None) -> None:
+        if self._status != NOT_STARTED:
+            return
+        self._status = RUNNING
+        try:
+            source = (
+                _call_with_supported_kwargs(self._fn, input=self._input)
+                if callable(self._fn)
+                else self._fn
+            )
+        except Exception as exc:  # noqa: BLE001 - surfaced as actor error
+            self._snapshot = ActorSnapshot("error", error=exc)
+            self._notify()
+            return
+        self._task = _ensure_future(self._consume(source))
+        self._task.add_done_callback(self._on_finished)
+
+    async def _consume(self, source: Any) -> Any:
+        last = None
+        async for value in source:
+            if self._status == STOPPED:
+                break
+            last = value
+            self._snapshot = ActorSnapshot("active", context=value)
+            self._notify()
+        return last
+
+    def _on_finished(self, task: asyncio.Task) -> None:
+        if self._status == STOPPED or task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            self._snapshot = ActorSnapshot("error", error=exc)
+        else:
+            self._snapshot = ActorSnapshot("done", output=task.result())
+        self._notify()
+
+    def stop(self) -> None:
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+        self._task = None
+        self._status = STOPPED
+        self._listeners.clear()
+
+    def send(self, event) -> ActorSnapshot:
+        # Observable actors ignore incoming events.
+        return self._snapshot
+
+
 def _build_backend(actor: Actor, logic, clock: Clock | None, input: Any):
     if isinstance(logic, Machine):
         return _MachineBackend(actor, logic, clock)
@@ -308,9 +448,11 @@ def _build_backend(actor: Actor, logic, clock: Clock | None, input: Any):
         return _PromiseBackend(actor, logic, input)
     if isinstance(logic, CallbackLogic):
         return _CallbackBackend(actor, logic, input)
+    if isinstance(logic, ObservableLogic):
+        return _ObservableBackend(actor, logic, input)
     raise TypeError(
-        "create_actor expects a Machine, from_promise(...), or from_callback(...) "
-        f"logic, got {type(logic).__name__}."
+        "create_actor expects a Machine, from_promise(...), from_callback(...), "
+        f"or from_observable(...) logic, got {type(logic).__name__}."
     )
 
 
@@ -565,7 +707,7 @@ class Actor:
         A logic object (Machine / promise / callback logic) is used directly; a
         string is looked up in the machine's ``actors`` registry.
         """
-        if isinstance(src, (Machine, PromiseLogic, CallbackLogic)):
+        if isinstance(src, (Machine, PromiseLogic, CallbackLogic, ObservableLogic)):
             return src
         if isinstance(src, str):
             machine = self._backend.interpreter.machine
@@ -627,3 +769,46 @@ def create_actor(
     owned by this actor.
     """
     return Actor(logic, id=id, clock=clock, system=system, input=input)
+
+
+def to_promise(actor: Actor) -> asyncio.Future:
+    """Adapt *actor* to an :class:`asyncio.Future` (XState v5 ``toPromise``).
+
+    The future resolves with the actor's ``output`` when its snapshot reaches
+    ``status == "done"``, or raises its ``error`` when it reaches
+    ``status == "error"``.  If the actor is already settled the future resolves
+    immediately; otherwise it resolves on the next settling snapshot.  Must be
+    called with a running event loop.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        raise RuntimeError(
+            "to_promise() requires a running event loop; await it inside an "
+            "async context, e.g. within asyncio.run(...)."
+        ) from None
+
+    future: asyncio.Future = loop.create_future()
+
+    def _settle(snapshot: Any) -> None:
+        if future.done():
+            return
+        status = getattr(snapshot, "status", None)
+        if status == "done":
+            future.set_result(getattr(snapshot, "output", None))
+        elif status == "error":
+            error = getattr(snapshot, "error", None)
+            future.set_exception(
+                error
+                if isinstance(error, BaseException)
+                else RuntimeError(str(error))
+            )
+
+    snapshot = actor.get_snapshot()
+    if getattr(snapshot, "status", None) in ("done", "error"):
+        _settle(snapshot)
+        return future
+
+    subscription = actor.subscribe(_settle)
+    future.add_done_callback(lambda _f: subscription.unsubscribe())
+    return future

--- a/tests/test_async_actors.py
+++ b/tests/test_async_actors.py
@@ -1,0 +1,235 @@
+"""Tests for async actor logic (0.5.0).
+
+Covers coroutine ``from_promise`` resolution on the event loop,
+``from_observable`` streaming, ``to_promise`` adaptation, async ``invoke``
+integration with a machine parent, and the running-loop requirement.
+"""
+
+import asyncio
+
+import pytest
+
+from xstate import (
+    Machine,
+    assign,
+    create_actor,
+    from_observable,
+    from_promise,
+    to_promise,
+)
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+async def _wait_for(predicate, timeout: float = 1.0) -> None:
+    """Poll until *predicate* is true or *timeout* (seconds) elapses."""
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
+    while not predicate():
+        if loop.time() > deadline:
+            raise AssertionError("condition not met within timeout")
+        await asyncio.sleep(0.005)
+
+
+def _fetch_machine(fetcher):
+    return Machine(
+        {
+            "id": "fetcher_parent",
+            "context": {"result": None, "error": None},
+            "initial": "loading",
+            "states": {
+                "loading": {
+                    "invoke": {
+                        "id": "fetch",
+                        "src": "fetcher",
+                        "onDone": {
+                            "target": "success",
+                            "actions": [assign({"result": lambda c, e: e.data})],
+                        },
+                        "onError": {
+                            "target": "failure",
+                            "actions": [assign({"error": lambda c, e: str(e.data)})],
+                        },
+                    }
+                },
+                "success": {},
+                "failure": {},
+            },
+        },
+        actors={"fetcher": fetcher},
+    )
+
+
+# ---------------------------------------------------------------------------
+# async from_promise
+# ---------------------------------------------------------------------------
+
+
+async def test_async_promise_resolves_with_output():
+    async def fetch(input):
+        await asyncio.sleep(0)
+        return 42
+
+    actor = create_actor(from_promise(fetch)).start()
+    # Not resolved synchronously: the coroutine runs on the loop.
+    assert actor.get_snapshot().status == "active"
+    result = await to_promise(actor)
+    assert result == 42
+    assert actor.get_snapshot().status == "done"
+
+
+async def test_async_promise_receives_input():
+    async def double(input):
+        await asyncio.sleep(0)
+        return input * 2
+
+    actor = create_actor(from_promise(double), input=21).start()
+    assert await to_promise(actor) == 42
+
+
+async def test_async_promise_rejects_into_error():
+    async def boom(input):
+        await asyncio.sleep(0)
+        raise ValueError("nope")
+
+    actor = create_actor(from_promise(boom)).start()
+    with pytest.raises(ValueError, match="nope"):
+        await to_promise(actor)
+    snap = actor.get_snapshot()
+    assert snap.status == "error"
+    assert isinstance(snap.error, ValueError)
+
+
+async def test_stop_cancels_pending_async_promise():
+    started = asyncio.Event()
+
+    async def slow(input):
+        started.set()
+        await asyncio.sleep(10)
+        return "done"
+
+    actor = create_actor(from_promise(slow)).start()
+    await started.wait()
+    actor.stop()
+    assert actor.status == "stopped"
+    await asyncio.sleep(0.01)
+    # Never resolved — the task was cancelled.
+    assert actor.get_snapshot().status == "active"
+
+
+# ---------------------------------------------------------------------------
+# to_promise
+# ---------------------------------------------------------------------------
+
+
+async def test_to_promise_on_already_resolved_sync_actor():
+    # A plain (sync) from_promise resolves eagerly on start.
+    actor = create_actor(from_promise(lambda input: 7)).start()
+    assert actor.get_snapshot().status == "done"
+    assert await to_promise(actor) == 7
+
+
+async def test_to_promise_raises_on_sync_actor_error():
+    def boom(input):
+        raise RuntimeError("sync boom")
+
+    actor = create_actor(from_promise(boom)).start()
+    with pytest.raises(RuntimeError, match="sync boom"):
+        await to_promise(actor)
+
+
+# ---------------------------------------------------------------------------
+# from_observable
+# ---------------------------------------------------------------------------
+
+
+async def test_observable_emits_values_then_done():
+    async def numbers(input):
+        for i in range(3):
+            await asyncio.sleep(0)
+            yield i
+
+    emitted: list = []
+
+    actor = create_actor(from_observable(numbers))
+    actor.subscribe(
+        lambda snap: (
+            emitted.append(snap.context)
+            if snap.status == "active" and snap.context is not None
+            else None
+        )
+    )
+    actor.start()
+    result = await to_promise(actor)
+    assert emitted == [0, 1, 2]
+    assert result == 2  # output is the final emitted value
+    assert actor.get_snapshot().status == "done"
+
+
+async def test_observable_propagates_error():
+    async def failing(input):
+        yield 1
+        raise RuntimeError("stream boom")
+
+    actor = create_actor(from_observable(failing)).start()
+    with pytest.raises(RuntimeError, match="stream boom"):
+        await to_promise(actor)
+    assert actor.get_snapshot().status == "error"
+
+
+async def test_observable_receives_input():
+    async def gen(input):
+        for i in range(input):
+            await asyncio.sleep(0)
+            yield i
+
+    actor = create_actor(from_observable(gen), input=2).start()
+    assert await to_promise(actor) == 1  # last of range(2) -> 0, 1
+
+
+# ---------------------------------------------------------------------------
+# async invoke integration (machine parent)
+# ---------------------------------------------------------------------------
+
+
+async def test_invoke_async_promise_on_done():
+    async def fetcher(input):
+        await asyncio.sleep(0)
+        return 99
+
+    actor = create_actor(_fetch_machine(from_promise(fetcher))).start()
+    # The parent does not resolve synchronously with an async child.
+    assert actor.get_snapshot().value == "loading"
+    await _wait_for(lambda: actor.get_snapshot().value == "success")
+    assert actor.get_snapshot().context["result"] == 99
+
+
+async def test_invoke_async_promise_on_error():
+    async def boom(input):
+        await asyncio.sleep(0)
+        raise ValueError("kaboom")
+
+    actor = create_actor(_fetch_machine(from_promise(boom))).start()
+    await _wait_for(lambda: actor.get_snapshot().value == "failure")
+    assert actor.get_snapshot().context["error"] == "kaboom"
+
+
+# ---------------------------------------------------------------------------
+# running-loop requirement (synchronous context)
+# ---------------------------------------------------------------------------
+
+
+def test_async_promise_without_running_loop_raises():
+    async def fetch(input):
+        return 1
+
+    with pytest.raises(RuntimeError, match="running event loop"):
+        create_actor(from_promise(fetch)).start()
+
+
+def test_to_promise_without_running_loop_raises():
+    actor = create_actor(from_promise(lambda input: 1)).start()
+    with pytest.raises(RuntimeError, match="running event loop"):
+        to_promise(actor)


### PR DESCRIPTION
## Summary

**Completes the 0.5.0 async milestone.** The synchronous actor model (PR history) and the `AsyncInterpreter` (#9) already existed; this PR bridges the *actors themselves* onto the event loop, so deferred (promise) and streaming (observable) logic resolve asynchronously, and adds `to_promise` to await any actor.

With this, `xstate` is bumped to **`0.5.0`**.

## What changed (`src/xstate/actor.py`)

### `from_promise` — coroutine resolution
A `from_promise` whose function is an `async def` now schedules its coroutine as an `asyncio.Task` and settles via a done-callback: `status == "done"` with `output`, or `status == "error"` with the exception. **A plain (sync) function still resolves eagerly on `start()`** — so all existing synchronous behavior, and the synchronous `invoke` resolution path, are unchanged (verified: the 45 existing actor tests pass untouched).

### `from_observable` — new actor logic
Iterates an async iterable (e.g. an async generator function, called with `input`): each value becomes an `"active"` snapshot with `context` set to the value (listeners notified), and exhaustion settles `"done"` with the final value as `output` (or `"error"` if it raises).

### `to_promise(actor)` — actor → `asyncio.Future`
Adapts any actor — sync or async, machine or logic — to a future that resolves with `output` or raises `error`. Settles immediately if the actor is already done/error, otherwise on the next settling snapshot (auto-unsubscribes on completion).

### Async `invoke` integration
An async `from_promise` / `from_observable` invoked child feeds `done.invoke.<id>` / `error.platform.<id>` back to its machine parent once its task settles — carried by the existing reconciler and the synchronous `send` path, so a machine parent transitions correctly without itself being async.

### `_ensure_future` helper
Centralizes the running-loop requirement with a clear `RuntimeError` ("requires a running event loop … `asyncio.run(...)`") and closes an orphaned coroutine so it doesn't emit a "never awaited" warning.

## Other

- `__init__.py`: export `from_observable`, `to_promise`
- `pyproject.toml`: version `0.4.0` → `0.5.0`; add `tests/test_async_actors.py` to the existing A006 (`input` shadowing) per-file-ignore, consistent with the other actor test files
- `CLAUDE.md`: move async actors to "Working", mark current state `0.5.0`, refresh the stubbed list toward 0.6.0 (`setup()`, persistence)

## Tests (`tests/test_async_actors.py`, 13)

Async `from_promise` resolve / reject / input; `stop()` cancels a pending task; `to_promise` over both already-resolved sync actors and pending async actors (output + error); `from_observable` emit-then-done, error propagation, and `input`; async `invoke` `onDone` / `onError` against a machine parent; and the running-loop `RuntimeError` for both `from_promise` and `to_promise` in a sync context.

## Verification

```
273 passed   (+13; was 260)   ← clean under -W error::DeprecationWarning
ruff check src/ tests/   ← All checks passed
mypy src/xstate/         ← Success: no issues found in 14 source files
```

## Usage

```python
import asyncio
from xstate import create_actor, from_promise, from_observable, to_promise

async def main():
    async def fetch(input):
        await asyncio.sleep(0.1)
        return {"id": input}

    actor = create_actor(from_promise(fetch), input=42).start()
    print(await to_promise(actor))  # {"id": 42}

asyncio.run(main())
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01E5AJUvQDU2YYNtWWUD54ML)_