### PR TITLE
Refresh public documentation for current state

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,22 +30,22 @@ dependencies; development tools are managed through Poetry.
 Run the primary suite before opening a PR:
 
 ```bash
-python3 -m pytest tests/ --ignore=tests/test_scxml.py
+poetry run python -m pytest tests/ --ignore=tests/test_scxml.py
 ```
 
 Run type checking and linting:
 
 ```bash
-python3 -m mypy src/xstate/
-ruff format --check src/ tests/
-ruff check src/ tests/
+poetry run mypy src/xstate/
+poetry run ruff format --check src/ tests/
+poetry run ruff check src/ tests/
 ```
 
 SCXML changes need the SCXML test framework:
 
 ```bash
 git submodule update --init
-PYTHONPATH=src python3 -m pytest tests/test_scxml.py
+poetry run python -m pytest tests/test_scxml.py
 ```
 
 The current known full-SCXML gap is the `more-parallel` conformance group.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,38 +1,66 @@
+# Contributing
 
-## Git Flow:
+Thanks for helping shape `xstate-python`. The project is still alpha, so small,
+well-tested changes with clear intent are especially valuable.
 
-1. Checkout the latest master:
+## Branches
+
+Start from the branch your work is stacked on. For ordinary work, branch from
+`master`; for follow-up work on an open PR, branch from that PR branch.
+
+Use descriptive branch names without a `codex/` prefix, for example:
 
 ```bash
 git checkout master
 git pull
+git checkout -b docs-current-state-refresh
 ```
 
-2. Branch off of master:
+## Development Setup
 
 ```bash
-# example: jenny-tru/54 or jenny-tru/quick-fix-for-thing
-git checkout -b <USERNAME>/<ISSUE>
+poetry install
 ```
 
-3. Make your changes!
+The package uses a `src/` layout and Python 3.13+. The core runtime has no
+dependencies; development tools are managed through Poetry.
 
-4. Run tests:
+## Checks
+
+Run the primary suite before opening a PR:
 
 ```bash
-pytest
-# To see print() output:
-pytest -s
+python3 -m pytest tests/ --ignore=tests/test_scxml.py
 ```
 
-5. Commit your changes, through the VS Code UI or:
+Run type checking and linting:
 
 ```bash
-git commit -a -m "Your commit message here"
+python3 -m mypy src/xstate/
+ruff format --check src/ tests/
+ruff check src/ tests/
 ```
 
-6. Push to origin, through the VS Code UI or:
+SCXML changes need the SCXML test framework:
 
 ```bash
-git push origin head
+git submodule update --init
+PYTHONPATH=src python3 -m pytest tests/test_scxml.py
 ```
+
+The current known full-SCXML gap is the `more-parallel` conformance group.
+Do not treat those existing failures as caused by unrelated docs or tooling
+changes.
+
+## Pull Requests
+
+Please keep PRs focused:
+
+- Explain what changed and why.
+- Mention compatibility impact, especially public API or snapshot behavior.
+- Include the exact checks you ran and their results.
+- Keep generated/cache files out of commits.
+- Avoid staging local agent context files such as `AGENTS.md`.
+
+For stacked work, make the PR base the branch it depends on and call out the
+stack order in the PR body.

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ framework:
 
 ```bash
 git submodule update --init
-PYTHONPATH=src python3 -m pytest tests/test_scxml.py
+poetry run python -m pytest tests/test_scxml.py
 ```
 
 Current branch result: `45 passed`, `8 failed`; the remaining failures are the
@@ -374,14 +374,14 @@ safe Boolean evaluator.
 poetry install
 
 # Primary suite
-python3 -m pytest tests/ --ignore=tests/test_scxml.py
+poetry run python -m pytest tests/ --ignore=tests/test_scxml.py
 
 # Type checking
-python3 -m mypy src/xstate/
+poetry run mypy src/xstate/
 
 # Formatting and linting
-ruff format --check src/ tests/
-ruff check src/ tests/
+poetry run ruff format --check src/ tests/
+poetry run ruff check src/ tests/
 ```
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -1,255 +1,143 @@
 <h1 align="center">XState for Python</h1>
 
 <p align="center">
-  <strong>Statecharts and state machines for Python</strong> — a port of
-  <a href="https://github.com/statelyai/xstate">XState</a> built on the
+  <strong>Statecharts and actor-based state machines for Python</strong>, shaped around
+  <a href="https://github.com/statelyai/xstate">XState</a> configs and the
   <a href="https://www.w3.org/TR/scxml/#AlgorithmforSCXMLInterpretation">W3C SCXML</a>
   execution algorithm.
 </p>
 
 <p align="center">
-  <a href="https://github.com/JovaniPink/xstate-python/actions"><img alt="Tests" src="https://img.shields.io/badge/tests-194%20passing-brightgreen"></a>
-  <img alt="Python" src="https://img.shields.io/badge/python-3.9%20%E2%80%93%203.13-blue">
+  <a href="https://github.com/JovaniPink/xstate-python/actions"><img alt="Primary tests" src="https://img.shields.io/badge/primary%20tests-284%20passing-brightgreen"></a>
+  <img alt="Python" src="https://img.shields.io/badge/python-3.13%2B-blue">
   <img alt="Status" src="https://img.shields.io/badge/status-alpha%20(0.5.0)-orange">
   <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-green"></a>
 </p>
 
 ---
 
-## Why this library?
+## Why This Library?
 
-There are several good Python state-machine libraries. This one owns a specific
-niche: **native [XState](https://github.com/statelyai/xstate) / [Stately.ai](https://stately.ai/editor)
-JSON compatibility, backed by a real SCXML execution engine.**
+This project has a narrow, useful goal: load native
+[XState](https://github.com/statelyai/xstate) / [Stately](https://stately.ai/editor)
+JSON in Python and run it with a statechart engine that follows the SCXML
+microstep/macrostep model.
 
-A statechart you design in the Stately editor or share with a JavaScript
-codebase is the *same* JSON you load here — no translation layer:
+That means a chart designed visually in Stately, or shared with a JavaScript
+frontend, can stay declarative:
 
 ```python
 import json
+
 from xstate import Machine
 
-machine = Machine(json.load(open("my_machine.json")))
+with open("machine.json") as f:
+    config = json.load(f)
+
+machine = Machine(config)
 ```
+
+Only live implementation details need Python bindings: action functions, guard
+functions, delay values, and actor logic.
 
 | | xstate-python |
 |---|---|
-| **XState JSON** | Loaded directly as a Python `dict` — the differentiator |
-| **Engine** | W3C SCXML microstep/macrostep algorithm (`algorithm.py`) |
-| **Statechart features** | Hierarchy, parallel regions, history, guards, context, delays, actors |
-| **Runtime** | Pure `Machine.transition` *or* a stateful `Interpreter` / `Actor` |
-| **Dependencies** | **None** for the core (SCXML XML import is an optional extra) |
-
-See [`docs/comparison.md`](./docs/comparison.md) for a full feature matrix against
-`transitions`, `python-statemachine`, `Sismic`, and others.
+| XState JSON | Loaded directly as Python `dict` data |
+| Engine | W3C SCXML-style run-to-completion algorithm |
+| Core runtime deps | None |
+| Main runtime APIs | Pure `Machine.transition`, `Interpreter`, `AsyncInterpreter`, `Actor` |
+| Current focus | XState v5 alignment, actors, setup, and SCXML correctness |
 
 ## Installation
 
+The package metadata is ready for `xstate`, but this branch is still pre-release.
+For now, install from source:
+
 ```bash
-# from source (no PyPI release yet — 0.5.0 in progress)
 git clone https://github.com/JovaniPink/xstate-python.git
 cd xstate-python
 poetry install
 ```
 
-The core has **no runtime dependencies**. SCXML *XML* import (with JavaScript
-`cond` evaluation) is an optional extra: `pip install "xstate[scxml]"`.
+The core library has no runtime dependencies. The `scxml` extra is intentionally
+dependency-free on Python 3.13+; SCXML Boolean `cond` support covers the safe
+subset `true`, `false`, `!`, `&&`, `||`, and parentheses.
 
 ## Quickstart
 
-A `Machine` is a pure function over `(state, event) -> state`:
+`Machine` is the pure state transition layer: `(state, event) -> state`.
 
 ```python
 from xstate import Machine
 
