### PR TITLE
Add XState query parity helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ run-to-completion execution core.
 - License: MIT
 - Python: 3.13+
 - Runtime dependencies: none
-- Current status: alpha, version `0.5.0`
+- Current status: alpha, version `0.6.0`
 
 The central bet is simple: charts designed in Stately or shared with a
 JavaScript frontend should load directly as Python `dict` / JSON data, with
@@ -67,6 +67,11 @@ Working:
   `from_callback`, `from_observable`, and `to_promise`.
 - XState v5 alignment: `guard`, `output`, `always`, `MachineSnapshot`,
   `state.matches(...)`, `state.can(...)`, and `setup(...).create_machine(...)`.
+- XState snapshot queries: `tags`, `meta`, `state.has_tag(...)`,
+  `state.hasTag(...)`, `state_in(...)`, and `stateIn(...)` are present on the
+  0.7.0 branch.
+- Dependency-free Mermaid diagram export via `to_mermaid(machine)` is present
+  on the 0.7.0 branch.
 - Handler adaptation through `HandlerArgs`, with legacy callable forms still
   supported at the public `Machine(config, ...)` boundary.
 - Public snapshot immutability: configuration is a `frozenset`, actions are a
@@ -77,8 +82,7 @@ Working:
 Known gaps:
 
 - Full SCXML conformance still has known `more-parallel` failures.
-- Persistence / snapshot serialization is not implemented.
-- Composable guard helpers beyond the current `setup(...)` API are future work.
+- Graph/test helper APIs beyond Mermaid export are future work.
 - SCXML condition support is intentionally not a general JavaScript evaluator.
 
 ## Important Constraints

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,27 +7,27 @@ hierarchical state machines for Python, following the W3C SCXML execution algori
 a **solid, published Python statechart library** that tracks XState v5's architecture and owns
 the niche of native XState JSON compatibility.
 
-**PyPI name:** `xstate` | **License:** MIT | **Python:** 3.9–3.13
+**PyPI name:** `xstate` | **License:** MIT | **Python:** 3.13+
 
 ---
 
 ## Architecture
 
 ```
-xstate/
+src/xstate/
   __init__.py       Public API: `from xstate import Machine`
-  machine.py        Machine class — entry point, orchestrates a statechart definition
-  state_node.py     StateNode — represents a single state in the hierarchy
-  state.py          State — current snapshot: {value, configuration, context, actions}
+  machine.py        Machine class — entry point and pure transition API
+  config_parser.py  Two-pass XState config parser and normalizer
+  schema.py         TypedDict boundary for raw XState config data
+  state_node.py     Resolved state hierarchy model
+  state.py          Public State / MachineSnapshot snapshots
   algorithm.py      SCXML execution engine (microstep/macrostep, entry/exit sets)
-  transition.py     Transition — event, guard, target, actions
-  action.py         Action — entry/exit/transition side effects
-  event.py          Event — typed event wrapper
-  interpreter.py    Interpreter — synchronous event loop + queue, subscriptions, `after` scheduling
-  async_interpreter.py  AsyncInterpreter — asyncio-native runtime (`async start/send/stop`, awaitable actions)
-  actor.py          Actor model — create_actor, ActorSystem, from_promise/from_callback, invoke reconciliation
-  scheduler.py      Clock abstractions (`SimulatedClock` for tests, `ThreadClock` for real time)
-  scxml.py          SCXML XML → Machine config converter (requires `scxml` extra for js conds)
+  transition.py     Resolved transition model
+  handlers.py       HandlerArgs and HandlerAdapter callable adaptation
+  guards.py         Composable guards and state_in/stateIn helpers
+  mermaid.py        Dependency-free Mermaid diagram export
+  actor.py          Actor model, create_actor, ActorSystem, actor logic helpers
+  scxml.py          SCXML XML → Machine config converter with safe Boolean conds
 ```
 
 `algorithm.py` is the heart of the library. It implements the W3C SCXML algorithm:
@@ -37,7 +37,7 @@ The critical execution order is: `main_event_loop` → `microstep` → `main_eve
 
 ---
 
-## Current state (0.5.0)
+## Current state (0.6.0 release-ready, 0.7.0 branch in progress)
 
 **Working:**
 - Hierarchical (compound) states
@@ -58,7 +58,8 @@ The critical execution order is: `main_event_loop` → `microstep` → `main_eve
   cancelled on exit; numeric delays or named refs via `Machine(config, delays={...})`.
   Driven by a pluggable `Clock`: `SimulatedClock` (deterministic, advance with
   `clock.increment(ms)`) or `ThreadClock` (real wall-clock, the default)
-- SCXML XML import (requires `pip install xstate[scxml]` for JS-cond evaluation)
+- SCXML XML import with a dependency-free safe Boolean cond subset
+  (`true`, `false`, `!`, `&&`, `||`, parentheses)
 - **XState v5 config alignment** (0.4.0):
   - `guard` is the canonical key for transition conditions; `cond` still works
     but emits a `DeprecationWarning`
