### PR TITLE
Prepare 0.6.0 release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,31 +2,33 @@ name: Release
 on:
   release:
     types:
-      - created
+      - published
 
 jobs:
   publish:
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [3.7]
-        poetry-version: [1.1.6]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Run image
-        uses: abatilo/actions-poetry@v2.0.0
-        with:
-          poetry-version: ${{ matrix.poetry-version }}
-      - name: Publish
+          python-version: "3.13"
+      - name: Install Poetry
+        run: pip install "poetry>=2.0"
+      - name: Install dependencies
+        run: poetry install
+      - name: Check package metadata
+        run: poetry check --lock
+      - name: Run tests
+        run: poetry run pytest tests/ --ignore=tests/test_scxml.py
+      - name: Check formatting
+        run: poetry run ruff format --check src/ tests/
+      - name: Run lint
+        run: poetry run ruff check src/ tests/
+      - name: Run type checks
+        run: poetry run mypy src/xstate/
+      - name: Publish to PyPI
         env:
           PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: |
-          poetry config pypi-token.pypi $PYPI_TOKEN
-          poetry publish --build
+        run: poetry publish --build --username __token__ --password "$PYPI_TOKEN"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           python-version: "3.13"
       - name: Install Poetry
-        run: pip install "poetry>=2.0"
+        run: python -m pip install "poetry>=2.0,<3.0"
       - name: Install dependencies
         run: poetry install
       - name: Check package metadata
@@ -30,5 +30,5 @@ jobs:
         run: poetry run mypy src/xstate/
       - name: Publish to PyPI
         env:
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-        run: poetry publish --build --username __token__ --password "$PYPI_TOKEN"
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
+        run: poetry publish --build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented here.
+
+## 0.6.0 - 2026-06-28
+
+### Added
+
+- Added the `setup(...).create_machine(...)` builder for XState v5-style named
+  actions, guards, delays, and actors.
+- Added composable guard helpers: `and_`, `or_`, and `not_`.
+- Added snapshot serialization and restoration helpers:
+  `serialize_snapshot(...)` and `deserialize_snapshot(...)`.
+- Added observable actor helpers with `from_observable(...)` and
+  `to_promise(...)`.
+- Added public project context docs and refreshed user-facing documentation for
+  the current architecture and runtime behavior.
+
+### Changed
+
+- Made Python 3.13+ the supported release floor.
+- Modernized the release workflow for Poetry 2.x and current GitHub Actions.
+- Kept the core runtime dependency-free, including SCXML import and the safe
+  SCXML Boolean `cond` evaluator.
+- Improved sync interpreter runtime safety around delayed sends and timer-driven
+  callbacks.
+
+### Fixed
+
+- Replaced stale release metadata and outdated Python/Poetry workflow settings.
+- Aligned docs, packaging metadata, and CI expectations for the 0.6.0 release.

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/JovaniPink/xstate-python/actions"><img alt="Primary tests" src="https://img.shields.io/badge/primary%20tests-284%20passing-brightgreen"></a>
+  <a href="https://github.com/JovaniPink/xstate-python/actions/workflows/pull_request.yaml"><img alt="Tests and code quality" src="https://github.com/JovaniPink/xstate-python/actions/workflows/pull_request.yaml/badge.svg"></a>
   <img alt="Python" src="https://img.shields.io/badge/python-3.13%2B-blue">
-  <img alt="Status" src="https://img.shields.io/badge/status-alpha%20(0.5.0)-orange">
+  <img alt="Status" src="https://img.shields.io/badge/status-alpha%20(0.6.0)-orange">
   <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-green"></a>
 </p>
 
@@ -50,8 +50,8 @@ functions, delay values, and actor logic.
 
 ## Installation
 