-lights = Machine({
-    "id": "lights",
-    "initial": "green",
-    "states": {
-        "green":  {"on": {"TIMER": "yellow"}},
-        "yellow": {"on": {"TIMER": "red"}},
-        "red":    {"on": {"TIMER": "green"}},
-    },
-})
-
-state = lights.initial_state          # state.value == "green"
-state = lights.transition(state, "TIMER")   # "yellow"
-state = lights.transition(state, "TIMER")   # "red"
-```
-
-`machine.transition` has no side effects — it returns a fresh `State`. To run a
-machine as a live, stateful service with an event queue, use the
-[`Interpreter`](#running-a-machine--interpreter) or
-[`Actor`](#actors--invoke-050) APIs below.
-
-## Core concepts
-
-### Hierarchical (compound) states
-
-States can nest. A `final` child fires `onDone` on its parent:
-
-```python
-machine = Machine({
-    "id": "lights",
-    "initial": "green",
-    "states": {
-        "green":  {"on": {"TIMER": "yellow"}},
-        "yellow": {"on": {"TIMER": "red"}},
-        "red": {
-            "initial": "walk",
-            "states": {
-                "walk":    {"on": {"COUNTDOWN": "wait"}},
-                "wait":    {"on": {"COUNTDOWN": "stop"}},
-                "stop":    {"on": {"TIMEOUT": "timeout"}},
-                "timeout": {"type": "final"},
-            },
-            "onDone": "green",
-        },
-    },
-})
-# state.value for a compound state is a dict: {"red": "walk"}
-```
-
-### Parallel states
-
-A `parallel` state activates all of its regions at once; events broadcast to
-every region. `value` becomes a nested dict:
-
-```python
-player = Machine({
-    "id": "player",
-    "type": "parallel",
-    "states": {
-        "playback": {
-            "initial": "paused",
-            "states": {
-                "paused":  {"on": {"PLAY": "playing"}},
-                "playing": {"on": {"PAUSE": "paused"}},
-            },
-        },
-        "volume": {
-            "initial": "unmuted",
-            "states": {
-                "unmuted": {"on": {"MUTE": "muted"}},
-                "muted":   {"on": {"UNMUTE": "unmuted"}},
-            },
-        },
-    },
-})
-# state.value == {"playback": "paused", "volume": "unmuted"}
-```
-
-### Guards (conditions)
-
-A transition only fires if its `cond` passes. Guards are a callable
-`(context, event) -> bool`, or a string resolved from the `guards=` registry:
-
-```python
-machine = Machine(
+lights = Machine(
     {
-        "id": "search",
-        "initial": "idle",
+        "id": "lights",
+        "initial": "green",
         "states": {
-            "idle": {
-                "on": {
-                    "SEARCH": {"target": "searching", "cond": "isNotEmpty"},
-                },
-            },
-            "searching": {},
+            "green": {"on": {"TIMER": "yellow"}},
+            "yellow": {"on": {"TIMER": "red"}},
+            "red": {"on": {"TIMER": "green"}},
         },
-    },
-    guards={"isNotEmpty": lambda ctx, ev: bool(ev.data.get("query"))},
+    }
+)
+
+state = lights.initial_state
+assert state.value == "green"
+
+state = lights.transition(state, "TIMER")
+assert state.value == "yellow"
+```
+
+Use an event object when you need payload data:
+
+```python
+state = lights.transition(state, {"type": "TIMER", "source": "clock"})
+```
+
+## Loading XState JSON
+
+The JSON stays data-only. Python registries provide implementations by name:
+
+```python
+import json
+
+from xstate import Machine, assign, from_promise
+
+with open("search_machine.json") as f:
+    config = json.load(f)
+
+machine = Machine(
+    config,
+    guards={"hasQuery": lambda ctx, event: bool(event.data.get("query"))},
+    actions={"rememberQuery": assign({"query": lambda _ctx, event: event.data["query"]})},
+    delays={"debounce": 300},
+    actors={"fetchResults": from_promise(lambda input: ["Ada", "Grace"])},
 )
 ```
 
-### Context and `assign`
+Prefer XState v5 keys such as `guard`, `output`, and `always`. Older `cond`,
+`data`, and `on: {"": ...}` forms remain supported for compatibility and may
+emit deprecation warnings.
 
-`context` is the machine's extended (quantitative) state. Update it with the
-`assign` action — snapshots are deep-copied, so transitions never mutate a prior
-state:
+## Running A Machine
 
-```python
-from xstate import Machine, assign
-
-counter = Machine({
-    "id": "counter",
-    "context": {"count": 0},
-    "initial": "active",
-    "states": {
-        "active": {
-            "on": {
-                "INC": {"actions": [assign({"count": lambda c, e: c["count"] + 1})]},
-                "RESET": {"actions": [assign({"count": 0})]},
-            },
-        },
-    },
-})
-
-# Event payloads reach guards/assigners via event.data:
-state = counter.transition(counter.initial_state, {"type": "INC"})
-state.context  # {"count": 1}
-```
-
-### Entry / exit actions
-
-Run side effects on entering or leaving a state. Reference them by name and
-supply implementations through `actions=`:
+`interpret(machine)` turns a pure machine into a stateful service with
+subscriptions, run-to-completion queuing, delayed transitions, and side-effect
+actions:
 
 ```python
-machine = Machine(
-    {
-        "id": "door",
-        "initial": "closed",
-        "states": {
-            "closed": {"entry": ["lock"], "exit": ["unlock"], "on": {"OPEN": "open"}},
-            "open": {},
-        },
-    },
-    actions={"lock": lambda: print("locked"), "unlock": lambda: print("unlocked")},
-)
-```
-
-### History states
-
-A history pseudo-state restores a parent's most recent configuration —
-`shallow` (default) or `deep`:
-
-```python
-"hist": {"type": "history", "history": "deep"}
-```
-
-### Eventless transitions (`always`)
-
-Transitions that are checked immediately after every step, taken as soon as
-their guard passes (XState v5 `always:`; the v4 `on: {"": ...}` form also works):
-
-```python
-"checking": {
-    "always": [
-        {"target": "valid", "cond": "isValid"},
-        {"target": "invalid"},
-    ],
-},
-```
-
-## Running a machine — `Interpreter`
-
-The `Interpreter` turns a pure machine into a live service with a
-run-to-completion event queue, subscriptions, and delayed transitions:
-
-```python
-from xstate import Machine, interpret
+from xstate import interpret
 
 service = interpret(machine).start()
-service.subscribe(lambda state: print("->", state.value))
-service.send("TIMER")
+subscription = service.subscribe(lambda state: print("->", state.value))
+
+service.send("SEARCH")
+subscription.unsubscribe()
 service.stop()
 ```
 
-### Delayed transitions (`after`)
-
-`after` schedules a transition some milliseconds after a state is entered, and
-cancels it on exit. Timing runs through a pluggable **`Clock`**:
+Delayed transitions use a pluggable clock. Use `SimulatedClock` in tests:
 
 ```python
 from xstate import Machine, interpret
@@ -257,193 +145,262 @@ from xstate.scheduler import SimulatedClock
 
 machine = Machine(
     {
-        "id": "light",
-        "initial": "green",
+        "id": "timer",
+        "initial": "waiting",
         "states": {
-            "green":  {"after": {"GREEN_TIME": "yellow"}},
-            "yellow": {"after": {2000: "red"}},
-            "red":    {},
+            "waiting": {"after": {1000: "done"}},
+            "done": {"type": "final"},
         },
-    },
-    delays={"GREEN_TIME": 6000},   # named delays resolve here
+    }
 )
 
-clock = SimulatedClock()           # deterministic — no real waiting
+clock = SimulatedClock()
 service = interpret(machine, clock=clock).start()
-clock.increment(6000)              # fires green -> yellow
-clock.increment(2000)              # fires yellow -> red
+
+clock.increment(1000)
+assert service.state.value == "done"
 ```
 
-Use `SimulatedClock` in tests for reproducible timing; `ThreadClock` (the
-default) uses real wall-clock time.
+The synchronous interpreter serializes timer callbacks and user sends with a
+re-entrant lock so `ThreadClock` callbacks cannot interleave state mutation.
 
-## Actors & `invoke` (0.5.0)
+## Async Runtime
 
-The actor model is XState v5's runtime. `create_actor` runs *actor logic* — a
-`Machine`, or logic from `from_promise` / `from_callback` — as an addressable
-actor inside a system.
+`interpret_async(machine)` provides the asyncio-native runtime. It supports
+`await start()`, `await send()`, `await stop()`, async action callables, and
+event-loop scheduled `after` transitions:
 
-### `invoke:` — run a child actor for a state's lifetime
+```python
+from xstate import interpret_async
+
+service = interpret_async(machine)
+await service.start()
+await service.send("SEARCH")
+await service.stop()
+```
+
+The pure transition and guard layer remains synchronous; only action execution,
+timers, and actor settlement are async-aware.
+
+## Actors And `invoke`
+
+XState v5 treats running logic as actors. This library supports machine actors,
+promise actors, callback actors, observable actors, spawning, parent/child
+messaging, and `invoke` lifecycle wiring.
 
 ```python
 from xstate import Machine, assign, create_actor, from_promise
 
+
 def fetch_user(input):
     return {"id": input["user_id"], "name": "Ada"}
+
 
 machine = Machine(
     {
         "id": "fetcher",
+        "context": {"user_id": 42, "user": None},
         "initial": "loading",
-        "context": {"user_id": 42, "data": None},
         "states": {
             "loading": {
                 "invoke": {
                     "id": "getUser",
                     "src": "fetchUser",
-                    "input": lambda ctx, ev: {"user_id": ctx["user_id"]},
+                    "input": lambda ctx, _event: {"user_id": ctx["user_id"]},
                     "onDone": {
-                        "target": "done",
-                        "actions": [assign({"data": lambda c, e: e.data})],
+                        "target": "success",
+                        "actions": [assign({"user": lambda _ctx, event: event.data})],
                     },
-                    "onError": "failed",
-                },
+                    "onError": "failure",
+                }
             },
-            "done": {"type": "final"},
-            "failed": {},
+            "success": {"type": "final"},
+            "failure": {},
         },
     },
     actors={"fetchUser": from_promise(fetch_user)},
 )
 
 actor = create_actor(machine).start()
-actor.get_snapshot().value      # "done"
-actor.get_snapshot().context    # {"user_id": 42, "data": {"id": 42, "name": "Ada"}}
+snapshot = actor.get_snapshot()
+
+assert snapshot.value == "success"
+assert snapshot.context["user"]["name"] == "Ada"
 ```
 
-### Actor logic kinds
+Actor helpers exported from `xstate` include:
 
-- **`from_promise(fn)`** — `fn(input)` runs once; resolves to `done.invoke.<id>`
-  (`onDone`) or, if it raises, `error.platform.<id>` (`onError`).
-- **`from_callback(fn)`** — `fn(send_back, receive, input)` bridges an external
-  event source; `send_back(event)` notifies the parent, `receive(handler)`
-  handles incoming events, and a returned callable runs as cleanup on stop.
+- `create_actor(machine_or_logic)`
+- `from_promise(fn)`
+- `from_callback(fn)`
+- `from_observable(fn_or_async_iterable)`
+- `to_promise(actor)`
+- `send_parent(event)` and `send_to(actor_id, event)`
 
-### Spawning and messaging
+## `setup()` And Handler Signatures
 
-```python
-child = actor.spawn(child_machine, id="worker")   # ad-hoc child actor
-
-from xstate import send_parent, send_to
-# inside a child machine:  {"entry": [send_parent("READY")]}
-# address a sibling by id: {"actions": [send_to("logger", "LOG")]}
-```
-
-## Loading from XState JSON
-
-Because the config *is* XState JSON, the structure lives in a `.json` file and
-only the live parts (guards, actions, delays, actor logic) are wired in Python,
-keyed by the names used in the JSON:
+`setup(...)` mirrors XState v5's named implementation style and creates machines
+in stricter mode:
 
 ```python