@@ -92,12 +93,15 @@ The critical execution order is: `main_event_loop` → `microstep` → `main_eve
   `setup(guards=..., actions=..., delays=..., actors=...).create_machine(config)`
 - **Snapshot serialization** (0.6.0, `from xstate import serialize_snapshot, deserialize_snapshot`)
   — persist and restore State; `create_actor(machine, snapshot=...)` for round-trip replay
+- **Snapshot queries** (0.7.0 branch) — active `tags`, read-only `meta`,
+  `state.has_tag(...)`, `state.hasTag(...)`, and `state_in(...)` / `stateIn(...)`
+- **Mermaid export** (0.7.0 branch, `from xstate import to_mermaid`) —
+  dependency-free `stateDiagram-v2` text generation
 
-Handler-signature note: guards/assigners are invoked arity-aware by
-`algorithm._invoke`, which supports four calling conventions: `()`, `(context)`,
-`(context, event)` (the v4 positional styles), and keyword-only
-`(*, context, event)` (the v5 single-object style). `error` status plumbing is a
-placeholder until the actor model lands (0.5.0).
+Handler-signature note: public registries are adapted at machine construction by
+`HandlerAdapter`. Prefer `handler(HandlerArgs(...))`; legacy `()`, `(context)`,
+`(context, event)`, and keyword-only forms still work at the compatibility
+boundary.
 
 ---
 
@@ -111,7 +115,7 @@ placeholder until the actor model lands (0.5.0).
 | 0.4.0 | v5 config alignment | Rename `cond`→`guard`, `data`→`output`, `always:`, single-object handler signatures, MachineSnapshot |
 | 0.5.0 | Actor model | `create_actor`, actor system, `from_promise`/`from_callback`, asyncio |
 | 0.6.0 | Setup & parity | `setup()`, composable guards (`and_`/`or_`/`not_`), snapshot serialization |
-| 0.7.0 | Next parity | State `tags` + `hasTag()`, `choose`/`pure` actions, `stateIn` guard, Mermaid/Graphviz diagrams, TypedDict config schemas |
+| 0.7.0 | Next parity | State `tags` + `hasTag()`, `stateIn` guard, Mermaid diagrams; next: `choose`/`pure` actions, Graphviz diagrams, TypedDict config schemas |
 | 0.8.0+ | Internal refactor | `StateNodeConfigParser` factory, opt-in immutable `context_factory`, `ParamSpec` handler typing |
 
 The differentiating niche: **XState / Stately.ai JSON compatibility** — neither `transitions`
@@ -149,22 +153,20 @@ Targets drawn from XState v5 (https://stately.ai/docs/xstate) and the Python sta
 landscape (`transitions`, `python-statemachine`, `Sismic`). Ranked by parity value × differentiation.
 
 **XState v5 parity gaps:**
-- **State `tags`** — `tags: ["loading"]` in config; `state.hasTag("loading")` on `MachineSnapshot`. Cheap, high-use.
+- **State `tags`** — ✅ on 0.7.0 branch: `tags: ["loading"]` in config; `state.has_tag("loading")` and `state.hasTag("loading")` on `MachineSnapshot`.
 - **`choose` action** — conditional action selection (run the first branch whose guard passes).
 - **`pure` action** — a function returning a list of actions to run, with no side effects of its own.
-- **`stateIn` guard** — user-facing guard over the current configuration. We already have `in_state`
-  on transitions internally; expose it as a first-class guard (and as `stateIn(...)` alongside `and_`/`or_`/`not_`).
+- **`stateIn` guard** — ✅ on 0.7.0 branch: user-facing guard over the current configuration, exposed as `state_in(...)` and `stateIn(...)`.
 - **`enqueueActions`** — batch/queue actions imperatively inside an action body.
 - **Transition `reenter: true`** — re-enter the source state on a self-transition (vs. internal).
 - **`stopChild` action** — explicitly stop a spawned/invoked actor.
 - **Dynamic `sendTo` targets** — `to=` resolved from `(context, event)`.
-- **Machine / state `meta`** — per-node metadata surfaced via `state.meta` / `getMeta()`.
+- **Machine / state `meta`** — ✅ on 0.7.0 branch: per-node metadata surfaced via read-only `state.meta`.
 - **Partial event descriptors / wildcard** — `on: {"UPDATE.*": ...}` style matching.
 
 **Differentiators worth owning (gaps in the Python field):**
-- **Mermaid / Graphviz diagram export** — `transitions` has `GraphMachine`; we have none. High value
-  given native XState JSON in → diagram out.
-- **`hasTag` / `can` / `matches` snapshot ergonomics** — round out `MachineSnapshot` query methods.
+- **Mermaid / Graphviz diagram export** — Mermaid export is ✅ on 0.7.0 branch via `to_mermaid(machine)`; Graphviz remains deferred.
+- **`hasTag` / `can` / `matches` snapshot ergonomics** — `has_tag` / `hasTag`, `can`, and `matches` are present.
 - **Observer pattern** — `python-statemachine`'s `add_observer`; we have `subscribe`, consider a
   multi-callback observer protocol with entry/exit hooks.
 
@@ -202,12 +204,10 @@ ruff check src/ tests/
 
 ### Never reintroduce Js2Py as a hard dependency
 
-`Js2Py` cannot build on Python 3.11+ and is a security anti-pattern for a library.
-It has been moved to the optional `scxml` extra, lazy-imported inside `_eval_scxml_cond()`.
-**Do not `import js2py` at module level anywhere in `xstate/`.**
-
-The long-term plan (0.2.0) is to replace the remaining Js2Py usage in `scxml.py` with
-a pure-Python SCXML condition evaluator.
+`Js2Py` cannot build on modern Python and is a security anti-pattern for a
+library. The SCXML importer now uses a small pure-Python Boolean evaluator.
+**Do not reintroduce `js2py` or a general JavaScript evaluator anywhere in
+`xstate/`.**
 
 ### Algorithm changes require SCXML test verification
 

--- a/README.md
+++ b/README.md
@@ -298,9 +298,47 @@ containers are immutable at the boundary: `configuration` is a `frozenset`,
 `actions` is a `tuple`, and `history_value` is read-only. For immutable
 dataclass contexts, use `dataclass_context()` / `DataclassContextAdapter`.
 
+Snapshots also expose XState-style query data:
+
+```python
+state = machine.initial_state
+
+state.has_tag("loading")  # Pythonic
+state.hasTag("loading")   # XState-compatible alias
+state.tags                # frozenset of active state tags
+state.meta                # read-only mapping of active state ids to metadata
+```
+
+Use `state_in(...)` / `stateIn(...)` when a reusable guard should depend on the
+current active state configuration:
+
+```python
+from xstate import Machine, state_in
+
+machine = Machine(
+    {
+        "id": "workflow",
+        "initial": "editing",
+        "states": {
+            "editing": {"on": {"SUBMIT": "review"}},
+            "review": {
+                "on": {
+                    "APPROVE": {
+                        "target": "published",
+                        "guard": state_in("review"),
+                    }
+                }
+            },
+            "published": {"type": "final", "tags": ["done"]},
+        },
+    }
+)
+```
+
 ## Core Statechart Features
 
 - Hierarchical and parallel states
+- State tags, metadata, `matches(...)`, `can(...)`, and `has_tag(...)`
 - Entry, exit, and transition actions
 - Named and inline guards
 - Context and `assign`
@@ -310,6 +348,20 @@ dataclass contexts, use `dataclass_context()` / `DataclassContextAdapter`.
 - Delayed transitions via `after`
 - SCXML XML import
 - Actor invocation with `invoke`, `onDone`, and `onError`
+
+## Diagrams
+
+`to_mermaid(machine)` exports a dependency-free Mermaid `stateDiagram-v2` string:
+
+```python
+from xstate import to_mermaid
+
+print(to_mermaid(machine))
+```
+
+This is intentionally lightweight: it covers state hierarchy, initial states,
+transition arrows, and targetless-transition comments without adding Graphviz or
+browser-rendering dependencies.
 
 ## Examples
 
@@ -348,6 +400,9 @@ from xstate import (
     send_to,
     cancel,
     raise_,
+    state_in,
+    stateIn,
+    to_mermaid,
     dataclass_context,
 )
 from xstate.scheduler import SimulatedClock, ThreadClock
@@ -390,6 +445,8 @@ poetry run ruff check src/ tests/
 |---|---|
 | PyPI release | `0.6.0` release-readiness is complete; publish via GitHub Release |
 | XState v5 setup | `setup(...).create_machine(...)` and composable guards are present |
+| Snapshot queries | `tags`, `meta`, `has_tag`/`hasTag`, and `state_in`/`stateIn` are present on the 0.7.0 branch |
+| Diagrams | Dependency-free Mermaid export is present on the 0.7.0 branch |
 | Async | `AsyncInterpreter`, async actors, `from_observable`, and `to_promise` are present |
 | SCXML | XML import works; safe Boolean cond subset works; `more-parallel` conformance remains open |
 | Persistence | Snapshot serialization and restore helpers are present |

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -29,6 +29,8 @@ bridge between XState's JSON ecosystem and Python backends.
 | Setup API | `setup(...).create_machine(...)` exists for stricter named implementations |
 | Context policy | Default deep-copy adapter plus immutable dataclass adapter |
 | Snapshots | `MachineSnapshot = State`; immutable public containers |
+| Snapshot queries | Active `tags`, `meta`, `has_tag`/`hasTag`, and `state_in`/`stateIn` guard helpers are present on the 0.7.0 branch |
+| Diagrams | Dependency-free Mermaid `stateDiagram-v2` export is present on the 0.7.0 branch |
 | Sync runtime | `Interpreter` with RTC queue, subscriptions, delayed transitions, and lock-serialized timer sends |
 | Async runtime | `AsyncInterpreter` with async start/send/stop, awaitable actions, and event-loop timers |
 | Actor model | `create_actor`, `ActorSystem`, spawn, parent/child tree, `send_parent`, `send_to` |
@@ -45,7 +47,11 @@ bridge between XState's JSON ecosystem and Python backends.
 - Delayed transitions via `after`, numeric or named delays.
 - Machine snapshots with `status`, `output`, `error`, `matches(...)`, and
   `can(event)`.
+- Active state tags and metadata via immutable `state.tags` and `state.meta`,
+  plus `has_tag(...)` / `hasTag(...)`.
+- Reusable current-state guards via `state_in(...)` / `stateIn(...)`.
 - Snapshot serialization and restoration helpers for actor persistence flows.
+- Mermaid diagram export via `to_mermaid(machine)`.
 - XState v5 naming alignment: `guard`, `output`, `always`, `actors`,
   `MachineSnapshot`, `create_actor`, and `setup`.
 - Primary suite passes in current Python 3.13/3.14 CI.
@@ -73,7 +79,7 @@ JavaScript and wanting the same machine shape in Python services.
 | High | Fix the remaining SCXML `more-parallel` conformance cases |
 | Medium | Document snapshot persistence and restore helpers |
 | Medium | Inspector protocol compatibility |
-| Medium | More XState v5 utilities: composable guards, `provide`, graph/test helpers |
+| Medium | More XState v5 utilities: `provide`, action helpers, graph/test helpers |
 | Low | Django/FastAPI examples after the runtime API settles |
 
 ## Success Metrics

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -23,6 +23,8 @@ release-readiness work.
 | Actor model | No | No | Yes, XState v5-style actors | Partial | No | No |
 | Invoke/services | No | Yes | Yes, `invoke` + promise/callback/observable actors | Yes | No | No |
 | Setup-style named implementations | No | No | Yes, `setup(...).create_machine(...)` | Partial | No | No |
+| Snapshot tags/meta | No | Yes, metadata-style helpers | Yes, active tags/meta on snapshots | Partial | Yes | No |
+| Diagram export | Yes, GraphMachine | Yes | Yes, Mermaid text export | Partial | Yes | No |
 | Runtime dependencies | Varies | Varies | **None for core** | Varies | Varies | Small |
 | Docs quality | Good | Excellent | Improving | Good | Excellent | Good |
 | License | MIT | MIT | MIT | MIT | LGPL-3.0 | MIT |
@@ -58,6 +60,10 @@ structure with a JavaScript/XState frontend or a Stately-authored design.
   `from_callback`, `from_observable`, `to_promise`, `send_parent`, `send_to`,
   and `invoke` reconciliation.
 - Snapshot serialization and restoration helpers for persistence flows.
+- Active snapshot `tags`, `meta`, `has_tag`/`hasTag`, and
+  `state_in`/`stateIn` guard helpers on the 0.7.0 branch.
+- Dependency-free Mermaid diagram export via `to_mermaid(machine)` on the
+  0.7.0 branch.
 - SCXML XML import with a safe Boolean cond subset: `true`, `false`, `!`, `&&`,
   `||`, and parentheses.
 
@@ -68,7 +74,7 @@ structure with a JavaScript/XState frontend or a Stately-authored design.
 | PyPI release | 0.6.0 packaging metadata and release workflow are ready; publish via GitHub Release. |
 | SCXML conformance | Current full SCXML run is `45 passed`, `8 failed`; remaining failures are the known `more-parallel` cases. |
 | Full ECMAScript cond support | Intentionally not implemented; unsupported SCXML expressions raise `InvalidConfigError`. |
-| Graph/test utilities | No equivalent of XState graph traversal helpers yet. |
+| Graph/test utilities | Mermaid export exists on the 0.7.0 branch; no graph traversal/test-path helpers yet. |
 | Inspector protocol | No `@statelyai/inspect` compatibility yet. |
 
 ## Strategic Position

--- a/src/xstate/__init__.py
+++ b/src/xstate/__init__.py
@@ -21,10 +21,11 @@ from xstate.exceptions import (  # noqa
     UnregisteredImplementationError,
     XStateError,
 )
-from xstate.guards import and_, not_, or_  # noqa
+from xstate.guards import and_, not_, or_, state_in, stateIn  # noqa
 from xstate.handlers import HandlerArgs  # noqa
 from xstate.interpreter import Interpreter, interpret  # noqa
 from xstate.machine import Machine  # noqa
+from xstate.mermaid import to_mermaid  # noqa
 from xstate.scheduler import Clock, SimulatedClock, ThreadClock  # noqa
 from xstate.setup_api import MachineSetup, setup  # noqa
 from xstate.snapshot import deserialize_snapshot, serialize_snapshot  # noqa
@@ -78,7 +79,11 @@ __all__ = [
     "and_",
     "or_",
     "not_",
+    "state_in",
+    "stateIn",
     # Snapshot serialization (0.6.0)
     "serialize_snapshot",
     "deserialize_snapshot",
+    # Diagrams (0.7.0)
+    "to_mermaid",
 ]

--- a/src/xstate/algorithm.py
+++ b/src/xstate/algorithm.py
@@ -551,9 +551,11 @@ def condition_match(
         inner = cond.fn if isinstance(cond, HandlerAdapter) else cond
         if isinstance(inner, _ComposableGuard):
             guards = getattr(transition.source.machine, "guards", {}) or {}
-            if not inner._call(context, event, guards):
+            if not inner._call(context, event, guards, state=configuration):
                 return False
-        elif not bool(invoke_handler(cond, context, event, params=params)):
+        elif not bool(
+            invoke_handler(cond, context, event, params=params, state=configuration)
+        ):
             return False
 
     in_spec = getattr(transition, "in_state", None)

--- a/src/xstate/algorithm.py
+++ b/src/xstate/algorithm.py
@@ -474,7 +474,7 @@ def _matches_in_state(in_spec, configuration: AbstractSet[StateNode]) -> bool:
     ``in_spec`` is the value of an XState ``in`` transition guard:
     - str ``"#id"``   — true if a state with that id is active
     - str ``"a.b"``   — true if the state keyed "b" whose parent is keyed "a" is active
-    - dict ``{k: v}`` — true if all k/v pairs are satisfied (each a one-level path)
+    - dict ``{k: v}`` — true if all nested state-value paths are satisfied
     """
     if isinstance(in_spec, str):
         if in_spec.startswith("#"):
@@ -506,10 +506,23 @@ def _matches_in_state(in_spec, configuration: AbstractSet[StateNode]) -> bool:
         return _path_active(parts)
     if isinstance(in_spec, dict):
         return all(
-            _matches_in_state(f"{parent_key}.{child_key}", configuration)
-            for parent_key, child_key in in_spec.items()
+            _matches_in_state(path, configuration) for path in _state_paths(in_spec)
         )
     return True
+
+
+def _state_paths(state_value: dict) -> list[str]:
+    paths: list[str] = []
+
+    def walk(prefix: list[str], value) -> None:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                walk([*prefix, str(key)], child)
+            return
+        paths.append(".".join([*prefix, str(value)]))
+
+    walk([], state_value)
+    return paths
 
 
 def condition_match(

--- a/src/xstate/config_parser.py
+++ b/src/xstate/config_parser.py
@@ -71,6 +71,8 @@ class StateNodeConfigParser:
                 Literal["atomic", "compound", "parallel", "final", "history"],
                 node_type,
             ),
+            tags=self._build_tags(config.get("tags"), self._path(path, "tags")),
+            meta=config.get("meta"),
         )
         self.machine._register(node)
 
@@ -433,6 +435,24 @@ class StateNodeConfigParser:
             ]
         raise InvalidConfigError(
             f"{self._path(path, 'target')} must be a string or list."
+        )
+
+    def _build_tags(self, raw_tags: Any, path: str) -> frozenset[str]:
+        if raw_tags is None:
+            return frozenset()
+        if isinstance(raw_tags, str):
+            return frozenset({raw_tags})
+        if isinstance(raw_tags, (list, tuple, set, frozenset)):
+            tags: list[str] = []
+            for index, tag in enumerate(raw_tags):
+                if not isinstance(tag, str):
+                    raise InvalidConfigError(
+                        f"{path}[{index}] must be a string, got {type(tag)!r}."
+                    )
+                tags.append(tag)
+            return frozenset(tags)
+        raise InvalidConfigError(
+            f"{path} must be a string or list of strings, got {type(raw_tags)!r}."
         )
 
     def _resolve_target(self, source: StateNode, target: Any, path: str) -> StateNode:

--- a/src/xstate/guards.py
+++ b/src/xstate/guards.py
@@ -166,12 +166,28 @@ class _StateInGuard(_ComposableGuard):
         return _matches_in_state(self._state_value, state)
 
     def __call__(self, context: Any = None, event: Any = None) -> bool:
-        if hasattr(context, "state"):
+        # Detect the call shape explicitly. `hasattr(context, "state")` is
+        # unsafe: a user's own context object may legitimately carry a `state`
+        # attribute, which would route it down the HandlerArgs path and raise
+        # AttributeError on `context.context`. Use isinstance instead, and also
+        # accept a State/MachineSnapshot so guards can be evaluated directly
+        # against a snapshot.
+        from xstate.handlers import HandlerArgs
+        from xstate.state import State
+
+        if isinstance(context, HandlerArgs):
             return self._call(
                 context.context,
                 context.event,
                 {},
                 state=context.state,
+            )
+        if isinstance(context, State):
+            return self._call(
+                context.context,
+                None,
+                {},
+                state=context.configuration,
             )
         return self._call(context, event, {})
 

--- a/src/xstate/guards.py
+++ b/src/xstate/guards.py
@@ -1,8 +1,9 @@
-"""Composable guard combinators (0.6.0).
+"""Composable guard helpers.
 
 ``and_``, ``or_``, and ``not_`` compose guards from smaller pieces without
 writing wrapper lambdas.  Sub-guards can be callables or strings that reference
 other named guards in the machine's ``guards`` registry.
+``state_in`` / ``stateIn`` checks the current active state configuration.
 
 Usage::
 
@@ -29,7 +30,10 @@ registry when the guard is evaluated by :func:`~xstate.algorithm.condition_match
 
 from __future__ import annotations
 
