### PR TITLE
feat: choose() and pure() higher-order actions (0.7.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,12 @@ The critical execution order is: `main_event_loop` → `microstep` → `main_eve
   configuration: `stateIn("#id")`, `stateIn("parent.child")`, or `stateIn({parent: child})`.
   Composes with `and_`/`or_`/`not_` and can be registered as a named guard; it reuses the same
   matcher as the internal transition `in` guard (`algorithm._matches_in_state`)
+- **`choose` / `pure` actions** (0.7.0, `from xstate import choose, pure`) — higher-order actions
+  that expand into sub-actions at execution time. `choose([{guard, actions}, ...])` runs the first
+  branch whose guard passes (a guardless branch is the default); `pure(fn)` runs the action(s)
+  returned by `fn(context, event)` (or none). Both are resolved inside `algorithm.execute_content`,
+  so nested `assign`/`raise_`/`send`/side-effects flow through the engine in order. `choose` branch
+  guards see `(context, event)` but not the configuration, so `stateIn` isn't supported inside them
 
 Handler-signature note: guards/assigners are invoked arity-aware by
 `algorithm._invoke`, which supports four calling conventions: `()`, `(context)`,

--- a/src/xstate/__init__.py
+++ b/src/xstate/__init__.py
@@ -1,4 +1,13 @@
-from xstate.action import assign, cancel, raise_, send, send_parent, send_to  # noqa
+from xstate.action import (  # noqa
+    assign,
+    cancel,
+    choose,
+    pure,
+    raise_,
+    send,
+    send_parent,
+    send_to,
+)
 from xstate.actor import (  # noqa
     Actor,
     ActorSystem,
@@ -58,6 +67,9 @@ __all__ = [
     "send_to",
     "cancel",
     "raise_",
+    # Higher-order actions (0.7.0)
+    "choose",
+    "pure",
     # Context adapters
     "ContextAdapter",
     "DeepCopyContextAdapter",

--- a/src/xstate/action.py
+++ b/src/xstate/action.py
@@ -10,6 +10,8 @@ SEND_TYPE = "xstate.send"
 CANCEL_TYPE = "xstate.cancel"
 SEND_PARENT_TYPE = "xstate.send_parent"
 SEND_TO_TYPE = "xstate.send_to"
+CHOOSE_TYPE = "xstate.choose"
+PURE_TYPE = "xstate.pure"
 
 # Action types handled by the interpreter, not the algorithm — passed through
 # _get_actions without resolution so the interpreter can act on them.
@@ -22,6 +24,8 @@ __all__ = [
     "CANCEL_TYPE",
     "SEND_PARENT_TYPE",
     "SEND_TO_TYPE",
+    "CHOOSE_TYPE",
+    "PURE_TYPE",
     "INTERPRETER_TYPES",
     "Action",
     "build_action",
@@ -31,6 +35,8 @@ __all__ = [
     "send_parent",
     "send_to",
     "cancel",
+    "choose",
+    "pure",
 ]
 
 
@@ -227,3 +233,47 @@ def cancel(send_id: str) -> dict[str, str]:
         cancel("t1")
     """
     return {"type": CANCEL_TYPE, "sendid": send_id}
+
+
+def choose(branches: list[dict[str, Any]]) -> dict[str, Any]:
+    """Run the actions of the first branch whose ``guard`` passes (v5 ``choose``).
+
+    *branches* is a list of dicts, each with:
+
+    - ``"actions"`` — an action spec or list of specs to run if the branch wins;
+    - ``"guard"`` (optional) — a callable ``(context, event)``, a registered
+      guard name, or a composable guard (``and_``/``or_``/``not_``).  A branch
+      with no guard always matches, so it acts as a default/``else`` branch.
+
+    Only the first matching branch runs; the rest are skipped.  Guards see the
+    current ``context`` and ``event`` but not the configuration, so ``stateIn``
+    is not supported inside a ``choose`` branch.
+
+    Example::
+
+        from xstate import choose, assign
+
+        choose([
+            {"guard": lambda c, e: c["count"] > 10, "actions": assign({"big": True})},
+            {"guard": "isMedium", "actions": [assign({"medium": True}), "notify"]},
+            {"actions": assign({"small": True})},  # default branch
+        ])
+    """
+    return {"type": CHOOSE_TYPE, "branches": branches}
+
+
+def pure(fn: Callable[..., Any]) -> dict[str, Any]:
+    """Build actions dynamically from ``fn(context, event)`` (v5 ``pure``).
+
+    ``fn`` returns an action spec, a list of specs, or ``None`` (no actions).
+    It must be **pure** — it computes *which* actions to run but performs no
+    side effects itself; the returned actions are then executed in order.
+
+    Example::
+
+        from xstate import pure, send_to
+
+        # Broadcast PING to every actor id listed in context.
+        pure(lambda ctx, ev: [send_to(a, "PING") for a in ctx["actors"]])
+    """
+    return {"type": PURE_TYPE, "fn": fn}

--- a/src/xstate/algorithm.py
+++ b/src/xstate/algorithm.py
@@ -5,7 +5,14 @@ from collections.abc import Iterable, Mapping
 from collections.abc import Set as AbstractSet
 from typing import Any
 
-from xstate.action import ASSIGN_TYPE, RAISE_TYPE, Action
+from xstate.action import (
+    ASSIGN_TYPE,
+    CHOOSE_TYPE,
+    PURE_TYPE,
+    RAISE_TYPE,
+    Action,
+    build_action,
+)
 from xstate.event import Event
 from xstate.exceptions import UnregisteredImplementationError
 from xstate.handlers import GuardReference, invoke_handler
@@ -765,6 +772,38 @@ def execute_transition_content(
     return context
 
 
+def _eval_action_guard(
+    guard: Any,
+    context: Any,
+    event: Event | None,
+    guards_registry: dict | None,
+) -> bool:
+    """Evaluate a ``choose`` branch guard against (context, event).
+
+    Accepts ``None`` (always true), a callable, a registered guard name, or a
+    composable guard.  Configuration-dependent guards (``stateIn``) are not
+    supported here, so they evaluate against an empty configuration.
+    """
+    if guard is None:
+        return True
+    registry = guards_registry or {}
+    resolved = guard
+    if isinstance(resolved, str):
+        resolved = registry.get(resolved)
+        if resolved is None:
+            raise UnregisteredImplementationError(
+                f"choose branch references guard '{guard}' but it is not "
+                "implemented. Pass it via Machine(config, guards={...})."
+            )
+    from xstate.guards import _ComposableGuard
+    from xstate.handlers import HandlerAdapter
+
+    inner = resolved.fn if isinstance(resolved, HandlerAdapter) else resolved
+    if isinstance(inner, _ComposableGuard):
+        return bool(inner._call(context, event, registry, None))
+    return bool(invoke_handler(resolved, context, event))
+
+
 def execute_content(
     action: Action,
     actions: list[Action],
@@ -776,6 +815,28 @@ def execute_content(
         internal_queue.append(Event(action.data.get("event", "")))
     elif action.type == ASSIGN_TYPE:
         context = _apply_assignment(action, context, event)
+    elif action.type == CHOOSE_TYPE:
+        guards_registry = action.data.get("_guards", {})
+        for branch in action.data.get("branches", []):
+            if _eval_action_guard(
+                branch.get("guard"), context, event, guards_registry
+            ):
+                for sub in branch.get("actions", []):
+                    context = execute_content(
+                        sub, actions, internal_queue, context, event
+                    )
+                break
+    elif action.type == PURE_TYPE:
+        fn = action.data.get("fn")
+        registry = action.data.get("_actions", {})
+        result = invoke_handler(fn, context, event)
+        if result is not None:
+            specs = result if isinstance(result, list) else [result]
+            for spec in specs:
+                sub = build_action(spec, registry)
+                context = execute_content(
+                    sub, actions, internal_queue, context, event
+                )
     else:
         actions.append(action)
     return context

--- a/src/xstate/config_parser.py
+++ b/src/xstate/config_parser.py
@@ -3,7 +3,13 @@ from __future__ import annotations
 import warnings
 from typing import Any, Literal, cast
 
-from xstate.action import ASSIGN_TYPE, Action, build_action
+from xstate.action import (
+    ASSIGN_TYPE,
+    CHOOSE_TYPE,
+    PURE_TYPE,
+    Action,
+    build_action,
+)
 from xstate.exceptions import InvalidConfigError
 from xstate.handlers import GuardReference, adapt_handler
 from xstate.state_node import StateNode
@@ -426,6 +432,12 @@ class StateNodeConfigParser:
                     for key, value in assignment.items()
                 }
             action.data["_context_adapter"] = self.machine.context_adapter
+        elif action.type == CHOOSE_TYPE:
+            self._adapt_choose(action, path)
+        elif action.type == PURE_TYPE:
+            # Returned actions are built lazily at execution time; stash the
+            # registry so string names / inline callables can be resolved then.
+            action.data["_actions"] = self.machine.actions
         elif callable(action.type):
             action.type = adapt_handler(
                 action.type,
@@ -434,6 +446,31 @@ class StateNodeConfigParser:
                 path=path,
             )
         return action
+
+    def _adapt_choose(self, action: Action, path: str) -> None:
+        raw_branches = action.data.get("branches") or []
+        branches: list[dict[str, Any]] = []
+        for index, raw_branch in enumerate(raw_branches):
+            branch_path = self._path(path, index)
+            if not isinstance(raw_branch, dict):
+                raise InvalidConfigError(
+                    f"{branch_path}: each choose branch must be a dict with "
+                    f"'actions' (and optional 'guard'), got {type(raw_branch)!r}."
+                )
+            guard = raw_branch.get("guard", raw_branch.get("cond"))
+            if callable(guard):
+                guard = adapt_handler(
+                    guard,
+                    kind="guard",
+                    strict=self.machine.strict,
+                    path=self._path(branch_path, "guard"),
+                )
+            sub_actions = self._build_actions(
+                raw_branch.get("actions"), self._path(branch_path, "actions")
+            )
+            branches.append({"guard": guard, "actions": sub_actions})
+        action.data["branches"] = branches
+        action.data["_guards"] = self.machine.guards
 
     def _resolve_targets(
         self, source: StateNode, target_spec: Any, path: str

--- a/tests/test_choose_pure.py
+++ b/tests/test_choose_pure.py
@@ -1,0 +1,468 @@
+"""Tests for choose() and pure() higher-order actions (0.7.0).
+
+`choose` runs the actions of the first branch whose guard passes.
+`pure` builds a list of actions from (context, event) with no side effects of
+its own. Both expand into sub-actions executed in order through the engine.
+"""
+
+import pytest
+
+from xstate import (
+    Machine,
+    and_,
+    assign,
+    choose,
+    create_actor,
+    pure,
+    raise_,
+)
+
+# ---------------------------------------------------------------------------
+# choose — branch selection
+# ---------------------------------------------------------------------------
+
+
+def _size_machine(guards=None):
+    return Machine(
+        {
+            "id": "m",
+            "initial": "a",
+            "context": {"n": 5},
+            "states": {
+                "a": {
+                    "on": {
+                        "GO": {
+                            "target": "b",
+                            "actions": [
+                                choose(
+                                    [
+                                        {
+                                            "guard": lambda c, e: c["n"] > 10,
+                                            "actions": assign({"size": "big"}),
+                                        },
+                                        {
+                                            "guard": "isMedium",
+                                            "actions": assign({"size": "medium"}),
+                                        },
+                                        {"actions": assign({"size": "small"})},
+                                    ]
+                                )
+                            ],
+                        }
+                    }
+                },
+                "b": {},
+            },
+        },
+        guards=guards or {"isMedium": lambda c, e: c["n"] > 3},
+    )
+
+
+def test_choose_picks_middle_branch():
+    actor = create_actor(_size_machine()).start()  # n == 5
+    actor.send("GO")
+    assert actor.get_snapshot().context["size"] == "medium"
+
+
+def test_choose_picks_first_branch():
+    machine = Machine(
+        {
+            "id": "m",
+            "initial": "a",
+            "context": {"n": 99},
+            "states": {
+                "a": {
+                    "on": {
+                        "GO": {
+                            "target": "b",
+                            "actions": [
+                                choose(
+                                    [
+                                        {
+                                            "guard": lambda c, e: c["n"] > 10,
+                                            "actions": assign({"size": "big"}),
+                                        },
+                                        {"actions": assign({"size": "small"})},
+                                    ]
+                                )
+                            ],
+                        }
+                    }
+                },
+                "b": {},
+            },
+        }
+    )
+    actor = create_actor(machine).start()
+    actor.send("GO")
+    assert actor.get_snapshot().context["size"] == "big"
+
+
+def test_choose_falls_through_to_default_branch():
+    machine = Machine(
+        {
+            "id": "m",
+            "initial": "a",
+            "context": {"n": 1},
+            "states": {
+                "a": {
+                    "on": {
+                        "GO": {
+                            "target": "b",
+                            "actions": [
+                                choose(
+                                    [
+                                        {
+                                            "guard": lambda c, e: c["n"] > 10,
+                                            "actions": assign({"size": "big"}),
+                                        },
+                                        {"actions": assign({"size": "small"})},
+                                    ]
+                                )
+                            ],
+                        }
+                    }
+                },
+                "b": {},
+            },
+        }
+    )
+    actor = create_actor(machine).start()
+    actor.send("GO")
+    assert actor.get_snapshot().context["size"] == "small"
+
+
+def test_choose_runs_only_first_match():
+    machine = Machine(
+        {
+            "id": "m",
+            "initial": "a",
+            "context": {"hits": 0},
+            "states": {
+                "a": {
+                    "on": {
+                        "GO": {
+                            "target": "b",
+                            "actions": [
+                                choose(
+                                    [
+                                        {
+                                            "guard": lambda c, e: True,
+                                            "actions": assign(
+                                                {"hits": lambda c, e: c["hits"] + 1}
+                                            ),
+                                        },
+                                        {
+                                            "guard": lambda c, e: True,
+                                            "actions": assign(
+                                                {"hits": lambda c, e: c["hits"] + 10}
+                                            ),
+                                        },
+                                    ]
+                                )
+                            ],
+                        }
+                    }
+                },
+                "b": {},
+            },
+        }
+    )
+    actor = create_actor(machine).start()
+    actor.send("GO")
+    assert actor.get_snapshot().context["hits"] == 1
+
+
+def test_choose_no_match_runs_nothing():
+    machine = Machine(
+        {
+            "id": "m",
+            "initial": "a",
+            "context": {"touched": False},
+            "states": {
+                "a": {
+                    "on": {
+                        "GO": {
+                            "target": "b",
+                            "actions": [
+                                choose(
+                                    [
+                                        {
+                                            "guard": lambda c, e: False,
+                                            "actions": assign({"touched": True}),
+                                        }
+                                    ]
+                                )
+                            ],
+                        }
+                    }
+                },
+                "b": {},
+            },
+        }
+    )
+    actor = create_actor(machine).start()
+    actor.send("GO")
+    assert actor.get_snapshot().context["touched"] is False
+
+
+def test_choose_with_composable_guard():
+    machine = Machine(
+        {
+            "id": "m",
+            "initial": "a",
+            "context": {"x": True, "y": True},
+            "states": {
+                "a": {
+                    "on": {
+                        "GO": {
+                            "target": "b",
+                            "actions": [
+                                choose(
+                                    [
+                                        {
+                                            "guard": and_("isX", "isY"),
+                                            "actions": assign({"both": True}),
+                                        },
+                                        {"actions": assign({"both": False})},
+                                    ]
+                                )
+                            ],
+                        }
+                    }
+                },
+                "b": {},
+            },
+        },
+        guards={"isX": lambda c, e: c["x"], "isY": lambda c, e: c["y"]},
+    )
+    actor = create_actor(machine).start()
+    actor.send("GO")
+    assert actor.get_snapshot().context["both"] is True
+
+
+def test_choose_in_entry_action():
+    machine = Machine(
+        {
+            "id": "m",
+            "initial": "a",
+            "context": {"n": 7},
+            "states": {
+                "a": {
+                    "entry": [
+                        choose(
+                            [
+                                {
+                                    "guard": lambda c, e: c["n"] > 5,
+                                    "actions": assign({"label": "high"}),
+                                },
+                                {"actions": assign({"label": "low"})},
+                            ]
+                        )
+                    ]
+                },
+            },
+        }
+    )
+    actor = create_actor(machine).start()
+    assert actor.get_snapshot().context["label"] == "high"
+
+
+def test_choose_unknown_guard_raises():
+    machine = Machine(
+        {
+            "id": "m",
+            "initial": "a",
+            "context": {},
+            "states": {
+                "a": {
+                    "on": {
+                        "GO": {
+                            "actions": [
+                                choose([{"guard": "missing", "actions": []}])
+                            ]
+                        }
+                    }
+                },
+            },
+        }
+    )
+    actor = create_actor(machine).start()
+    with pytest.raises(Exception, match="missing"):
+        actor.send("GO")
+
+
+def test_choose_invalid_branch_raises():
+    from xstate.exceptions import InvalidConfigError
+
+    with pytest.raises(InvalidConfigError, match="each choose branch must be a dict"):
+        Machine(
+            {
+                "id": "m",
+                "initial": "a",
+                "states": {"a": {"entry": [choose(["not-a-dict"])]}},
+            }
+        )
+
+
+# ---------------------------------------------------------------------------
+# pure — dynamic action lists
+# ---------------------------------------------------------------------------
+
+
+def test_pure_returns_single_action():
+    machine = Machine(
+        {
+            "id": "m",
+            "initial": "a",
+            "context": {"items": [1, 2, 3]},
+            "states": {
+                "a": {
+                    "on": {
+                        "GO": {
+                            "target": "b",
+                            "actions": [
+                                pure(lambda c, e: assign({"total": sum(c["items"])}))
+                            ],
+                        }
+                    }
+                },
+                "b": {},
+            },
+        }
+    )
+    actor = create_actor(machine).start()
+    actor.send("GO")
+    assert actor.get_snapshot().context["total"] == 6
+
+
+def test_pure_returns_list_of_actions():
+    machine = Machine(
+        {
+            "id": "m",
+            "initial": "a",
+            "context": {"a": 0, "b": 0},
+            "states": {
+                "a": {
+                    "on": {
+                        "GO": {
+                            "target": "b",
+                            "actions": [
+                                pure(
+                                    lambda c, e: [
+                                        assign({"a": 1}),
+                                        assign({"b": 2}),
+                                    ]
+                                )
+                            ],
+                        }
+                    }
+                },
+                "b": {},
+            },
+        }
+    )
+    actor = create_actor(machine).start()
+    actor.send("GO")
+    snap = actor.get_snapshot()
+    assert snap.context["a"] == 1
+    assert snap.context["b"] == 2
+
+
+def test_pure_returns_none_runs_nothing():
+    machine = Machine(
+        {
+            "id": "m",
+            "initial": "a",
+            "context": {"touched": False},
+            "states": {
+                "a": {
+                    "on": {
+                        "GO": {
+                            "target": "b",
+                            "actions": [pure(lambda c, e: None)],
+                        }
+                    }
+                },
+                "b": {},
+            },
+        }
+    )
+    actor = create_actor(machine).start()
+    actor.send("GO")
+    assert actor.get_snapshot().context["touched"] is False
+
+
+def test_pure_side_effect_action_runs():
+    calls = []
+    machine = Machine(
+        {
+            "id": "m",
+            "initial": "a",
+            "context": {},
+            "states": {
+                "a": {
+                    "on": {
+                        "GO": {
+                            "target": "b",
+                            "actions": [pure(lambda c, e: "notify")],
+                        }
+                    }
+                },
+                "b": {},
+            },
+        },
+        actions={"notify": lambda: calls.append("notified")},
+    )
+    actor = create_actor(machine).start()
+    actor.send("GO")
+    assert calls == ["notified"]
+
+
+def test_pure_can_raise_event():
+    machine = Machine(
+        {
+            "id": "m",
+            "initial": "a",
+            "context": {"chained": False},
+            "states": {
+                "a": {
+                    "on": {
+                        "GO": {
+                            "target": "b",
+                            "actions": [pure(lambda c, e: raise_("NEXT"))],
+                        }
+                    }
+                },
+                "b": {
+                    "on": {
+                        "NEXT": {
+                            "target": "c",
+                            "actions": assign({"chained": True}),
+                        }
+                    }
+                },
+                "c": {},
+            },
+        }
+    )
+    actor = create_actor(machine).start()
+    actor.send("GO")
+    snap = actor.get_snapshot()
+    assert snap.value == "c"
+    assert snap.context["chained"] is True
+
+
+def test_pure_in_entry_action():
+    machine = Machine(
+        {
+            "id": "m",
+            "initial": "a",
+            "context": {"ready": False},
+            "states": {
+                "a": {"entry": [pure(lambda c, e: assign({"ready": True}))]},
+            },
+        }
+    )
+    actor = create_actor(machine).start()
+    assert actor.get_snapshot().context["ready"] is True


### PR DESCRIPTION
## Summary

Third **0.7.0** feature — XState v5's conditional/dynamic action primitives, **`choose`** and
**`pure`**. Both are *higher-order* actions: they expand into other actions at execution time.

```python
from xstate import choose, pure, assign, send_to

# choose: run the first branch whose guard passes (guardless branch = default)
choose([
    {"guard": lambda c, e: c["count"] > 10, "actions": assign({"size": "big"})},
    {"guard": "isMedium", "actions": [assign({"size": "medium"}), "notify"]},
    {"actions": assign({"size": "small"})},
])

# pure: build the action list dynamically from (context, event)
pure(lambda c, e: [send_to(a, "PING") for a in c["actors"]])
```

## How it works

Both resolve inside `algorithm.execute_content` — the single dispatch point every entry/exit/
transition action already flows through — so their nested `assign` / `raise_` / `send` / side-effect
sub-actions run **in declared order through the engine**, exactly like top-level actions. That means
`choose`/`pure` work identically in `entry`, `exit`, and transition `actions` lists, and a `pure`
that returns `raise_("NEXT")` correctly drives the next microstep.

## What changed

| File | Change |
|------|--------|
| `src/xstate/action.py` | `CHOOSE_TYPE` / `PURE_TYPE` markers + `choose()` / `pure()` creators |
| `src/xstate/config_parser.py` | `_adapt_action` builds + adapts each `choose` branch's sub-actions and binds its guard at parse time; stamps the guards/actions registries so names resolve at run time. `pure` stores the actions registry for lazy build. |
| `src/xstate/algorithm.py` | `_eval_action_guard` helper; `execute_content` expands `CHOOSE`/`PURE` into sub-actions (recursively) |
| `src/xstate/__init__.py` | Export `choose`, `pure` |
| `tests/test_choose_pure.py` | 15 new tests |
| `CLAUDE.md` | Record `choose`/`pure` in the "working" feature list |

## Design notes

- **Guards reuse the existing resolution path**: `choose` branch guards accept a callable, a
  registered guard name, or a composable guard (`and_`/`or_`/`not_`) — resolved the same way as
  transition guards. **Limitation**: branch guards see `(context, event)` but not the configuration,
  so `stateIn` is not supported inside a `choose` branch (documented in the `choose` docstring and
  CLAUDE.md).
- **`pure` returns specs, not pre-built actions**: the returned spec/list is built at run time with
  the machine's actions registry, so string names, action-creator dicts, and inline callables all
  work; returning `None` runs nothing.
- **No SCXML-core signature change**: only two new `elif` branches in `execute_content` for the new
  action types; the existing `RAISE` / `ASSIGN` / else paths are untouched.

## Test plan

- [x] `python3 -m pytest tests/ --ignore=tests/test_scxml.py` → **371 passed** (15 new), 0 failures
- [x] `ruff check src/ tests/` → All checks passed
- [x] `mypy src/xstate/` → Success: no issues found in 21 source files
- [x] **SCXML**: `tests/test_scxml.py` → **53 failed, identical to master** (pre-existing; the
      `test-framework` submodule isn't initialized in this environment). New action types don't
      appear in SCXML tests, so there is no conformance regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5AJUvQDU2YYNtWWUD54ML)_