-The package metadata is ready for `xstate`, but this branch is still pre-release.
-For now, install from source:
+The `0.6.0` package metadata is ready for release. Until the GitHub release
+publishes to PyPI, install from source:
 
 ```bash
 git clone https://github.com/JovaniPink/xstate-python.git
@@ -388,11 +388,11 @@ poetry run ruff check src/ tests/
 
 | Area | Current state |
 |---|---|
-| PyPI release | Packaging metadata is modernized; release still pending |
-| XState v5 setup | `setup(...).create_machine(...)` exists; composable guard helpers remain future work |
+| PyPI release | `0.6.0` release-readiness is complete; publish via GitHub Release |
+| XState v5 setup | `setup(...).create_machine(...)` and composable guards are present |
 | Async | `AsyncInterpreter`, async actors, `from_observable`, and `to_promise` are present |
 | SCXML | XML import works; safe Boolean cond subset works; `more-parallel` conformance remains open |
-| Persistence | Snapshot serialization is not implemented yet |
+| Persistence | Snapshot serialization and restore helpers are present |
 
 ## Related Projects
 

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -2,8 +2,7 @@
 
 Research snapshot: June 2026. External ecosystem numbers are approximate and
 should be refreshed before publication or fundraising use. Repo capability notes
-reflect the current stacked branch state after typed-core and Python 3.13
-runtime-safety work.
+reflect the current `master` branch after the 0.6.0 release-readiness work.
 
 ## Product Thesis
 
@@ -22,7 +21,7 @@ bridge between XState's JSON ecosystem and Python backends.
 
 | Area | Status |
 |---|---|
-| Packaging | Project metadata is modernized for Python 3.13+, PyPI release still pending |
+| Packaging | Project metadata is modernized for Python 3.13+ and ready for the 0.6.0 PyPI release |
 | Core transition API | `Machine(config).transition(state, event)` |
 | XState JSON | Native Python dict / JSON-compatible config boundary |
 | Parser architecture | Typed schema + normalization/parser layer |
@@ -46,9 +45,10 @@ bridge between XState's JSON ecosystem and Python backends.
 - Delayed transitions via `after`, numeric or named delays.
 - Machine snapshots with `status`, `output`, `error`, `matches(...)`, and
   `can(event)`.
+- Snapshot serialization and restoration helpers for actor persistence flows.
 - XState v5 naming alignment: `guard`, `output`, `always`, `actors`,
   `MachineSnapshot`, `create_actor`, and `setup`.
-- Primary suite result: `284 passed`.
+- Primary suite passes in current Python 3.13/3.14 CI.
 - SCXML `cond-js` subset result: `4 passed`.
 - Full SCXML result: `45 passed`, `8 failed` in known `more-parallel` cases.
 
@@ -68,10 +68,10 @@ JavaScript and wanting the same machine shape in Python services.
 
 | Priority | Work |
 |---|---|
-| High | Publish to PyPI as `xstate` |
+| High | Publish 0.6.0 to PyPI as `xstate` |
 | High | Document the public API by concept: machines, guards/actions, context, interpreter, actors, async, SCXML |
 | High | Fix the remaining SCXML `more-parallel` conformance cases |
-| Medium | Snapshot persistence and restore helpers |
+| Medium | Document snapshot persistence and restore helpers |
 | Medium | Inspector protocol compatibility |
 | Medium | More XState v5 utilities: composable guards, `provide`, graph/test helpers |
 | Low | Django/FastAPI examples after the runtime API settles |
@@ -80,8 +80,8 @@ JavaScript and wanting the same machine shape in Python services.
 
 | Metric | Near-term target |
 |---|---|
-| PyPI release | `pip install xstate` works |
-| Primary test count | 300+ focused tests |
+| PyPI release | `pip install xstate` works after the 0.6.0 GitHub Release |
+| Primary test count | Maintain 300+ focused tests |
 | SCXML pass rate | Resolve known `more-parallel` group |
 | Docs | README plus concept docs for the main public APIs |
 | Examples | JSON, sync, async, actor, and integration examples |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,14 +1,14 @@
 # Python State Machine Library Comparison
 
 Research snapshot: June 2026. Competitor figures are intentionally approximate;
-the xstate-python column reflects the current stacked branch state after the
-typed-core and Python 3.13 runtime-safety work.
+the xstate-python column reflects the current `master` branch after the 0.6.0
+release-readiness work.
 
 ## Feature Matrix
 
 | Feature | **transitions** | **python-statemachine** | **xstate-python** | **xstate-statemachine** | **Sismic** | **Automat** |
 |---|---|---|---|---|---|---|
-| Status | Mature / active | Mature / active | Alpha / active fork | Small active project | Mature niche | Mature focused FSM |
+| Status | Mature / active | Mature / active | Alpha / 0.6.0 release-ready | Small active project | Mature niche | Mature focused FSM |
 | Python support | Broad legacy support | Modern Python | **3.13+** | Modern Python | Modern Python | Modern Python |
 | XState JSON | No | No | **Yes, native** | Yes | No | No |
 | SCXML algorithm | No | Yes | **Yes, partial conformance** | Partial | Yes | No |
@@ -57,6 +57,7 @@ structure with a JavaScript/XState frontend or a Stately-authored design.
 - Actor model with `create_actor`, `ActorSystem`, `spawn`, `from_promise`,
   `from_callback`, `from_observable`, `to_promise`, `send_parent`, `send_to`,
   and `invoke` reconciliation.
+- Snapshot serialization and restoration helpers for persistence flows.
 - SCXML XML import with a safe Boolean cond subset: `true`, `false`, `!`, `&&`,
   `||`, and parentheses.
 
@@ -64,10 +65,9 @@ structure with a JavaScript/XState frontend or a Stately-authored design.
 
 | Gap | Notes |
 |---|---|
-| PyPI release | Packaging metadata is ready, but release is still pending. |
+| PyPI release | 0.6.0 packaging metadata and release workflow are ready; publish via GitHub Release. |
 | SCXML conformance | Current full SCXML run is `45 passed`, `8 failed`; remaining failures are the known `more-parallel` cases. |
 | Full ECMAScript cond support | Intentionally not implemented; unsupported SCXML expressions raise `InvalidConfigError`. |
-| Persistence | Snapshot serialization/deserialization helpers are not implemented yet. |
 | Graph/test utilities | No equivalent of XState graph traversal helpers yet. |
 | Inspector protocol | No `@statelyai/inspect` compatibility yet. |
 

--- a/docs/examples/fetch_with_retry.py
+++ b/docs/examples/fetch_with_retry.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""A data-fetch machine with retry/backoff — showcasing the 0.5.0 actor model.
+"""A data-fetch machine with retry/backoff — showcasing the actor runtime.
 
 Where ``traffic_intersection.py`` is a pure control-flow chart loaded from JSON,
 this example shows the pieces that need Python: **invoked actors**, **context**,

--- a/poetry.lock
+++ b/poetry.lock
@@ -424,7 +424,6 @@ files = [
 
 [package.dependencies]
 pytest = ">=8.4,<10"
-typing-extensions = {version = ">=4.12", markers = "python_version < \"3.13\""}
 
 [package.extras]
 docs = ["sphinx (>=5.3)", "sphinx-rtd-theme (>=1)", "sphinx-tabs (>=3.5)"]
@@ -494,5 +493,5 @@ scxml = []
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.11"
-content-hash = "e7092c6659068ff4692084a9380a057b037e5261949edfe7a98958d6467eafb8"
+python-versions = ">=3.13"
+content-hash = "97b01673ecda312018969255bcf6d529f50f5bf32cc37deaa1563ccd40e15318"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "xstate"
 version = "0.6.0"
 description = "Statecharts and state machines for Python, inspired by XState."
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.13"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [
@@ -25,9 +25,8 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = []
 
@@ -54,7 +53,7 @@ mypy = "^1.0"
 
 [tool.ruff]
 line-length = 88
-target-version = "py311"
+target-version = "py313"
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "A", "SIM", "C4"]
@@ -77,7 +76,7 @@ known-first-party = ["xstate"]
 
 [tool.mypy]
 mypy_path = "src"
-python_version = "3.11"
+python_version = "3.13"
 # Strict checks enforced on the public surface (event.py, state.py, machine.py,
 # exceptions.py). Internal algorithm/actor/interpreter complexity is covered
 # progressively via the per-module overrides below.

--- a/src/xstate/algorithm.py
+++ b/src/xstate/algorithm.py
@@ -818,9 +818,7 @@ def execute_content(
     elif action.type == CHOOSE_TYPE:
         guards_registry = action.data.get("_guards", {})
         for branch in action.data.get("branches", []):
-            if _eval_action_guard(
-                branch.get("guard"), context, event, guards_registry
-            ):
+            if _eval_action_guard(branch.get("guard"), context, event, guards_registry):
                 for sub in branch.get("actions", []):
                     context = execute_content(
                         sub, actions, internal_queue, context, event
@@ -834,9 +832,7 @@ def execute_content(
             specs = result if isinstance(result, list) else [result]
             for spec in specs:
                 sub = build_action(spec, registry)
-                context = execute_content(
-                    sub, actions, internal_queue, context, event
-                )
+                context = execute_content(sub, actions, internal_queue, context, event)
     else:
         actions.append(action)
     return context

--- a/src/xstate/guards.py
+++ b/src/xstate/guards.py
@@ -90,8 +90,7 @@ class _AndGuard(_ComposableGuard):
         self, context: Any, event: Any, registry: dict, configuration: Any = None
     ) -> bool:
         return all(
-            self._eval(g, context, event, registry, configuration)
-            for g in self._guards
+            self._eval(g, context, event, registry, configuration) for g in self._guards
         )
 
 
@@ -105,8 +104,7 @@ class _OrGuard(_ComposableGuard):
         self, context: Any, event: Any, registry: dict, configuration: Any = None
     ) -> bool:
         return any(
-            self._eval(g, context, event, registry, configuration)
-            for g in self._guards
+            self._eval(g, context, event, registry, configuration) for g in self._guards
         )
 
 

--- a/src/xstate/machine.py
+++ b/src/xstate/machine.py
@@ -142,7 +142,7 @@ class Machine:
                 result.append(
                     self._bind_action(
                         action,
-                        self.actions[action.type],  # type: ignore[index]
+                        self.actions[action.type],
                         context,
                         event,
                     )

--- a/src/xstate/scheduler.py
+++ b/src/xstate/scheduler.py
@@ -13,18 +13,9 @@ implementations are provided:
 from __future__ import annotations
 
 import abc
-import sys
 import threading
 from collections.abc import Callable
-from typing import Any
-
-if sys.version_info >= (3, 12):
-    from typing import override
-else:
-
-    def override(fn: Any) -> Any:  # noqa: D103
-        return fn
-
+from typing import Any, override
 
 __all__ = ["Clock", "SimulatedClock", "ThreadClock"]
 

--- a/src/xstate/state.py
+++ b/src/xstate/state.py
@@ -80,9 +80,7 @@ class State:
         current configuration; querying it is the idiomatic way to ask "is the
         machine loading / busy / editable" without enumerating state values.
         """
-        return frozenset(
-            tag for node in self.configuration for tag in node.tags
-        )
+        return frozenset(tag for node in self.configuration for tag in node.tags)
 
     def has_tag(self, tag: str) -> bool:
         """Return True if any active state node declares *tag* (v5 ``hasTag``)."""

--- a/tests/test_choose_pure.py
+++ b/tests/test_choose_pure.py
@@ -278,9 +278,7 @@ def test_choose_unknown_guard_raises():
                 "a": {
                     "on": {
                         "GO": {
-                            "actions": [
-                                choose([{"guard": "missing", "actions": []}])
-                            ]
+                            "actions": [choose([{"guard": "missing", "actions": []}])]
                         }
                     }
                 },

--- a/tests/test_modernization.py
+++ b/tests/test_modernization.py
@@ -1,18 +1,10 @@
 from __future__ import annotations
 
-import sys
 import threading
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from types import MappingProxyType
-
-if sys.version_info >= (3, 12):
-    from typing import override
-else:
-
-    def override(fn):  # type: ignore[misc]
-        return fn
-
+from typing import override
 
 import pytest
 

--- a/tests/test_state_in_guard.py
+++ b/tests/test_state_in_guard.py
@@ -5,7 +5,6 @@ in the given state. It reuses the same matching as a transition `in` guard and
 composes with and_/or_/not_.
 """
 
-
 from xstate import Machine, and_, create_actor, not_, or_, stateIn
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -44,9 +44,7 @@ def test_tags_as_single_string():
 
 
 def test_no_tags_is_empty_frozenset():
-    machine = Machine(
-        {"id": "m", "initial": "idle", "states": {"idle": {}}}
-    )
+    machine = Machine({"id": "m", "initial": "idle", "states": {"idle": {}}})
     assert machine.initial_state.tags == frozenset()
 
 


### PR DESCRIPTION
## Summary

Prepares the repository for the `v0.6.0` release.

- Makes Python 3.13+ the authoritative supported floor across packaging, Ruff, MyPy, docs, and lock metadata.
- Modernizes the release workflow to use current GitHub Actions, Poetry 2.x, validation before publish, and the existing `PYPI_TOKEN` path.
- Adds `CHANGELOG.md` with 0.6.0 release notes and refreshes public docs to remove stale 0.5.0/test-count/snapshot status claims.
- Removes obsolete `typing.override` compatibility shims now that the package floor is Python 3.13+.

## Release impact

- No runtime API changes.
- Packaging compatibility changes to Python 3.13+ only.
- Publishing still requires repository secret `PYPI_TOKEN`; Trusted Publishing remains a follow-up once configured on PyPI.

## Validation

- `python3 -m poetry lock`
- `python3 -m poetry install`
- `python3 -m poetry check --lock`
- `python3 -m poetry run pytest tests/ --ignore=tests/test_scxml.py` — 336 passed, 17 warnings
- `python3 -m poetry run ruff format --check src/ tests/`
- `python3 -m poetry run ruff check src/ tests/`
- `python3 -m poetry run mypy src/xstate/`
- `python3 -m poetry build --output /private/tmp/xstate-python-dist-0.6.0-final`

## After merge

Create the GitHub Release `v0.6.0` from `master` and confirm the release workflow publishes to PyPI.