-import json
-from xstate import Machine
+from xstate import HandlerArgs, setup
 
-config = json.load(open("machine.json"))
-machine = Machine(
-    config,
-    guards={"crossingIsClear": ...},
-    actions={"allRed": ...},
-    delays={"walkTime": 5000},
-    actors={"fetchUser": ...},
+
+def has_query(args: HandlerArgs) -> bool:
+    return bool(args.event.data.get("query"))
+
+
+machine = setup(guards={"hasQuery": has_query}).create_machine(
+    {
+        "id": "search",
+        "initial": "idle",
+        "states": {
+            "idle": {"on": {"SEARCH": {"target": "searching", "guard": "hasQuery"}}},
+            "searching": {},
+        },
+    }
 )
 ```
 
-> **Note:** `assign` carries a live callable, so context mutations are written
-> in Python rather than in the JSON. Everything else — hierarchy, parallel
-> regions, guards/actions/delays/actor logic *by name*, `after`, `onDone` —
-> is fully declarative.
+Legacy callables still work through adapter compatibility: `()`, `(context)`,
+`(context, event)`, and keyword-only `(*, context, event)`.
+
+## Context And Snapshots
+
+`context` is extended state. Use `assign(...)` to return updated context during
+a transition:
+
+```python
+from xstate import Machine, assign
+
+counter = Machine(
+    {
+        "id": "counter",
+        "context": {"count": 0},
+        "initial": "active",
+        "states": {
+            "active": {
+                "on": {
+                    "INC": {
+                        "actions": [
+                            assign({"count": lambda ctx, _event: ctx["count"] + 1})
+                        ]
+                    }
+                }
+            }
+        },
+    }
+)
+```
+
+By default, state context is snapshot-isolated with deep copies. Public snapshot
+containers are immutable at the boundary: `configuration` is a `frozenset`,
+`actions` is a `tuple`, and `history_value` is read-only. For immutable
+dataclass contexts, use `dataclass_context()` / `DataclassContextAdapter`.
+
+## Core Statechart Features
+
+- Hierarchical and parallel states
+- Entry, exit, and transition actions
+- Named and inline guards
+- Context and `assign`
+- Eventless transitions via `always`
+- Final states and `onDone`
+- Shallow and deep history states
+- Delayed transitions via `after`
+- SCXML XML import
+- Actor invocation with `invoke`, `onDone`, and `onError`
 
 ## Examples
 
-Runnable, verified examples live in [`docs/examples/`](./docs/examples):
+Runnable examples live in [`docs/examples/`](./docs/examples):
 
 | Example | Showcases |
 |---|---|
-| [`traffic_intersection.json`](./docs/examples/traffic_intersection.json) + [`.py`](./docs/examples/traffic_intersection.py) | A complex chart **loaded from JSON**: parallel regions, nested compound states, named `after` delays, a guarded pedestrian request, and a global `EMERGENCY` override |
-| [`fetch_with_retry.py`](./docs/examples/fetch_with_retry.py) | The **0.5.0 actor model**: `invoke` + `from_promise`, `onDone`/`onError`, context/`assign`, a `canRetry` guard, and `after` backoff |
+| [`traffic_intersection.json`](./docs/examples/traffic_intersection.json) + [`traffic_intersection.py`](./docs/examples/traffic_intersection.py) | XState JSON loading, parallel regions, nested states, named delays, guards, entry actions, and deterministic clocks |
+| [`fetch_with_retry.py`](./docs/examples/fetch_with_retry.py) | `invoke`, `from_promise`, retries with `after`, context assignment, and guarded transitions |
+
+Run them from the repo root:
 
 ```bash
-PYTHONPATH=. python docs/examples/traffic_intersection.py
-PYTHONPATH=. python docs/examples/fetch_with_retry.py
+PYTHONPATH=src python3 docs/examples/traffic_intersection.py
+PYTHONPATH=src python3 docs/examples/fetch_with_retry.py
 ```
-
-Smaller snippets are in [`examples/`](./examples).
 
 ## Public API
 
 ```python
 from xstate import (
-    Machine,                       # pure (state, event) -> state
-    interpret, Interpreter,        # running service + event queue
-    create_actor, Actor, ActorSystem,   # actor model (v5)
-    from_promise, from_callback,   # actor logic kinds
-    assign, send, send_parent, send_to, cancel, raise_,   # action creators
-    MachineSnapshot,               # v5 snapshot
+    Machine,
+    MachineSnapshot,
+    setup,
+    HandlerArgs,
+    interpret,
+    interpret_async,
+    create_actor,
+    from_promise,
+    from_callback,
+    from_observable,
+    to_promise,
+    assign,
+    send,
+    send_parent,
+    send_to,
+    cancel,
+    raise_,
+    dataclass_context,
 )
-from xstate.scheduler import Clock, SimulatedClock, ThreadClock
+from xstate.scheduler import SimulatedClock, ThreadClock
 ```
-
-```python
-machine = Machine(config, actions={}, guards={}, delays={}, actors={})
-state = machine.initial_state          # State(value, configuration, context, actions)
-state = machine.transition(state, "EVENT" | {"type": "EVENT", ...})
-state.value      # str for atomic states, dict for compound/parallel
-state.context    # extended state
-state.can(event) # bool — would this event cause a transition?
-```
-
-## Roadmap
-
-| Version | Theme | Highlights |
-|---|---|---|
-| 0.1.0 | Stabilize | Engine fixes, drop Js2Py hard dep, modern packaging |
-| 0.2.0 | Solid v4 FSM | Pure-Python guards, deep history, context/`assign`, full parallel |
-| 0.3.0 | Interpreter | RTC event loop, delayed transitions (`after`/`cancel`) |
-| 0.4.0 | v5 alignment | `guard`/`output`/`always:`, single-object handlers, `MachineSnapshot` |
-| **0.5.0** | **Actor model** | **`create_actor`, `invoke`, `from_promise`/`from_callback`, messaging** ← current |
-| 0.6.0+ | Setup & parity | `setup()`, composable guards, persistence, asyncio |
 
 ## SCXML
 
-The engine implements the [W3C SCXML algorithm](https://www.w3.org/TR/scxml/#AlgorithmforSCXMLInterpretation).
-SCXML *XML* documents can be imported with `pip install "xstate[scxml]"`, and the
-[SCION test framework](./test-framework) (a git submodule) verifies conformance:
+The algorithm core follows the W3C SCXML execution model. XML import is exposed
+through `xstate.scxml.scxml_to_machine(...)` and verified against the SCXML test
+framework:
 
 ```bash
 git submodule update --init
-poetry run pytest tests/test_scxml.py
+PYTHONPATH=src python3 -m pytest tests/test_scxml.py
 ```
+
+Current branch result: `45 passed`, `8 failed`; the remaining failures are the
+known `more-parallel` conformance cases. The `cond-js` subset passes with the
+safe Boolean evaluator.
 
 ## Developing
 
 ```bash
-poetry install                                   # dev deps
-poetry run pytest --ignore=tests/test_scxml.py   # primary test suite (194 tests)
-poetry run mypy xstate/                           # type check
-poetry run black xstate/ tests/                   # format
-poetry run isort xstate/ tests/
-poetry run flake8 xstate/ tests/
+poetry install
+
+# Primary suite
+python3 -m pytest tests/ --ignore=tests/test_scxml.py
+
+# Type checking
+python3 -m mypy src/xstate/
+
+# Formatting and linting
+ruff format --check src/ tests/
+ruff check src/ tests/
 ```
 
-A VS Code [dev container](https://code.visualstudio.com/docs/remote/containers)
-is included: open the folder in a container and run the tests.
+## Roadmap
 
-## Related projects
+| Area | Current state |
+|---|---|
+| PyPI release | Packaging metadata is modernized; release still pending |
+| XState v5 setup | `setup(...).create_machine(...)` exists; composable guard helpers remain future work |
+| Async | `AsyncInterpreter`, async actors, `from_observable`, and `to_promise` are present |
+| SCXML | XML import works; safe Boolean cond subset works; `more-parallel` conformance remains open |
+| Persistence | Snapshot serialization is not implemented yet |
 
-- [XState](https://github.com/statelyai/xstate) — the original JavaScript/TypeScript library
-- [Stately.ai](https://stately.ai/editor) — visual statechart editor (exports the JSON this library loads)
-- [python-statemachine](https://github.com/fgmacedo/python-statemachine) · [transitions](https://github.com/pytransitions/transitions) · [Sismic](https://github.com/AlexandreDecan/sismic)
+## Related Projects
+
+- [XState](https://github.com/statelyai/xstate)
+- [Stately](https://stately.ai/editor)
+- [python-statemachine](https://github.com/fgmacedo/python-statemachine)
+- [transitions](https://github.com/pytransitions/transitions)
+- [Sismic](https://github.com/AlexandreDecan/sismic)
 
 ## License
 

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -1,409 +1,98 @@
-# xstate-python — Product Document
+# xstate-python Product Notes
 
-> Research snapshot: June 2026. XState JS data sourced from stately.ai/docs, npmjs.com,
-> github.com/statelyai/xstate, and the official CHANGELOG. Python library data from PyPI,
-> GitHub, and each library's documentation. All numeric claims cross-verified across ≥2 sources.
+Research snapshot: June 2026. External ecosystem numbers are approximate and
+should be refreshed before publication or fundraising use. Repo capability notes
+reflect the current stacked branch state after typed-core and Python 3.13
+runtime-safety work.
 
----
+## Product Thesis
 
-## 1. What We Are Building
+`xstate-python` is a Python implementation of XState-style statecharts with
+native XState/Stately JSON compatibility and an SCXML-style execution core.
 
-**xstate-python** is a Python implementation of [XState](https://github.com/statelyai/xstate)
-— hierarchical statecharts with the W3C SCXML execution algorithm at the core and native
-compatibility with XState / Stately.ai JSON config.
+The short pitch:
 
-The one-sentence pitch:
+> Design a statechart in Stately, share the JSON with Python, and run it with
+> predictable statechart semantics.
 
-> *Design your state machine in the Stately.ai visual editor, export the JSON, drop it into
-> Python — it just works.*
+The bet is not to out-feature every Python FSM package. The bet is to own the
+bridge between XState's JSON ecosystem and Python backends.
 
-No other maintained Python library does this. That gap is the bet.
+## Current State
 
----
-
-## 2. The Market
-
-### 2a. XState JS — what we are tracking
-
-XState is at **v5.32.1** (released June 12, 2025 — 32 minor versions in 18 months).
-
-| Metric | Value | Source |
-|---|---|---|
-| GitHub stars | **~29,700** | github.com/statelyai/xstate (direct) |
-| Weekly npm downloads | **~4.7M** (raw) / ~1.5M (adjusted) | npmtrends / snyk.io |
-| @xstate/react weekly downloads | ~2.18M | npmjs.com |
-| Discord members | ~5,000 | toolify.ai/discord/xstate |
-| Companies using in prod | 194+ estimated | therstack.com; Gatsby, Kong, Koordinates, Back Market confirmed |
-
-XState released v5.0.0 on **December 1, 2023**. It is actively maintained with roughly one
-minor release per month. The release cadence signals a healthy, committed upstream.
-
-### 2b. Stately ecosystem (the platform that makes XState a product)
-
-| Product | What it is | Relevant to us |
-|---|---|---|
-| **Stately Studio** | Visual statechart editor → exports XState JSON | Our JSON import is the bridge |
-| **Stately Sky** | Edge-deployed live actors (Cloudflare Workers + Durable Objects; ~50ms latency globally) | Out of scope for open-source lib |
-| **Stately Inspector** (`@statelyai/inspect`) | Universal actor inspector, replaced `@xstate/inspect` in Jan 2024 | Future: Python-compatible inspector protocol |
-
-**Stately Studio pricing** (as of June 2026, unchanged since Nov 2023):
-
-| Tier | Price | Key limits |
-|---|---|---|
-| Community | Free | Unlimited public projects; 3 AI generations/month |
-| Pro | $39/mo | Private projects; 1,000 AI gens/month; Sky; GitHub Sync; React UI gen |
-| Team | $199/mo (≤10 users) | Shared projects; team roles |
-| Enterprise | Custom | SSO; audit logs; custom hosting; embed Studio |
-
-The Stately Studio → JSON export is the funnel for xstate-python users. A team using Stately
-Studio Pro to design machines will want Python import to work seamlessly.
-
-### 2c. Python state machine landscape
-
-| Library | Stars | Latest | Hier. | Parallel | Async | SCXML | XState JSON | Actor model |
-|---|---|---|---|---|---|---|---|---|
-| **transitions** | ~6,500 | 0.9.3 — Jul 2025 | Ext | Ext | Yes | No | No | No |
-| **python-statemachine** | ~1,200 | 3.1.2 — May 2026 | Yes (v3+) | Yes (v3+) | Yes | W3C suite | No | No |
-| **Sismic** | ~163 | 1.6.11 — Oct 2025 | Yes (UML2) | Yes | Yes | Full 1.0 | No | No |
-| **Automat** | ~647 | 25.4.16 — Apr 2025 | No | No | No | No | No | No |
-| **xstate-statemachine** *(basiltt)* | ~14 | 0.5.0 — Mar 2026 | Yes | Yes | Yes | Partial | Yes | Partial |
-| **xstate-python** *(this)* | ~194 | WIP — not on PyPI | Yes | Yes | **No** | Partial | **Yes** | **Yes** |
-
-**Key competitive observations:**
-
-- `transitions` dominates on adoption but has no SCXML, no XState JSON, no actor model. It is the
-  "easy FSM" option; we are not competing for that segment.
-- `python-statemachine` is the strongest technical competitor: W3C SCXML test suite, async,
-  invoked services, Django integration, excellent docs. The critical gap: **no XState JSON
-  compatibility**.
-- `Sismic` targets formal verification (Design by Contract). Niche audience; not a threat.
-- `xstate-statemachine` (basiltt) is the closest rival on our niche. 14 stars, minimal docs,
-  no full actor model. We are ahead on every technical dimension.
-- We are the **only** Python library combining SCXML algorithm + XState JSON + full actor model.
-
----
-
-## 3. XState v5 API — What We Track
-
-XState v5 is a significant redesign. Here is the full API mapping relevant to xstate-python.
-
-### Core API renames (v4 → v5)
-
-| v4 | v5 | Status in xstate-python |
-|---|---|---|
-| `Machine(config)` | `createMachine(config)` | `Machine()` retained; `createMachine` alias pending |
-| `interpret(machine)` | `createActor(machine)` | Both exist (`interpret` + `create_actor`) ✓ |
-| `machine.withConfig(impl)` | `machine.provide(impl)` | Not implemented |
-| `machine.withContext(ctx)` | `createActor(m, { input })` | `Machine(config, context=...)` partial |
-| `service.state` | `actor.getSnapshot()` | `interpreter.state` + `actor.get_snapshot()` ✓ |
-| `service.onTransition(fn)` | `actor.subscribe(fn)` | Both work ✓ |
-| `state.done` (bool) | `snapshot.status === 'done'` | `state.status == "done"` ✓ |
-| `State` class | `MachineSnapshot` object | `MachineSnapshot = State` alias ✓ |
-| `cond:` | `guard:` | Both accepted ✓ |
-| `data:` (final output) | `output:` | Both accepted ✓ |
-| `on: { '': ... }` | `always:` | Both accepted ✓ |
-| `services:` (in config) | `actors:` | `invoke: { src: name }` + registry ✓ |
-| `(context, event) =>` | `({ context, event }) =>` | Positional; single-object form planned |
-| `pure()` / `choose()` | `enqueueActions()` | Not implemented |
-| `spawn()` | `spawnChild()` action | `actor.spawn(logic)` ✓ |
-| `stop()` action | `stopChild()` | `actor.stop()` ✓ |
-| `send()` action | `sendTo()` / `raise()` | Both `send`, `send_to`, `raise_` ✓ |
-| `EmittedFrom<T>` | `SnapshotFrom<T>` | Python: no generics yet |
-| `schema:` | `types:` | Not implemented (Python doesn't need it) |
-| `external: false` | `reenter: true` | Not implemented |
-
-### v5 features not in v4 (and their status here)
-
-| v5 Feature | Released | Status in xstate-python |
-|---|---|---|
-| `setup()` API — typed factory | v5.0.0 | **Not implemented** |
-| Actor system (`system.get(id)`) | v5.0.0 | `ActorSystem` exists; `system.get()` not exposed ✓ partial |
-| `input` — typed actor initialization | v5.0.0 | `invoke.input` works; `createActor(m, input=...)` partial |
-| `toPromise(actor)` | v5.2.0 | Not implemented |
-| `assertEvent(event, type)` | v5.3.0 | Not implemented |
-| `getNextSnapshot()` | v5.5.0 | Not implemented |
-| `emit()` action creator | v5.9.0 | Not implemented |
-| Actor logic inspection events | v5.7.0 | Not implemented |
-| Graph/test utilities (from `@xstate/graph`) | v5.20.0 | Not implemented |
-| `setup.extend()` | v5.24.0 | Not implemented |
-| `system.getAll()` | v5.23.0 | Not implemented |
-| `transition()` / `initialTransition()` pure fns | v5.19.0 | Not implemented |
-| Routable states (`route: {}`) | v5.28.0 | Not implemented |
-| `actor.select(selector)` | v5.29.0 | Not implemented |
-| `mapState(snapshot, mapper)` | v5.31.0 | Not implemented |
-| Higher-order guards (`and()`, `or()`, `not()`) | v5.0.0 | Not implemented |
-| `snapshot.children` (live actor refs) | v5.0.0 | Not implemented |
-| `fromObservable` actor logic | v5.0.0 | Not implemented |
-| `fromTransition` actor logic | v5.0.0 | Not implemented |
-| `@statelyai/inspect` protocol | Jan 2024 | Not implemented |
-| `params` in actions/guards | v5.9.0 | Not implemented |
-| `AbortSignal` in `fromPromise` | v5.13.0 | Not implemented |
-| `maxIterations` guard (infinite loop prevention) | v5.31.0 | Not implemented |
-
----
-
-## 4. xstate-python: Current State (post 0.5.0 / post best-practices fix)
-
-### What works today
-
-| Capability | Notes |
+| Area | Status |
 |---|---|
-| Hierarchical (compound) states | Full |
-| Parallel states | Full — broadcast, nested, `onDone` when all regions done |
-| Guards (callable or named string) | Arity-aware: `()`, `(ctx)`, `(ctx, event)` |
-| Entry / exit actions | Full |
-| Context + `assign` | Named assigns run in declared order (build_action fix); deep-copy isolation |
-| Final states + `onDone` | Full — `output` / `data` both accepted |
-| `always:` / eventless transitions | Full — `on: {'': ...}` also accepted |
-| History states | Shallow and deep |
-| Delayed transitions (`after`) | `SimulatedClock` + `ThreadClock`; named delay refs |
-| Synchronous `Interpreter` | Run-to-completion queue; `subscribe()`; `send()`; `start()`/`stop()` |
-| `create_actor` / `ActorSystem` | v5 actor model — spawn, parent/child, `send_parent`, `send_to` |
-| `invoke:` | Child actor for state lifetime; `onDone` / `onError` |
-| `from_promise` / `from_callback` | Actor logic kinds |
-| `MachineSnapshot` | v5 alias for `State`; `status` / `output` / `error` fields |
-| XState v5 config keys | `guard`, `output`, `always`, `actors`; both `cond`/`guard` and `data`/`output` accepted |
-| Named action ordering | `build_action` resolves at construction; `assign`/`raise_`/`send` in registry run in declared position |
-| SCXML XML import | Optional extra (`pip install xstate[scxml]`) |
-| `__all__` / clean public API | 18 exported names |
+| Packaging | Project metadata is modernized for Python 3.13+, PyPI release still pending |
+| Core transition API | `Machine(config).transition(state, event)` |
+| XState JSON | Native Python dict / JSON-compatible config boundary |
+| Parser architecture | Typed schema + normalization/parser layer |
+| Handler adaptation | Build-time `HandlerAdapter`; legacy signatures still supported |
+| Setup API | `setup(...).create_machine(...)` exists for stricter named implementations |
+| Context policy | Default deep-copy adapter plus immutable dataclass adapter |
+| Snapshots | `MachineSnapshot = State`; immutable public containers |
+| Sync runtime | `Interpreter` with RTC queue, subscriptions, delayed transitions, and lock-serialized timer sends |
+| Async runtime | `AsyncInterpreter` with async start/send/stop, awaitable actions, and event-loop timers |
+| Actor model | `create_actor`, `ActorSystem`, spawn, parent/child tree, `send_parent`, `send_to` |
+| Actor logic | `from_promise`, `from_callback`, `from_observable`, `to_promise` |
+| Invoke | Child actor lifetime reconciliation with `done.invoke.*` and `error.platform.*` events |
+| SCXML XML import | Present; safe Boolean cond subset; known `more-parallel` failures remain |
 
-### Test coverage
+## What Works Today
 
-- **206 tests** passing (as of last push to master)
-- `tests/test_best_practices.py` — 12 regression tests for the architectural fixes
-- `tests/test_v5_config.py` — v5 config key compatibility
-- `tests/test_actor_logic.py` — `from_promise`, `from_callback`, `create_actor`
-- `docs/examples/` — 2 complex runnable examples (traffic intersection, fetch with retry)
+- Hierarchical, parallel, final, and history states.
+- Entry/exit/transition actions and `assign`.
+- Guards via `guard` or legacy `cond`.
+- Eventless transitions via `always` or legacy empty-event syntax.
+- Delayed transitions via `after`, numeric or named delays.
+- Machine snapshots with `status`, `output`, `error`, `matches(...)`, and
+  `can(event)`.
+- XState v5 naming alignment: `guard`, `output`, `always`, `actors`,
+  `MachineSnapshot`, `create_actor`, and `setup`.
+- Primary suite result: `284 passed`.
+- SCXML `cond-js` subset result: `4 passed`.
+- Full SCXML result: `45 passed`, `8 failed` in known `more-parallel` cases.
 
----
+## Competitive Position
 
-## 5. Gap Analysis
-
-### Priority gaps (what blocks adoption)
-
-| Gap | Severity | Effort | Target |
-|---|---|---|---|
-| **Not on PyPI** | Blocking — zero installs | Low | Immediate |
-| **No async interpreter** | Blocks all async Python (FastAPI, Django async, Celery) | High | 0.6.0 |
-| **SCXML test suite not run** — pass rate unknown | Credibility gap vs `python-statemachine` | Medium | 0.6.0 |
-| **Docs too thin** — one README, minimal API docs | Adoption friction | Medium | Continuous |
-
-### API parity gaps (what limits power users)
-
-| Gap | Effort | Target |
+| Library | Main strength | Why xstate-python is different |
 |---|---|---|
-| `setup()` API + typed factory | High | 0.7.0 |
-| `snapshot.children` (live actor refs in snapshot) | Medium | 0.6.0 |
-| `enqueueActions()` (replace `pure`/`choose`) | Medium | 0.6.0 |
-| `higher-order guards` (`and_`, `or_`, `not_`) | Low | 0.6.0 |
-| `fromObservable` / `fromTransition` actor logic | Medium | 0.6.0 |
-| `machine.provide()` alias | Low | 0.7.0 |
-| Single-object handler sig `({context, event})` | Medium | 0.7.0 |
-| `assertEvent()` / `getNextSnapshot()` utilities | Low | 0.7.0 |
-| `toPromise(actor)` | Low | 0.7.0 |
-| Pure-Python SCXML condition evaluator | High | 0.6.0 |
-| `@statelyai/inspect` protocol compatibility | Medium | 0.8.0 |
-| `actor.select(selector)` | Low | 0.8.0 |
-| Graph traversal / test model utilities | Medium | 0.8.0 |
-| Type stubs (`.pyi`) and generics | High | 0.8.0 |
+| `transitions` | Popular, flexible FSMs | Does not consume XState JSON or model XState actors |
+| `python-statemachine` | Strong docs and SCXML credibility | Does not target Stately/XState JSON compatibility |
+| `Sismic` | Formal statecharts and contracts | Different audience; no XState JSON bridge |
+| `xstate-statemachine` | Closest XState JSON niche | Smaller surface; weaker actor/setup/runtime parity |
 
----
+The strongest adoption story is a team already using XState or Stately in
+JavaScript and wanting the same machine shape in Python services.
 
-## 6. Strategic Position
+## Roadmap
 
-### The bet
-
-XState's visual editor (Stately Studio) exports JSON that neither `transitions` nor
-`python-statemachine` can consume. Every team that:
-
-- Designs machines in Stately Studio and needs a Python backend
-- Shares statechart config across a JS frontend and Python service
-- Adopts XState v5 and needs Python parity (actor model, `invoke`, `from_promise`)
-- Migrates from an XState JS codebase to Python microservices
-
-…has no maintained option other than `xstate-statemachine` (14 stars, minimal docs).
-We are the answer.
-
-### How we win
-
-1. **First-class XState JSON** is already implemented. The registries
-   (`actions=`, `guards=`, `delays=`, `actors=`) map named strings to Python callables;
-   the config is pure data. This architecture is right. It needs PyPI and better docs.
-
-2. **v5 actor model parity** is already substantial: `create_actor`, `from_promise`,
-   `from_callback`, `invoke`, `send_parent`, `send_to`. No Python competitor offers this.
-
-3. **SCXML algorithm correctness** — `algorithm.py` implements the W3C algorithm. We need
-   to run the SCXML test framework and publish the pass rate. This is the credibility moat.
-
-4. **Stately ecosystem integration** — as Stately Studio grows (Pro plan $39/mo, GitHub Sync,
-   React UI generation), the demand for "and the same machine in Python" grows with it.
-
-### Where `python-statemachine` beats us (honest assessment)
-
-- Async support (we are blocking all asyncio use cases)
-- Django integration (native `StateMachineField`)
-- Documentation quality and tutorial depth
-- W3C SCXML test suite pass rate (published)
-- Stable PyPI releases (13 releases vs. our 0)
-
-These are fixable. Priority order: **PyPI → async → SCXML test suite → docs**.
-
----
-
-## 7. Roadmap
-
-### Immediate — 0.1.0 (this week)
-
-The code is ready. The only blocker is packaging.
-
-- [ ] Tag `v0.1.0` on master; configure `pyproject.toml` (classifiers, keywords, project URLs)
-- [ ] `pip install xstate` must work
-- [ ] Verify CI uploads to PyPI on tag
-- [ ] Set GitHub repo description
-- [ ] Add "Install in 10 seconds" badge to README top
-
-### 0.2.0 — Credibility (1–2 months)
-
-- [ ] Run SCXML W3C test suite; fix failures; publish pass rate in README
-- [ ] Pure-Python SCXML condition evaluator (replace JS eval in `scxml.py`)
-- [ ] `snapshot.children` — live `ActorRef` dict on `MachineSnapshot`
-- [ ] Higher-order guards: `and_()`, `or_()`, `not_()` (matching `and()`, `or()`, `not()` in v5)
-- [ ] `enqueueActions()` equivalent
-- [ ] Mermaid diagram export (`machine.to_mermaid()`)
-- [ ] Per-concept API docs (one page per concept, mirroring stately.ai/docs structure)
-
-### 0.3.0 — Async (2–4 months)
-
-- [ ] `AsyncInterpreter` — `asyncio`-based event loop, non-blocking `send()`
-- [ ] `from_promise` with true deferred resolution (currently synchronous eagerly resolving)
-- [ ] `from_observable` actor logic (async generator / `asyncio.Queue`)
-- [ ] `cancel()` for async delayed transitions via `asyncio.create_task`
-- [ ] FastAPI integration example; Celery task state example
-
-### 0.4.0 — Setup API and utilities (4–6 months)
-
-- [ ] `setup(types=..., guards=..., actions=..., actors=...)` → `create_machine(config)`
-- [ ] Single-object handler signature: `guard({"context": c, "event": e})`
-- [ ] `machine.provide(implementations)` — runtime implementation injection
-- [ ] `assert_event(event, type)` utility
-- [ ] `get_next_snapshot(logic, snapshot, event)` pure function
-- [ ] `to_promise(actor)` — converts actor to `asyncio.Future`
-- [ ] `params` support in actions and guards (decouple logic from config)
-
-### 0.5.0 — Integrations (6–9 months)
-
-- [ ] Django: `StateMachineField`, model mixin, admin panel state display
-- [ ] `@statelyai/inspect` WebSocket protocol — connect xstate-python actors to Stately Inspector
-- [ ] Stately Studio export round-trip validation (CI check)
-- [ ] Persistence helpers: serialize/deserialize `MachineSnapshot` to JSON / Redis
-- [ ] Type stubs (`.pyi`) for the full public API
-
-### 0.6.0+ — Parity and Polish
-
-- [ ] Full Python generics: `Machine[TContext, TEvent, TOutput]`
-- [ ] Graph traversal utilities (`get_shortest_paths`, `create_test_model`)
-- [ ] `actor.select(selector)` — derived observable slices
-- [ ] Routable states
-- [ ] `setup.extend()` — composable machine configuration
-
----
-
-## 8. What "Next" Means Right Now
-
-The single most important next action: **ship to PyPI**. Everything below is moot without it.
-
-Recommended sequence:
-
-1. **Tag v0.1.0 → PyPI** — 1 day
-2. **SCXML test suite** — run it, report pass rate, fix top failures — 1 week
-3. **Async interpreter** — unblocks the largest class of Python backend use cases — 2–3 weeks
-4. **Docs** — bring up to python-statemachine quality — ongoing
-
-The async gap is the biggest capability hole. Python web backends (FastAPI, Django async) run
-on an event loop; a synchronous-only interpreter is a non-starter for them. Shipping `AsyncInterpreter`
-before anything else in 0.3.0 is the right call.
-
----
-
-## 9. Success Metrics
-
-| Metric | Today | 3-month target | 6-month target |
-|---|---|---|---|
-| PyPI install count | 0 (not published) | Live | 500+ weekly installs |
-| GitHub stars | ~194 | 300+ | 600+ |
-| SCXML W3C test pass rate | Unknown | >70% | >90% |
-| Test coverage | 206 tests | 250+ | 350+ |
-| Docs pages | 1 README + 2 examples | 8 concept docs | 15+ concept docs |
-| Open issues resolved/month | 0 | 3+ | 8+ |
-| Projects citing us as XState JSON alt | 0 | 2+ | 5+ |
-
----
-
-## 10. Reference: XState v5 Full Feature List (for tracking)
-
-*Track each against xstate-python status. Update as features are implemented.*
-
-### Implemented (✓) / Not yet (✗) / Partial (◐)
-
-| XState v5 Feature | xstate-python |
+| Priority | Work |
 |---|---|
-| `createMachine()` / `Machine()` | ◐ `Machine()` only |
-| `createActor()` / `interpret()` | ✓ both |
-| `setup()` typed factory | ✗ |
-| `input` — typed actor initialization | ◐ `invoke.input` only |
-| `output` — typed final state result | ✓ |
-| Actor system (`system.get(id)`) | ◐ `ActorSystem` exists; `get()` internal |
-| `systemId` registration | ✗ |
-| `invoke:` child actors | ✓ |
-| `from_promise` | ✓ (synchronous only) |
-| `from_callback` | ✓ |
-| `from_observable` / `from_transition` | ✗ |
-| `spawnChild()` / `spawn()` action | ✓ `actor.spawn()` |
-| `stopChild()` action | ✓ `actor.stop()` |
-| `sendTo()` action | ✓ `send_to()` |
-| `raise()` action | ✓ `raise_()` |
-| `send_parent()` action | ✓ |
-| `cancel()` action | ✓ |
-| `assign()` action | ✓ |
-| `log()` action | ✗ |
-| `enqueueActions()` | ✗ |
-| `emit()` action | ✗ |
-| Higher-order guards (`and`, `or`, `not`) | ✗ |
-| `params` in actions/guards | ✗ |
-| `guard:` (renamed from `cond`) | ✓ both accepted |
-| `always:` (renamed from `on: {'': ...}`) | ✓ both accepted |
-| `reenter:` (renamed from `internal: false`) | ✗ |
-| `machine.provide()` | ✗ (`Machine(config, actions=...)` covers most cases) |
-| `actor.getSnapshot()` | ✓ `actor.get_snapshot()` |
-| `actor.subscribe()` | ✓ |
-| `actor.select(selector)` | ✗ |
-| `snapshot.status` | ✓ |
-| `snapshot.output` | ✓ |
-| `snapshot.error` | ✓ |
-| `snapshot.children` | ✗ |
-| `toPromise(actor)` | ✗ |
-| `waitFor(actor, predicate)` | ✗ |
-| `assertEvent(event, type)` | ✗ |
-| `getNextSnapshot()` | ✗ |
-| `transition()` / `initialTransition()` pure fns | ✗ |
-| `mapState(snapshot, mapper)` | ✗ |
-| `getNextTransitions(state)` | ✗ |
-| Graph utilities (`getShortestPaths`, `createTestModel`) | ✗ |
-| Inspection (`createActor(m, { inspect })`) | ✗ |
-| `@statelyai/inspect` protocol | ✗ |
-| `MachineSnapshot` type | ✓ alias for `State` |
-| `SnapshotFrom<T>` TypeScript helper | ✗ (no Python generic yet) |
-| `maxIterations` option | ✗ |
-| Routable states | ✗ |
-| `setup.extend()` | ✗ |
-| `system.getAll()` | ✗ |
-| `machine.provide()` | ✗ |
-| SCXML XML import | ✓ (optional extra) |
-| Async interpreter | ✗ |
+| High | Publish to PyPI as `xstate` |
+| High | Document the public API by concept: machines, guards/actions, context, interpreter, actors, async, SCXML |
+| High | Fix the remaining SCXML `more-parallel` conformance cases |
+| Medium | Snapshot persistence and restore helpers |
+| Medium | Inspector protocol compatibility |
+| Medium | More XState v5 utilities: composable guards, `provide`, graph/test helpers |
+| Low | Django/FastAPI examples after the runtime API settles |
 
----
+## Success Metrics
 
-*Document maintained in `docs/PRODUCT.md`. Update after each milestone.*
-*Research sources: stately.ai/docs, github.com/statelyai/xstate/blob/main/packages/core/CHANGELOG.md,*
-*npmjs.com/package/xstate, snyk.io/advisor/npm-package/xstate, PyPI, each library's GitHub.*
+| Metric | Near-term target |
+|---|---|
+| PyPI release | `pip install xstate` works |
+| Primary test count | 300+ focused tests |
+| SCXML pass rate | Resolve known `more-parallel` group |
+| Docs | README plus concept docs for the main public APIs |
+| Examples | JSON, sync, async, actor, and integration examples |
+
+## Maintenance Notes
+
+- Do not add a JavaScript evaluator dependency. Unsupported SCXML
+  JavaScript/datamodel expressions should fail clearly instead of executing
+  arbitrary JavaScript.
+- Algorithm changes require SCXML verification.
+- Keep `Machine(config, actions=..., guards=..., delays=..., actors=...)`
+  compatible; it is the JSON boundary that makes the project valuable.
+- Prefer current XState v5 terminology in docs (`guard`, `output`, `always`) and
+  mention legacy aliases only as compatibility notes.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,72 +1,79 @@
 # Python State Machine Library Comparison
 
-Research snapshot: June 2026. Competitor figures sourced from PyPI, GitHub, and each library's
-documentation. The xstate-python column reflects the current state of this repo (0.3.x / 0.5.0
-actor branch), not the dormant upstream.
+Research snapshot: June 2026. Competitor figures are intentionally approximate;
+the xstate-python column reflects the current stacked branch state after the
+typed-core and Python 3.13 runtime-safety work.
 
 ## Feature Matrix
 
-| Feature | **transitions** | **python-statemachine** | **xstate-python** *(this project)* | **xstate-statemachine** *(basiltt)* | **Sismic** | **Automat** |
+| Feature | **transitions** | **python-statemachine** | **xstate-python** | **xstate-statemachine** | **Sismic** | **Automat** |
 |---|---|---|---|---|---|---|
-| **Stars / Status** | ~6,500 / Active | ~1,200 / Active | ~194 / Active (fork) | ~14 / Active | ~163 / Active | ~647 / Active |
-| **Latest release** | 0.9.3 (Jul 2025) | 3.1.2 (May 2026) | WIP (no PyPI release yet) | 0.5.0 (Mar 2026) | 1.6.11 (Oct 2025) | 25.4.16 (Apr 2025) |
-| **Python support** | 2.7, 3.8–3.13 | >=3.9 | 3.9–3.13 | >=3.9 | >=3.9 | >=3.9 |
-| **Hierarchical states** | Yes (ext) | Yes (v3.0+) | Yes | Yes | Yes (full UML2) | No |
-| **Parallel states** | Yes (ext) | Yes (v3.0+) | Yes (full — broadcast, nested, onDone) | Yes | Yes | No |
-| **Guards / Conditions** | Yes | Yes | Yes (callable or named, arity-aware) | Yes | Yes | No |
-| **Entry/Exit actions** | Yes | Yes | Yes | Yes | Yes | No |
-| **History states** | Yes (ext) | Yes (v3.0+) | Yes (shallow + deep) | Yes | Yes (shallow+deep) | No |
-| **Delayed transitions** | Yes (thread-based) | Yes (v3.0+) | Yes (`after` — SimulatedClock / ThreadClock) | Yes | Yes | No |
-| **Event queue** | Yes (queued mode) | Yes (v3.0+) | Yes (RTC queue in Interpreter) | Yes | Yes | No |
-| **Async support** | Yes (AsyncMachine) | Yes (auto-detect) | Planned (0.5.0 target) | Yes | Yes | No |
-| **SCXML compliance** | No | Yes (W3C test suite) | Partial (XML import; JS cond eval via optional extra) | Partial (XState JSON) | Yes (SCXML 1.0) | No |
-| **XState JSON format** | No | No | **Yes (native — the differentiator)** | Yes (Stately.ai export) | No | No |
-| **Eventless transitions** | No | Yes (v3.0+) | Yes (`always:`) | Yes | Yes | No |
-| **`invoke` / services** | No | Yes (v3.0+) | Yes (`invoke:` + `from_promise`/`from_callback` — 0.5.0) | Yes | No | No |
-| **Actor model** | No | No | Yes (`create_actor`, `ActorSystem`, `spawn`, `send_parent`/`send_to` — 0.5.0) | Partial | No | No |
-| **Context + assign** | No | Yes | Yes (`assign` action, deep-copy isolation) | Yes | Yes | No |
-| **Type safety** | Partial (.pyi stubs) | Partial | Partial (`from __future__ import annotations` throughout) | Yes (generics) | Partial | Yes (Protocol) |
-| **Visualization** | Graphviz, Mermaid | Graphviz, Mermaid | Basic (`viz.py`) | Mermaid, PlantUML | PlantUML | Graphviz |
-| **Testing utilities** | None dedicated | None dedicated | pytest suite (166 tests, SimulatedClock for deterministic timing) | Yes (snapshot) | Yes (BDD, DbC) | None dedicated |
-| **Design by Contract** | No | No | No | No | Yes | No |
-| **Docs quality** | Good | Excellent | Minimal | Good | Excellent | Good |
-| **License** | MIT | MIT | MIT | MIT | LGPL-3.0 | MIT |
+| Status | Mature / active | Mature / active | Alpha / active fork | Small active project | Mature niche | Mature focused FSM |
+| Python support | Broad legacy support | Modern Python | **3.13+** | Modern Python | Modern Python | Modern Python |
+| XState JSON | No | No | **Yes, native** | Yes | No | No |
+| SCXML algorithm | No | Yes | **Yes, partial conformance** | Partial | Yes | No |
+| Hierarchical states | Yes, extension | Yes | Yes | Yes | Yes | No |
+| Parallel states | Yes, extension | Yes | Yes, with known SCXML `more-parallel` gaps | Yes | Yes | No |
+| Guards/actions | Yes | Yes | Yes, named or inline | Yes | Yes | Limited |
+| Context/extended state | No native XState-style context | Yes | Yes, with `assign` and snapshot isolation | Yes | Yes | No |
+| Eventless transitions | No | Yes | Yes, `always` and legacy empty-event form | Yes | Yes | No |
+| Delayed transitions | Yes | Yes | Yes, `after` with pluggable clocks | Yes | Yes | No |
+| Sync runtime | Yes | Yes | Yes, RTC `Interpreter` | Yes | Yes | Yes |
+| Async runtime | Yes | Yes | Yes, `AsyncInterpreter` | Yes | Yes | No |
+| Actor model | No | No | Yes, XState v5-style actors | Partial | No | No |
+| Invoke/services | No | Yes | Yes, `invoke` + promise/callback/observable actors | Yes | No | No |
+| Setup-style named implementations | No | No | Yes, `setup(...).create_machine(...)` | Partial | No | No |
+| Runtime dependencies | Varies | Varies | **None for core** | Varies | Varies | Small |
+| Docs quality | Good | Excellent | Improving | Good | Excellent | Good |
+| License | MIT | MIT | MIT | MIT | LGPL-3.0 | MIT |
 
-## Where xstate-python Stands Today
+## Where xstate-python Fits
 
-**Implemented (0.3.x / 0.5.0-actor branch):**
+`xstate-python` is not trying to be the broadest Python FSM library. Its
+differentiator is the combination of:
 
-- Hierarchical (compound) states, parallel states (broadcast events, nested parallel, `onDone`)
-- Entry/exit actions, guards (callable or named string, arity-aware `(context, event)`)
-- Context + `assign` actions with deep-copy isolation between snapshots
-- Final states + `onDone` transitions; `always:` (eventless) transitions
-- History states — shallow and deep
-- Synchronous `Interpreter` with run-to-completion event queue, `subscribe()` listeners
-- Delayed transitions (`after`) driven by pluggable `Clock` — `SimulatedClock` (deterministic) or `ThreadClock` (real time)
-- Actor model (0.5.0): `create_actor`, `Actor`, `ActorSystem`, `spawn`, parent/child tree
-- `invoke:` wiring — a child actor runs for a state's lifetime, with `onDone`/`onError`
-- Actor logic kinds: `from_promise` / `from_callback`
-- Inter-actor messaging: `send_parent` / `send_to`
-- XState v5 config alignment: `guard`, `output`, `always`, `MachineSnapshot`, single-object handler signatures (0.4.0)
-- SCXML XML import (requires `pip install xstate[scxml]` — JS cond eval no longer a hard dep)
+- Native XState/Stately JSON compatibility.
+- SCXML-style run-to-completion semantics.
+- XState v5 concepts such as actors, `invoke`, `setup`, `MachineSnapshot`,
+  `guard`, `output`, and `always`.
 
-**Still to implement:**
+That makes it a good fit when a Python service needs to share statechart
+structure with a JavaScript/XState frontend or a Stately-authored design.
 
-| Priority | Gap |
+## Current xstate-python Capabilities
+
+- Hierarchical and parallel states.
+- Entry, exit, transition, assign, raise, send, cancel, parent, and targeted
+  actor actions.
+- Guards as named implementations, inline callables, or strict `setup`
+  handlers.
+- Context updates through `assign`, with deep-copy default isolation and an
+  immutable dataclass adapter.
+- Eventless transitions, final states, `onDone`, shallow/deep history, and
+  delayed `after` transitions.
+- Synchronous `Interpreter` with a run-to-completion queue and thread-safe timer
+  callback serialization.
+- `AsyncInterpreter` for asyncio runtimes and awaitable action side effects.
+- Actor model with `create_actor`, `ActorSystem`, `spawn`, `from_promise`,
+  `from_callback`, `from_observable`, `to_promise`, `send_parent`, `send_to`,
+  and `invoke` reconciliation.
+- SCXML XML import with a safe Boolean cond subset: `true`, `false`, `!`, `&&`,
+  `||`, and parentheses.
+
+## Known Gaps
+
+| Gap | Notes |
 |---|---|
-| High | PyPI publish (no release yet) |
-| High | Async interpreter (`asyncio`-based) + true deferred promise resolution (0.5.0/0.6.0) |
-| Medium | Pure-Python SCXML condition evaluator (replace JS eval entirely) |
-| Low | `setup()` API + composable guards (0.6.0) |
-| Low | Visualization (Mermaid export) |
+| PyPI release | Packaging metadata is ready, but release is still pending. |
+| SCXML conformance | Current full SCXML run is `45 passed`, `8 failed`; remaining failures are the known `more-parallel` cases. |
+| Full ECMAScript cond support | Intentionally not implemented; unsupported SCXML expressions raise `InvalidConfigError`. |
+| Persistence | Snapshot serialization/deserialization helpers are not implemented yet. |
+| Graph/test utilities | No equivalent of XState graph traversal helpers yet. |
+| Inspector protocol | No `@statelyai/inspect` compatibility yet. |
 
 ## Strategic Position
 
-The differentiating niche is **native XState / Stately.ai JSON compatibility**. Neither `transitions`
-nor `python-statemachine` accepts XState JSON natively. Users who design machines in the
-[Stately.ai editor](https://stately.ai/editor) or share config across JS and Python codebases
-have no other well-maintained option.
-
-`python-statemachine` is the strongest competitor on raw features (SCXML compliance, async,
-invoked services). The path to differentiation is not feature parity — it is owning the
-XState JSON import/export pipeline and tracking XState v5's actor model in Python.
+`transitions` and `python-statemachine` are excellent general-purpose Python
+libraries. `xstate-python` earns its place when XState JSON compatibility is the
+requirement: Stately designs, shared frontend/backend machine configs, and
+XState v5 actor-style runtime patterns in Python.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,115 +1,77 @@
 # Examples
 
-Two runnable, verified showcases of xstate-python. Run them from the repo root:
+These examples are meant to be readable first and realistic second. Run them
+from the repository root with `PYTHONPATH=src`:
 
 ```bash
-PYTHONPATH=. python docs/examples/traffic_intersection.py
-PYTHONPATH=. python docs/examples/fetch_with_retry.py
+PYTHONPATH=src python3 docs/examples/traffic_intersection.py
+PYTHONPATH=src python3 docs/examples/fetch_with_retry.py
 ```
 
----
+## Traffic Intersection
 
-## 1. Traffic intersection — *a complex chart loaded from XState JSON*
+Files: [`traffic_intersection.json`](./traffic_intersection.json) and
+[`traffic_intersection.py`](./traffic_intersection.py)
 
-**Files:** [`traffic_intersection.json`](./traffic_intersection.json) · [`traffic_intersection.py`](./traffic_intersection.py)
-
-This is the headline example: a non-trivial statechart authored as **plain
-XState JSON** (the shape you'd export from the [Stately.ai editor](https://stately.ai/editor))
-and loaded with nothing more than `json.load`. The Python file supplies only the
-live parts — the named guards, actions, and delay durations — through the
-`guards=`, `actions=`, and `delays=` registries.
+This is the headline XState JSON example. The chart is stored as plain JSON,
+matching the shape exported by Stately/XState tooling. Python supplies only the
+live implementation details:
 
 ```python
 config = json.load(open("traffic_intersection.json"))
 machine = Machine(config, actions=ACTIONS, guards=GUARDS, delays=DELAYS)
 ```
 
-### What it models
+It models a road intersection with three parallel regions plus a global
+emergency override:
 
-A road intersection with three **parallel** regions that each run on their own
-clock, plus a global emergency override:
-
-```
+```text
 intersection
-├── operational  (parallel)
-│   ├── northSouth   green ──6s──▶ yellow ──2s──▶ red ──8s──▶ green
-│   ├── eastWest     red   ──8s──▶ green  ──6s──▶ yellow ──2s──▶ red
-│   └── pedestrian   dontWalk ──PED_REQUEST [crossingIsClear]──▶ walk ──5s──▶ flashing ──3s──▶ dontWalk
-│        on EMERGENCY ─────────────────────────────────────────────▶ emergency
-└── emergency   entry / allRed
-     on CLEAR ──────────────────────────────────────────────────────▶ operational
+├── operational (parallel)
+│   ├── northSouth: green -> yellow -> red
+│   ├── eastWest:   red -> green -> yellow
+│   └── pedestrian: dontWalk -> walk -> flashing
+└── emergency
 ```
 
-### Features demonstrated
+What to look for:
 
 | Feature | Where |
 |---|---|
-| **Parallel** regions | `operational` runs `northSouth`, `eastWest`, `pedestrian` at once |
-| **Nested compound** states | each region is its own `green/yellow/red` chart |
-| **Delayed transitions** with **named delays** | `"after": {"nsGreen": "yellow"}` → resolved from `delays={...}` |
-| **Guards** | `PED_REQUEST` only crosses when `crossingIsClear` |
-| **Entry actions** by name | `pedestrian.walk` entry → `startWalkSignal` |
-| **Global event override** | `EMERGENCY` on the parallel parent interrupts every region |
-| **`SimulatedClock`** | deterministic time — `clock.increment(ms)` fires due timers |
+| Parallel regions | `operational` activates traffic and pedestrian regions together |
+| Nested states | each region has its own local chart |
+| Named delays | JSON delay names resolve through `delays={...}` |
+| Guards | `PED_REQUEST` checks `crossingIsClear` |
+| Entry actions | `startWalkSignal` and `allRed` are supplied by name |
+| Deterministic time | `SimulatedClock.increment(ms)` fires due timers |
 
-### Sample output
+## Fetch With Retry
 
-```
-initial                  {'operational': {'eastWest': 'red', 'pedestrian': 'dontWalk', 'northSouth': 'green'}}
-after 6s (ns green->)    {'operational': {'eastWest': 'red', 'pedestrian': 'dontWalk', 'northSouth': 'yellow'}}
-after +2s (ns yellow->)  {'operational': {'eastWest': 'green', 'pedestrian': 'dontWalk', 'northSouth': 'red'}}
-   [action] WALK signal illuminated
-PED_REQUEST              {'operational': {'eastWest': 'green', 'pedestrian': 'walk', 'northSouth': 'red'}}
-after +5s (walk->flash)  {'operational': {'eastWest': 'green', 'pedestrian': 'flashing', 'northSouth': 'red'}}
-   [action] all signals -> RED (emergency)
-EMERGENCY                emergency
-CLEAR                    {'operational': {'eastWest': 'red', 'pedestrian': 'dontWalk', 'northSouth': 'green'}}
-```
+File: [`fetch_with_retry.py`](./fetch_with_retry.py)
 
----
+This example shows the actor model. A parent machine invokes a promise actor,
+records success or failure in context, and retries with a delayed transition.
 
-## 2. Fetch with retry — *the 0.5.0 actor model*
-
-**File:** [`fetch_with_retry.py`](./fetch_with_retry.py)
-
-A data-fetch machine that invokes a flaky service, retries with backoff, and
-succeeds on the third attempt. This one is written as a Python `dict` (not a
-JSON file) because it uses `invoke`, `context`, and `assign` — which carry live
-callables.
-
-```
-fetcher
-idle ──FETCH──▶ loading
-                  invoke: fetchUser (from_promise, input = {user_id})
-                    onDone  ─▶ success (assign data)
-                    onError ─▶ retrying (assign error, retries += 1)
-retrying ──always [exhausted]──▶ failure
-         ──after backoff [canRetry]──▶ loading
+```text
+idle --FETCH--> loading
+loading invokes fetchUser
+  onDone  -> success
+  onError -> retrying
+retrying --after backoff--> loading
+retrying --always [exhausted]--> failure
 ```
 
-### Features demonstrated
+What to look for:
 
 | Feature | Where |
 |---|---|
-| **`invoke:`** a child actor for a state's lifetime | `loading.invoke` |
-| **`from_promise`** actor logic | `actors={"fetchUser": from_promise(fetch_user)}` |
-| **`onDone` / `onError`** wiring | resolve → `done.invoke.<id>` / `error.platform.<id>` |
-| **`input` from context** | `"input": lambda ctx, ev: {"user_id": ctx["user_id"]}` |
-| **`context` + `assign`** | records `data`, `error`, and `retries` |
-| **Guards** | `canRetry` gates the backoff retry; `exhausted` ends in `failure` |
-| **Delayed retry (`after`)** | `backoff` delay between attempts |
+| `invoke` lifecycle | `loading.invoke` starts child logic while the state is active |
+| Promise actor | `from_promise(fetch_user)` |
+| Completion events | `onDone` / `onError` handle actor settlement |
+| Context updates | `assign` records data, errors, and retries |
+| Guards | `canRetry` and `exhausted` choose the retry path |
+| Delayed retry | `after: {"backoff": ...}` |
 
-### Sample output
-
-```
-initial                value='idle' retries=0
-   [fetch] attempt 1 for user 42
-FETCH (attempt 1)      value='retrying' retries=1
-   [fetch] attempt 2 for user 42
-after backoff #1       value='retrying' retries=2
-   [fetch] attempt 3 for user 42
-after backoff #2       value='success' retries=2
-
-final value : success
-loaded data : {'id': 42, 'name': 'Ada Lovelace'}
-```
+This example is intentionally a Python dict because it contains live callables
+for `input`, guards, actions, and the promise actor. Pure state structure can
+still live in JSON when those live pieces are referenced by name.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -18,7 +18,9 @@ matching the shape exported by Stately/XState tooling. Python supplies only the
 live implementation details:
 
 ```python
-config = json.load(open("traffic_intersection.json"))
+with open("traffic_intersection.json") as f:
+    config = json.load(f)
+
 machine = Machine(config, actions=ACTIONS, guards=GUARDS, delays=DELAYS)
 ```
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -18,7 +18,7 @@ matching the shape exported by Stately/XState tooling. Python supplies only the
 live implementation details:
 
 ```python
-with open("traffic_intersection.json") as f:
+with open("docs/examples/traffic_intersection.json") as f:
     config = json.load(f)
 
 machine = Machine(config, actions=ACTIONS, guards=GUARDS, delays=DELAYS)


### PR DESCRIPTION
## Summary

This stacked PR refreshes the public markdown docs for the current branch stack. It is based on `python313-runtime-safety`, which itself stacks on `architecture-refactor-typed-core`, so the docs can describe the typed parser/handler/context work and the Python 3.13 runtime-safety modernization accurately.

Stack order:

1. #11 `architecture-refactor-typed-core` -> `master`
2. #12 `python313-runtime-safety` -> `architecture-refactor-typed-core`
3. This PR `docs-current-state-refresh` -> `python313-runtime-safety`

## What Changed

- Reworked `README.md` as a new-user entrypoint with a shorter install/quickstart path, XState JSON positioning, sync runtime, async runtime, actors, `setup`, context/snapshot behavior, SCXML status, public API exports, and current development commands.
- Updated `CONTRIBUTING.md` with modern branch guidance, Python 3.13+ setup, current test/type/lint commands, SCXML testing notes, and stacked PR expectations.
- Refreshed `docs/comparison.md` to reflect the current local feature surface: Python 3.13+, async interpreter, actor/setup support, safe SCXML Boolean cond support, and known SCXML gaps.
- Rewrote `docs/PRODUCT.md` around the current product thesis and branch state, moving async/setup/from_observable/to_promise/SCXML Boolean cond support out of the future bucket.
- Simplified `docs/examples/README.md` for approachability and updated example commands.

## Review Follow-Up

- Updated the JSON import example in `docs/examples/README.md` to use a context manager and the repo-root path `docs/examples/traffic_intersection.json`.
- Updated README and CONTRIBUTING development commands to use `poetry run ...` so they work in the Poetry-managed environment created by `poetry install`.
- Pulled in the latest stacked fixes from PR #11 and PR #12 so this docs PR reflects the current branch state.

## Why

The public docs were behind the code and PR stack. They still referenced older Python support, optional JavaScript cond evaluation, older toolchain commands, planned async/setup work, and outdated test counts. That made the repo harder for a new user or reviewer to understand.

This PR keeps the docs focused on what the stacked branches actually provide now, while leaving agent-only markdown alone.

## Validation

- `rg "python3 -m pytest|python3 -m mypy|^ruff |PYTHONPATH=src python3 -m pytest tests/test_scxml|open\(\"traffic_intersection\.json\"" README.md CONTRIBUTING.md docs`
  - no matches.
- `PYTHONPATH=src python3 docs/examples/traffic_intersection.py`
  - passed and printed the expected traffic intersection trace.
- `PYTHONPATH=src python3 docs/examples/fetch_with_retry.py`
  - passed and printed the expected retry/success trace.
- `python3 -m pytest tests/test_modernization.py tests/test_architecture_refactor.py`
  - `17 passed`.
- `python3 -m pytest tests/ --ignore=tests/test_scxml.py`
  - `292 passed`, 3 existing warnings for intentionally unregistered fixture actions.
- `PYTHONPATH=src python3 -m pytest tests/test_scxml.py -k cond-js`
  - `4 passed`.
- `python3 -m mypy src/xstate/`
  - clean.
- `python3 -m ruff format --check src/ tests/`
  - clean.
- `python3 -m ruff check src/ tests/`
  - clean.

## Scope Notes

- Only public markdown files were changed by the docs commit.
- `CLAUDE.md` was intentionally left untouched.
- The untracked local `AGENTS.md` was intentionally not edited or staged.