+import inspect
 from typing import Any
+
+__all__ = ["and_", "or_", "not_", "state_in", "stateIn"]
 
 
 class _ComposableGuard:
@@ -39,7 +43,14 @@ class _ComposableGuard:
     directly in the machine's ``guards`` dict.
     """
 
-    def _eval(self, guard: Any, context: Any, event: Any, registry: dict) -> bool:
+    def _eval(
+        self,
+        guard: Any,
+        context: Any,
+        event: Any,
+        registry: dict,
+        state: Any | None = None,
+    ) -> bool:
         if isinstance(guard, str):
             fn = registry.get(guard)
             if fn is None:
@@ -49,12 +60,18 @@ class _ComposableGuard:
                 )
             guard = fn
         if isinstance(guard, _ComposableGuard):
-            return guard._call(context, event, registry)
+            return guard._call(context, event, registry, state=state)
         from xstate.handlers import invoke_handler
 
-        return bool(invoke_handler(guard, context, event))
+        return bool(invoke_handler(guard, context, event, state=state))
 
-    def _call(self, context: Any, event: Any, registry: dict) -> bool:
+    def _call(
+        self,
+        context: Any,
+        event: Any,
+        registry: dict,
+        state: Any | None = None,
+    ) -> bool:
         raise NotImplementedError
 
     def __call__(self, context: Any = None, event: Any = None) -> bool:
@@ -68,8 +85,16 @@ class _AndGuard(_ComposableGuard):
     def __init__(self, guards: tuple[Any, ...]):
         self._guards = guards
 
-    def _call(self, context: Any, event: Any, registry: dict) -> bool:
-        return all(self._eval(g, context, event, registry) for g in self._guards)
+    def _call(
+        self,
+        context: Any,
+        event: Any,
+        registry: dict,
+        state: Any | None = None,
+    ) -> bool:
+        return all(
+            self._eval(g, context, event, registry, state=state) for g in self._guards
+        )
 
 
 class _OrGuard(_ComposableGuard):
@@ -78,8 +103,16 @@ class _OrGuard(_ComposableGuard):
     def __init__(self, guards: tuple[Any, ...]):
         self._guards = guards
 
-    def _call(self, context: Any, event: Any, registry: dict) -> bool:
-        return any(self._eval(g, context, event, registry) for g in self._guards)
+    def _call(
+        self,
+        context: Any,
+        event: Any,
+        registry: dict,
+        state: Any | None = None,
+    ) -> bool:
+        return any(
+            self._eval(g, context, event, registry, state=state) for g in self._guards
+        )
 
 
 class _NotGuard(_ComposableGuard):
@@ -88,8 +121,59 @@ class _NotGuard(_ComposableGuard):
     def __init__(self, guard: Any):
         self._guard = guard
 
-    def _call(self, context: Any, event: Any, registry: dict) -> bool:
-        return not self._eval(self._guard, context, event, registry)
+    def _call(
+        self,
+        context: Any,
+        event: Any,
+        registry: dict,
+        state: Any | None = None,
+    ) -> bool:
+        return not self._eval(
+            self._guard,
+            context,
+            event,
+            registry,
+            state=state,
+        )
+
+
+class _StateInGuard(_ComposableGuard):
+    """Guard that passes when the active state configuration matches a spec."""
+
+    __signature__ = inspect.Signature(
+        [
+            inspect.Parameter(
+                "args",
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            )
+        ]
+    )
+
+    def __init__(self, state_value: Any):
+        self._state_value = state_value
+
+    def _call(
+        self,
+        context: Any,
+        event: Any,
+        registry: dict,
+        state: Any | None = None,
+    ) -> bool:
+        if state is None:
+            return False
+        from xstate.algorithm import _matches_in_state
+
+        return _matches_in_state(self._state_value, state)
+
+    def __call__(self, context: Any = None, event: Any = None) -> bool:
+        if hasattr(context, "state"):
+            return self._call(
+                context.context,
+                context.event,
+                {},
+                state=context.state,
+            )
+        return self._call(context, event, {})
 
 
 def and_(*guards: Any) -> _AndGuard:
@@ -105,3 +189,13 @@ def or_(*guards: Any) -> _OrGuard:
 def not_(guard: Any) -> _NotGuard:
     """Return a guard that passes when *guard* does NOT pass."""
     return _NotGuard(guard)
+
+
+def state_in(state_value: Any) -> _StateInGuard:
+    """Return a guard that passes when the current state matches *state_value*."""
+    return _StateInGuard(state_value)
+
+
+def stateIn(state_value: Any) -> _StateInGuard:
+    """XState-compatible alias for :func:`state_in`."""
+    return state_in(state_value)

--- a/src/xstate/guards.py
+++ b/src/xstate/guards.py
@@ -59,9 +59,11 @@ class _ComposableGuard:
                     "Make sure it is registered in the machine's guards dict."
                 )
             guard = fn
-        if isinstance(guard, _ComposableGuard):
-            return guard._call(context, event, registry, state=state)
-        from xstate.handlers import invoke_handler
+        from xstate.handlers import HandlerAdapter, invoke_handler
+
+        inner = guard.fn if isinstance(guard, HandlerAdapter) else guard
+        if isinstance(inner, _ComposableGuard):
+            return inner._call(context, event, registry, state=state)
 
         return bool(invoke_handler(guard, context, event, state=state))
 

--- a/src/xstate/handlers.py
+++ b/src/xstate/handlers.py
@@ -25,6 +25,7 @@ class HandlerArgs:
     context: Any
     event: Event | None
     params: Any | None = None
+    state: Any | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -149,16 +150,27 @@ class HandlerAdapter:
         event: Event | None,
         *,
         params: Any = _UNSET,
+        state: Any | None = None,
     ) -> Any:
         call_params = self.default_params if params is _UNSET else params
-        args = HandlerArgs(context=context, event=event, params=call_params)
+        args = HandlerArgs(
+            context=context,
+            event=event,
+            params=call_params,
+            state=state,
+        )
 
         if self._mode == "args":
             return self.fn(args)
         if self._mode == "args_params":
             return self.fn(args, call_params)
         if self._mode == "keyword":
-            return self.fn(context=context, event=event, params=call_params)
+            return self.fn(
+                context=context,
+                event=event,
+                params=call_params,
+                state=state,
+            )
         if self._mode == "legacy_keyword":
             kwargs: dict[str, Any] = {}
             kw_names = {
@@ -170,6 +182,8 @@ class HandlerAdapter:
                 kwargs["event"] = event
             if "params" in kw_names:
                 kwargs["params"] = call_params
+            if "state" in kw_names:
+                kwargs["state"] = state
             return self.fn(**kwargs)
         if self._mode == "legacy_zero":
             return self.fn()
@@ -203,10 +217,11 @@ def invoke_handler(
     event: Event | None,
     *,
     params: Any = _UNSET,
+    state: Any | None = None,
 ) -> Any:
     if isinstance(fn, HandlerAdapter):
-        return fn(context, event, params=params)
+        return fn(context, event, params=params, state=state)
 
     # Compatibility shim for truly opaque callables. New machines should pass
     # through HandlerAdapter at parse/setup time so this is not the hot path.
-    return HandlerAdapter(fn)(context, event, params=params)
+    return HandlerAdapter(fn)(context, event, params=params, state=state)

--- a/src/xstate/machine.py
+++ b/src/xstate/machine.py
@@ -142,7 +142,7 @@ class Machine:
                 result.append(
                     self._bind_action(
                         action,
-                        self.actions[action.type],  # type: ignore[index]
+                        self.actions[action.type],
                         context,
                         event,
                     )

--- a/src/xstate/machine.py
+++ b/src/xstate/machine.py
@@ -142,7 +142,7 @@ class Machine:
                 result.append(
                     self._bind_action(
                         action,
-                        self.actions[action.type],
+                        self.actions[action.type],  # type: ignore[index]
                         context,
                         event,
                     )

--- a/src/xstate/mermaid.py
+++ b/src/xstate/mermaid.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -13,48 +12,82 @@ __all__ = ["to_mermaid"]
 
 def to_mermaid(machine: Machine) -> str:
     """Return a dependency-free Mermaid ``stateDiagram-v2`` representation."""
-    lines = ["stateDiagram-v2"]
-    if machine.root.initial_transition is not None:
-        for target in machine.root.initial.target:
-            lines.append(f"  [*] --> {_alias(target)}")
-    _emit_states(machine.root, lines, indent="  ")
-    _emit_transitions(machine.root, lines, indent="  ")
-    return "\n".join(lines) + "\n"
+    return _MermaidExporter(machine).render()
 
 
-def _emit_states(node: StateNode, lines: list[str], *, indent: str) -> None:
-    for child in node.states.values():
-        lines.append(f'{indent}state "{_escape(child.key)}" as {_alias(child)}')
-        if child.states:
-            lines.append(f"{indent}state {_alias(child)} {{")
-            if child.initial_transition is not None:
-                for target in child.initial.target:
-                    lines.append(f"{indent}  [*] --> {_alias(target)}")
-            _emit_states(child, lines, indent=f"{indent}  ")
-            lines.append(f"{indent}}}")
+class _MermaidExporter:
+    def __init__(self, machine: Machine) -> None:
+        self.machine = machine
+        self.aliases: dict[StateNode, str] = {}
 
+    def render(self) -> str:
+        lines = ["stateDiagram-v2"]
+        self._emit_initial(self.machine.root, lines, indent="  ")
+        self._emit_states(self.machine.root, lines, indent="  ")
+        self._emit_transitions(self.machine.root, lines, indent="  ")
+        return "\n".join(lines) + "\n"
 
-def _emit_transitions(node: StateNode, lines: list[str], *, indent: str) -> None:
-    for transition in node.transitions:
-        _emit_transition(transition, lines, indent=indent)
-    for child in node.states.values():
-        _emit_transitions(child, lines, indent=indent)
+    def _emit_initial(
+        self,
+        node: StateNode,
+        lines: list[str],
+        *,
+        indent: str,
+    ) -> None:
+        if node.initial_transition is None:
+            return
+        for target in node.initial.target:
+            if target is node:
+                continue
+            lines.append(f"{indent}[*] --> {self._alias(target)}")
 
+    def _emit_states(self, node: StateNode, lines: list[str], *, indent: str) -> None:
+        for child in node.states.values():
+            lines.append(
+                f'{indent}state "{_escape(child.key)}" as {self._alias(child)}'
+            )
+            if child.states:
+                lines.append(f"{indent}state {self._alias(child)} {{")
+                self._emit_initial(child, lines, indent=f"{indent}  ")
+                self._emit_states(child, lines, indent=f"{indent}  ")
+                lines.append(f"{indent}}}")
 
-def _emit_transition(
-    transition: Transition,
-    lines: list[str],
-    *,
-    indent: str,
-) -> None:
-    label = _transition_label(transition)
-    if not transition.target:
-        lines.append(f"{indent}%% {_alias(transition.source)} handles {label}")
-        return
-    for target in transition.target:
-        lines.append(
-            f"{indent}{_alias(transition.source)} --> {_alias(target)}: {label}"
-        )
+    def _emit_transitions(
+        self,
+        node: StateNode,
+        lines: list[str],
+        *,
+        indent: str,
+    ) -> None:
+        for transition in node.transitions:
+            self._emit_transition(transition, lines, indent=indent)
+        for child in node.states.values():
+            self._emit_transitions(child, lines, indent=indent)
+
+    def _emit_transition(
+        self,
+        transition: Transition,
+        lines: list[str],
+        *,
+        indent: str,
+    ) -> None:
+        label = _transition_label(transition)
+        if not transition.target:
+            lines.append(f"{indent}%% {self._alias(transition.source)} handles {label}")
+            return
+        for target in transition.target:
+            lines.append(
+                f"{indent}{self._alias(transition.source)} --> "
+                f"{self._alias(target)}: {label}"
+            )
+
+    def _alias(self, node: StateNode) -> str:
+        try:
+            return self.aliases[node]
+        except KeyError:
+            alias = "s_" + node.id.encode("utf-8").hex()
+            self.aliases[node] = alias
+            return alias
 
 
 def _transition_label(transition: Transition) -> str:
@@ -64,10 +97,6 @@ def _transition_label(transition: Transition) -> str:
     if transition.in_state is not None:
         label = f"{label} [in {transition.in_state!r}]"
     return _escape(label)
-
-
-def _alias(node: StateNode) -> str:
-    return "s_" + re.sub(r"[^0-9A-Za-z_]", "_", node.id)
 
 
 def _escape(value: object) -> str:

--- a/src/xstate/mermaid.py
+++ b/src/xstate/mermaid.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from xstate.machine import Machine
+    from xstate.state_node import StateNode
+    from xstate.transition import Transition
+
+__all__ = ["to_mermaid"]
+
+
+def to_mermaid(machine: Machine) -> str:
+    """Return a dependency-free Mermaid ``stateDiagram-v2`` representation."""
+    lines = ["stateDiagram-v2"]
+    if machine.root.initial_transition is not None:
+        for target in machine.root.initial.target:
+            lines.append(f"  [*] --> {_alias(target)}")
+    _emit_states(machine.root, lines, indent="  ")
+    _emit_transitions(machine.root, lines, indent="  ")
+    return "\n".join(lines) + "\n"
+
+
+def _emit_states(node: StateNode, lines: list[str], *, indent: str) -> None:
+    for child in node.states.values():
+        lines.append(f'{indent}state "{_escape(child.key)}" as {_alias(child)}')
+        if child.states:
+            lines.append(f"{indent}state {_alias(child)} {{")
+            if child.initial_transition is not None:
+                for target in child.initial.target:
+                    lines.append(f"{indent}  [*] --> {_alias(target)}")
+            _emit_states(child, lines, indent=f"{indent}  ")
+            lines.append(f"{indent}}}")
+
+
+def _emit_transitions(node: StateNode, lines: list[str], *, indent: str) -> None:
+    for transition in node.transitions:
+        _emit_transition(transition, lines, indent=indent)
+    for child in node.states.values():
+        _emit_transitions(child, lines, indent=indent)
+
+
+def _emit_transition(
+    transition: Transition,
+    lines: list[str],
+    *,
+    indent: str,
+) -> None:
+    label = _transition_label(transition)
+    if not transition.target:
+        lines.append(f"{indent}%% {_alias(transition.source)} handles {label}")
+        return
+    for target in transition.target:
+        lines.append(
+            f"{indent}{_alias(transition.source)} --> {_alias(target)}: {label}"
+        )
+
+
+def _transition_label(transition: Transition) -> str:
+    label = transition.event or "always"
+    if transition.cond is not None:
+        label = f"{label} [guard]"
+    if transition.in_state is not None:
+        label = f"{label} [in {transition.in_state!r}]"
+    return _escape(label)
+
+
+def _alias(node: StateNode) -> str:
+    return "s_" + re.sub(r"[^0-9A-Za-z_]", "_", node.id)
+
+
+def _escape(value: object) -> str:
+    return str(value).replace('"', r"\"")

--- a/src/xstate/schema.py
+++ b/src/xstate/schema.py
@@ -48,6 +48,8 @@ class InvokeConfig(TypedDict, total=False):
 class StateNodeConfig(TypedDict, total=False):
     id: str
     type: StateNodeType
+    tags: str | list[str]
+    meta: Any
     initial: str
     states: dict[str, StateNodeConfig]
     on: dict[str | None, TransitionConfig | str | list[TransitionConfig | str]]

--- a/src/xstate/state.py
+++ b/src/xstate/state.py
@@ -21,6 +21,8 @@ class State:
     context: Any
     actions: tuple[Callable[..., Any] | Action, ...]
     history_value: Mapping[str, frozenset[StateNode]]
+    tags: frozenset[str]
+    meta: Mapping[str, Any]
     status: Literal["active", "done", "error"]
     output: Any | None
     error: Any | None
@@ -46,6 +48,19 @@ class State:
             {
                 state_id: frozenset(states)
                 for state_id, states in (history_value or {}).items()
+            }
+        )
+        self.tags = frozenset(
+            tag for state_node in self.configuration for tag in state_node.tags
+        )
+        self.meta = MappingProxyType(
+            {
+                state_node.id: state_node.meta
+                for state_node in sorted(
+                    self.configuration,
+                    key=lambda node: node.order,
+                )
+                if state_node.meta is not None
             }
         )
         self.error = None
@@ -100,6 +115,14 @@ class State:
         if isinstance(value, dict):
             return _matches_dict(self.value, value)
         return False
+
+    def has_tag(self, tag: str) -> bool:
+        """Return True if any active state node has *tag*."""
+        return tag in self.tags
+
+    def hasTag(self, tag: str) -> bool:
+        """XState-compatible alias for :meth:`has_tag`."""
+        return self.has_tag(tag)
 
     def __repr__(self) -> str:
         return (

--- a/src/xstate/state.py
+++ b/src/xstate/state.py
@@ -55,7 +55,7 @@ class State:
         )
         self.meta = MappingProxyType(
             {
-                state_node.id: state_node.meta
+                state_node.id: _freeze_meta(state_node.meta)
                 for state_node in sorted(
                     self.configuration,
                     key=lambda node: node.order,
@@ -142,6 +142,18 @@ def _matches_dict(state_value: Any, pattern: Any) -> bool:
             for k, v in pattern.items()
         )
     )
+
+
+def _freeze_meta(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType(
+            {key: _freeze_meta(child) for key, child in value.items()}
+        )
+    if isinstance(value, list | tuple):
+        return tuple(_freeze_meta(child) for child in value)
+    if isinstance(value, set | frozenset):
+        return frozenset(_freeze_meta(child) for child in value)
+    return value
 
 
 # XState v5 public alias.

--- a/src/xstate/state_node.py
+++ b/src/xstate/state_node.py
@@ -30,6 +30,8 @@ class StateNode:
     transitions: list[Transition] = field(default_factory=list)
     entry: list[Action] = field(default_factory=list)
     exit: list[Action] = field(default_factory=list)
+    tags: frozenset[str] = field(default_factory=frozenset)
+    meta: Any | None = None
     donedata: Any | None = None
     history: Literal["shallow", "deep"] | None = None
     transition: Transition | None = None

--- a/tests/test_mermaid.py
+++ b/tests/test_mermaid.py
@@ -1,6 +1,10 @@
 from xstate import Machine, to_mermaid
 
 
+def _alias(state_id):
+    return "s_" + state_id.encode("utf-8").hex()
+
+
 def test_to_mermaid_exports_state_diagram():
     machine = Machine(
         {
@@ -29,13 +33,19 @@ def test_to_mermaid_exports_state_diagram():
     diagram = to_mermaid(machine)
 
     assert diagram.startswith("stateDiagram-v2\n")
-    assert "  [*] --> s_chart_idle\n" in diagram
-    assert '  state "idle" as s_chart_idle\n' in diagram
-    assert '  state "active" as s_chart_active\n' in diagram
-    assert "  state s_chart_active {\n" in diagram
-    assert "    [*] --> s_chart_active_pending\n" in diagram
-    assert "  s_chart_idle --> s_chart_active: START [guard]\n" in diagram
-    assert "  s_chart_active_pending --> s_chart_active_done: FINISH\n" in diagram
+    assert f"  [*] --> {_alias('chart.idle')}\n" in diagram
+    assert f'  state "idle" as {_alias("chart.idle")}\n' in diagram
+    assert f'  state "active" as {_alias("chart.active")}\n' in diagram
+    assert f"  state {_alias('chart.active')} {{\n" in diagram
+    assert f"    [*] --> {_alias('chart.active.pending')}\n" in diagram
+    assert (
+        f"  {_alias('chart.idle')} --> {_alias('chart.active')}: START [guard]\n"
+        in diagram
+    )
+    assert (
+        f"  {_alias('chart.active.pending')} --> "
+        f"{_alias('chart.active.done')}: FINISH\n" in diagram
+    )
 
 
 def test_to_mermaid_keeps_targetless_transitions_as_comments():
@@ -49,4 +59,47 @@ def test_to_mermaid_keeps_targetless_transitions_as_comments():
         }
     )
 
-    assert "%% s_chart_idle handles PING" in to_mermaid(machine)
+    assert f"%% {_alias('chart.idle')} handles PING" in to_mermaid(machine)
+
+
+def test_to_mermaid_does_not_emit_parallel_root_initial_target():
+    machine = Machine(
+        {
+            "id": "cross",
+            "type": "parallel",
+            "states": {
+                "a": {"initial": "a1", "states": {"a1": {}}},
+                "b": {"initial": "b1", "states": {"b1": {}}},
+            },
+        }
+    )
+
+    diagram = to_mermaid(machine)
+
+    assert f"  [*] --> {_alias('cross')}\n" not in diagram
+    assert f'  state "a" as {_alias("cross.a")}\n' in diagram
+    assert f"    [*] --> {_alias('cross.a.a1')}\n" in diagram
+    assert f'  state "b" as {_alias("cross.b")}\n' in diagram
+    assert f"    [*] --> {_alias('cross.b.b1')}\n" in diagram
+
+
+def test_to_mermaid_preserves_distinct_aliases_for_similar_ids():
+    machine = Machine(
+        {
+            "id": "m",
+            "initial": "a-b",
+            "states": {
+                "a-b": {"on": {"GO": "a_b"}},
+                "a_b": {},
+            },
+        }
+    )
+
+    diagram = to_mermaid(machine)
+
+    dashed = _alias("m.a-b")
+    underscored = _alias("m.a_b")
+    assert dashed != underscored
+    assert f'state "a-b" as {dashed}' in diagram
+    assert f'state "a_b" as {underscored}' in diagram
+    assert f"{dashed} --> {underscored}: GO" in diagram

--- a/tests/test_mermaid.py
+++ b/tests/test_mermaid.py
@@ -1,0 +1,52 @@
+from xstate import Machine, to_mermaid
+
+
+def test_to_mermaid_exports_state_diagram():
+    machine = Machine(
+        {
+            "id": "chart",
+            "initial": "idle",
+            "states": {
+                "idle": {
+                    "on": {
+                        "START": {
+                            "target": "active",
+                            "guard": lambda _context, _event: True,
+                        }
+                    }
+                },
+                "active": {
+                    "initial": "pending",
+                    "states": {
+                        "pending": {"on": {"FINISH": "done"}},
+                        "done": {"type": "final"},
+                    },
+                },
+            },
+        }
+    )
+
+    diagram = to_mermaid(machine)
+
+    assert diagram.startswith("stateDiagram-v2\n")
+    assert "  [*] --> s_chart_idle\n" in diagram
+    assert '  state "idle" as s_chart_idle\n' in diagram
+    assert '  state "active" as s_chart_active\n' in diagram
+    assert "  state s_chart_active {\n" in diagram
+    assert "    [*] --> s_chart_active_pending\n" in diagram
+    assert "  s_chart_idle --> s_chart_active: START [guard]\n" in diagram
+    assert "  s_chart_active_pending --> s_chart_active_done: FINISH\n" in diagram
+
+
+def test_to_mermaid_keeps_targetless_transitions_as_comments():
+    machine = Machine(
+        {
+            "id": "chart",
+            "initial": "idle",
+            "states": {
+                "idle": {"on": {"PING": {"actions": "trackPing"}}},
+            },
+        }
+    )
+
+    assert "%% s_chart_idle handles PING" in to_mermaid(machine)

--- a/tests/test_state_queries.py
+++ b/tests/test_state_queries.py
@@ -73,6 +73,31 @@ def test_state_meta_exposes_active_state_metadata_read_only():
         state.meta["doc.published"] = {"label": "Published"}  # type: ignore[index]
 
 
+def test_state_meta_freezes_nested_metadata_values():
+    machine = Machine(
+        {
+            "id": "doc",
+            "meta": {
+                "title": "Document workflow",
+                "labels": ["public", "reviewed"],
+                "nested": {"owner": "docs"},
+            },
+            "initial": "editing",
+            "states": {"editing": {}},
+        }
+    )
+
+    state = machine.initial_state
+
+    assert state.meta["doc"]["labels"] == ("public", "reviewed")
+    with pytest.raises(TypeError):
+        state.meta["doc"]["nested"]["owner"] = "changed"
+    with pytest.raises(TypeError):
+        state.meta["doc"]["labels"][0] = "changed"
+
+    assert machine.initial_state.meta["doc"]["nested"]["owner"] == "docs"
+
+
 def test_invalid_tags_are_path_aware():
     with pytest.raises(InvalidConfigError, match=r"states\.a\.tags\[0\]"):
         Machine(
@@ -177,3 +202,64 @@ def test_state_in_direct_call_with_state_snapshot():
     guard = state_in("#ready")
     assert guard(state) is True
     assert guard(machine.initial_state) is False
+
+
+def test_state_in_matches_nested_dict_state_values():
+    machine = Machine(
+        {
+            "id": "nested",
+            "initial": "a",
+            "states": {
+                "a": {
+                    "initial": "b",
+                    "states": {
+                        "b": {
+                            "initial": "c",
+                            "states": {"c": {}, "d": {}},
+                        }
+                    },
+                }
+            },
+        }
+    )
+
+    state = machine.initial_state
+
+    assert state.value == {"a": {"b": "c"}}
+    assert state_in({"a": {"b": "c"}})(state)
+    assert not state_in({"a": {"b": "d"}})(state)
+
+
+def test_named_composable_guard_preserves_registry_and_state():
+    machine = Machine(
+        {
+            "id": "cross",
+            "type": "parallel",
+            "states": {
+                "a": {
+                    "initial": "a1",
+                    "states": {
+                        "a1": {"on": {"GO": {"target": "a2", "guard": "outer"}}},
+                        "a2": {},
+                    },
+                },
+                "b": {
+                    "initial": "b1",
+                    "states": {
+                        "b1": {"on": {"GO_B2": "b2"}},
+                        "b2": {"id": "ready"},
+                    },
+                },
+            },
+        },
+        guards={
+            "inner": state_in("#ready"),
+            "outer": and_("inner"),
+        },
+    )
+
+    state = machine.initial_state
+    assert machine.transition(state, "GO").value == {"a": "a1", "b": "b1"}
+
+    state = machine.transition(state, "GO_B2")
+    assert machine.transition(state, "GO").value == {"a": "a2", "b": "b2"}

--- a/tests/test_state_queries.py
+++ b/tests/test_state_queries.py
@@ -138,3 +138,42 @@ def test_state_in_composes_with_other_guards():
     state = machine.transition(state, "GO_B2")
 
     assert machine.transition(state, "GO").value == {"a": "a2", "b": "b2"}
+
+
+def test_state_in_direct_call_with_context_having_state_attr_does_not_crash():
+    """A user context that happens to carry a `state` attribute must not be
+    mistaken for a HandlerArgs (regression for the old `hasattr` detection)."""
+
+    class UserContext:
+        # A perfectly ordinary user context that owns a `state` field.
+        state = "running"
+
+    guard = state_in("#ready")
+    # Previously raised AttributeError on `context.context`; now returns False
+    # because no active configuration was supplied.
+    assert guard(UserContext()) is False
+
+
+def test_state_in_direct_call_with_handler_args():
+    from xstate.handlers import HandlerArgs
+
+    machine = _parallel_machine_with_guard(lambda context, event: True)
+    state = machine.transition(machine.initial_state, "GO_B2")
+
+    guard = state_in("#ready")
+    args = HandlerArgs(context={}, event=None, state=state.configuration)
+    assert guard(args) is True
+
+    args_miss = HandlerArgs(
+        context={}, event=None, state=machine.initial_state.configuration
+    )
+    assert guard(args_miss) is False
+
+
+def test_state_in_direct_call_with_state_snapshot():
+    machine = _parallel_machine_with_guard(lambda context, event: True)
+    state = machine.transition(machine.initial_state, "GO_B2")
+
+    guard = state_in("#ready")
+    assert guard(state) is True
+    assert guard(machine.initial_state) is False

--- a/tests/test_state_queries.py
+++ b/tests/test_state_queries.py
@@ -1,0 +1,140 @@
+from types import MappingProxyType
+
+import pytest
+
+from xstate import Machine, and_, state_in, stateIn
+from xstate.exceptions import InvalidConfigError
+
+
+def test_state_tags_include_active_ancestors_and_leaf_nodes():
+    machine = Machine(
+        {
+            "id": "checkout",
+            "tags": ["app"],
+            "initial": "cart",
+            "states": {
+                "cart": {
+                    "tags": ["shopping"],
+                    "initial": "editing",
+                    "states": {
+                        "editing": {"tags": ["editable"]},
+                        "review": {"tags": ["reviewing"]},
+                    },
+                },
+                "paid": {"tags": ["done"]},
+            },
+        }
+    )
+
+    state = machine.initial_state
+
+    assert state.tags == frozenset({"app", "shopping", "editable"})
+    assert state.has_tag("shopping")
+    assert state.hasTag("editable")
+    assert not state.has_tag("done")
+
+
+def test_state_tags_are_immutable():
+    machine = Machine(
+        {
+            "id": "m",
+            "initial": "a",
+            "states": {"a": {"tags": ["active"]}},
+        }
+    )
+
+    state = machine.initial_state
+
+    with pytest.raises(AttributeError):
+        state.tags.add("other")  # type: ignore[attr-defined]
+
+
+def test_state_meta_exposes_active_state_metadata_read_only():
+    machine = Machine(
+        {
+            "id": "doc",
+            "meta": {"title": "Document workflow"},
+            "initial": "editing",
+            "states": {
+                "editing": {"meta": {"label": "Editing"}},
+                "published": {"meta": {"label": "Published"}},
+            },
+        }
+    )
+
+    state = machine.initial_state
+
+    assert isinstance(state.meta, MappingProxyType)
+    assert state.meta == {
+        "doc": {"title": "Document workflow"},
+        "doc.editing": {"label": "Editing"},
+    }
+    with pytest.raises(TypeError):
+        state.meta["doc.published"] = {"label": "Published"}  # type: ignore[index]
+
+
+def test_invalid_tags_are_path_aware():
+    with pytest.raises(InvalidConfigError, match=r"states\.a\.tags\[0\]"):
+        Machine(
+            {
+                "id": "m",
+                "initial": "a",
+                "states": {"a": {"tags": [object()]}},
+            }
+        )
+
+
+def _parallel_machine_with_guard(guard):
+    return Machine(
+        {
+            "id": "cross",
+            "type": "parallel",
+            "states": {
+                "a": {
+                    "initial": "a1",
+                    "states": {
+                        "a1": {"on": {"GO": {"target": "a2", "guard": guard}}},
+                        "a2": {},
+                    },
+                },
+                "b": {
+                    "initial": "b1",
+                    "states": {
+                        "b1": {"on": {"GO_B2": "b2"}},
+                        "b2": {"id": "ready"},
+                    },
+                },
+            },
+        }
+    )
+
+
+def test_state_in_guard_matches_dotted_path():
+    machine = _parallel_machine_with_guard(state_in("b.b2"))
+    state = machine.initial_state
+
+    assert machine.transition(state, "GO").value == {"a": "a1", "b": "b1"}
+
+    state = machine.transition(state, "GO_B2")
+    assert machine.transition(state, "GO").value == {"a": "a2", "b": "b2"}
+
+
+def test_stateIn_alias_matches_state_id():
+    machine = _parallel_machine_with_guard(stateIn("#ready"))
+    state = machine.initial_state
+
+    assert machine.transition(state, "GO").value == {"a": "a1", "b": "b1"}
+
+    state = machine.transition(state, "GO_B2")
+    assert machine.transition(state, "GO").value == {"a": "a2", "b": "b2"}
+
+
+def test_state_in_composes_with_other_guards():
+    machine = _parallel_machine_with_guard(
+        and_(state_in({"b": "b2"}), lambda context, event: True)
+    )
+    state = machine.initial_state
+
+    state = machine.transition(state, "GO_B2")
+
+    assert machine.transition(state, "GO").value == {"a": "a2", "b": "b2"}


### PR DESCRIPTION
## Summary

Stacked on PR #17 (`release-readiness-0.6.0`) because that release PR is still draft-blocked in GitHub.

This starts the 0.7.0 XState parity work with the highest-leverage query and visualization pieces:

- adds active state `tags` and read-only `meta` to public `State` / `MachineSnapshot`
- adds `state.has_tag(...)` plus XState-compatible `state.hasTag(...)`
- adds reusable `state_in(...)` / `stateIn(...)` guard helpers, including composition with `and_` / `or_` / `not_`
- threads active configuration through `HandlerArgs.state` for guard evaluation
- adds dependency-free `to_mermaid(machine)` export
- refreshes README, product/comparison docs, and tracked agent docs for the current branch stack

## Notes

PR #17 could not be merged from this session because GitHub reports it is still a draft, and the active token lacks permission to mark it ready or merge it. Once #17 lands, this PR can be retargeted to `master`.

## Validation

- `python3 -m poetry run pytest tests/test_state_queries.py tests/test_mermaid.py tests/test_state_in.py tests/test_guards.py`
- `python3 -m poetry run pytest tests/ --ignore=tests/test_scxml.py`
- `python3 -m poetry run pytest tests/test_scxml.py -k cond-js`
- `python3 -m poetry run ruff format --check src/ tests/`
- `python3 -m poetry run ruff check src/ tests/`
- `python3 -m poetry run mypy src/xstate/`