### PR TITLE
Prepare 0.7.0 release readiness

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -19,13 +19,29 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry
-        run: pip install "poetry>=2.0"
+        run: python -m pip install "poetry>=2.0,<3.0"
       - name: Install dependencies
         run: poetry install
       - name: Run tests
         run: poetry run pytest tests/ --ignore=tests/test_scxml.py --cov --cov-report=xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
+  scxml-smoke:
+    name: SCXML smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install Poetry
+        run: python -m pip install "poetry>=2.0,<3.0"
+      - name: Install dependencies
+        run: poetry install
+      - name: Run SCXML smoke suite
+        run: poetry run python -m pytest tests/test_scxml.py -m scxml_ci
   code-quality:
     strategy:
       fail-fast: false
@@ -41,7 +57,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry
-        run: pip install "poetry>=2.0"
+        run: python -m pip install "poetry>=2.0,<3.0"
       - name: Install dependencies
         run: poetry install
       - name: Check formatting

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,8 @@ jobs:
         run: poetry check --lock
       - name: Run tests
         run: poetry run pytest tests/ --ignore=tests/test_scxml.py
+      - name: Run SCXML smoke suite
+        run: poetry run python -m pytest tests/test_scxml.py -m scxml_ci
       - name: Check formatting
         run: poetry run ruff format --check src/ tests/
       - name: Run lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ run-to-completion execution core.
 - License: MIT
 - Python: 3.13+
 - Runtime dependencies: none
-- Current status: alpha, version `0.6.0`
+- Current status: alpha, version `0.7.0`
 
 The central bet is simple: charts designed in Stately or shared with a
 JavaScript frontend should load directly as Python `dict` / JSON data, with
@@ -54,6 +54,7 @@ Working:
 - Hierarchical, compound, parallel, final, and history states.
 - Entry, exit, transition actions, `assign`, `raise_`, `send`, `cancel`,
   `send_parent`, and `send_to`.
+- Higher-order action helpers with `choose(...)` and `pure(...)`.
 - Guards with canonical XState v5 `guard`; legacy `cond` remains compatible and
   emits deprecation warnings where appropriate.
 - `always`, `onDone`, `after`, delayed sends, named delays, and invoke
@@ -68,10 +69,8 @@ Working:
 - XState v5 alignment: `guard`, `output`, `always`, `MachineSnapshot`,
   `state.matches(...)`, `state.can(...)`, and `setup(...).create_machine(...)`.
 - XState snapshot queries: `tags`, `meta`, `state.has_tag(...)`,
-  `state.hasTag(...)`, `state_in(...)`, and `stateIn(...)` are present on the
-  0.7.0 branch.
-- Dependency-free Mermaid diagram export via `to_mermaid(machine)` is present
-  on the 0.7.0 branch.
+  `state.hasTag(...)`, `state_in(...)`, and `stateIn(...)`.
+- Dependency-free Mermaid diagram export via `to_mermaid(machine)`.
 - Handler adaptation through `HandlerArgs`, with legacy callable forms still
   supported at the public `Machine(config, ...)` boundary.
 - Public snapshot immutability: configuration is a `frozenset`, actions are a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented here.
 
+## 0.7.0 - 2026-07-01
+
+### Added
+
+- Added active snapshot tags and metadata: `state.tags`, read-only
+  `state.meta`, `state.has_tag(...)`, and the XState-compatible
+  `state.hasTag(...)` alias.
+- Added reusable current-state guard helpers via `state_in(...)` and
+  `stateIn(...)`.
+- Added higher-order action helpers: `choose(...)` for guarded action branch
+  selection and `pure(...)` for dynamically computed action lists.
+- Added dependency-free Mermaid `stateDiagram-v2` export with
+  `to_mermaid(machine)`.
+
 ## 0.6.0 - 2026-06-28
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ The critical execution order is: `main_event_loop` → `microstep` → `main_eve
 
 ---
 
-## Current state (0.6.0 release-ready, 0.7.0 branch in progress)
+## Current state (0.7.0 release-ready)
 
 **Working:**
 - Hierarchical (compound) states
@@ -93,9 +93,9 @@ The critical execution order is: `main_event_loop` → `microstep` → `main_eve
   `setup(guards=..., actions=..., delays=..., actors=...).create_machine(config)`
 - **Snapshot serialization** (0.6.0, `from xstate import serialize_snapshot, deserialize_snapshot`)
   — persist and restore State; `create_actor(machine, snapshot=...)` for round-trip replay
-- **Snapshot queries** (0.7.0 branch) — active `tags`, read-only `meta`,
+- **Snapshot queries** (0.7.0) — active `tags`, read-only `meta`,
   `state.has_tag(...)`, `state.hasTag(...)`, and `state_in(...)` / `stateIn(...)`
-- **Mermaid export** (0.7.0 branch, `from xstate import to_mermaid`) —
+- **Mermaid export** (0.7.0, `from xstate import to_mermaid`) —
   dependency-free `stateDiagram-v2` text generation
 - **State tags** (0.7.0) — declare `tags: ["loading"]` (or a single string) on any state node;
   query the snapshot with `state.has_tag("loading")` / `state.hasTag(...)` or read the aggregated
@@ -129,7 +129,7 @@ boundary.
 | 0.4.0 | v5 config alignment | Rename `cond`→`guard`, `data`→`output`, `always:`, single-object handler signatures, MachineSnapshot |
 | 0.5.0 | Actor model | `create_actor`, actor system, `from_promise`/`from_callback`, asyncio |
 | 0.6.0 | Setup & parity | `setup()`, composable guards (`and_`/`or_`/`not_`), snapshot serialization |
-| 0.7.0 | Next parity | State `tags` + `hasTag()`, `stateIn` guard, Mermaid diagrams; next: `choose`/`pure` actions, Graphviz diagrams, TypedDict config schemas |
+| 0.7.0 | Next parity | State `tags` + `hasTag()`, `stateIn` guard, `choose`/`pure` actions, Mermaid diagrams |
 | 0.8.0+ | Internal refactor | `StateNodeConfigParser` factory, opt-in immutable `context_factory`, `ParamSpec` handler typing |
 
 The differentiating niche: **XState / Stately.ai JSON compatibility** — neither `transitions`
@@ -167,19 +167,19 @@ Targets drawn from XState v5 (https://stately.ai/docs/xstate) and the Python sta
 landscape (`transitions`, `python-statemachine`, `Sismic`). Ranked by parity value × differentiation.
 
 **XState v5 parity gaps:**
-- **State `tags`** — ✅ on 0.7.0 branch: `tags: ["loading"]` in config; `state.has_tag("loading")` and `state.hasTag("loading")` on `MachineSnapshot`.
-- **`choose` action** — conditional action selection (run the first branch whose guard passes).
-- **`pure` action** — a function returning a list of actions to run, with no side effects of its own.
-- **`stateIn` guard** — ✅ on 0.7.0 branch: user-facing guard over the current configuration, exposed as `state_in(...)` and `stateIn(...)`.
+- **State `tags`** — ✅ in 0.7.0: `tags: ["loading"]` in config; `state.has_tag("loading")` and `state.hasTag("loading")` on `MachineSnapshot`.
+- **`choose` action** — ✅ in 0.7.0: conditional action selection that runs the first branch whose guard passes.
+- **`pure` action** — ✅ in 0.7.0: a function returning a list of actions to run, with no side effects of its own.
+- **`stateIn` guard** — ✅ in 0.7.0: user-facing guard over the current configuration, exposed as `state_in(...)` and `stateIn(...)`.
 - **`enqueueActions`** — batch/queue actions imperatively inside an action body.
 - **Transition `reenter: true`** — re-enter the source state on a self-transition (vs. internal).
 - **`stopChild` action** — explicitly stop a spawned/invoked actor.
 - **Dynamic `sendTo` targets** — `to=` resolved from `(context, event)`.
-- **Machine / state `meta`** — ✅ on 0.7.0 branch: per-node metadata surfaced via read-only `state.meta`.
+- **Machine / state `meta`** — ✅ in 0.7.0: per-node metadata surfaced via read-only `state.meta`.
 - **Partial event descriptors / wildcard** — `on: {"UPDATE.*": ...}` style matching.
 
 **Differentiators worth owning (gaps in the Python field):**
-- **Mermaid / Graphviz diagram export** — Mermaid export is ✅ on 0.7.0 branch via `to_mermaid(machine)`; Graphviz remains deferred.
+- **Mermaid / Graphviz diagram export** — Mermaid export is ✅ in 0.7.0 via `to_mermaid(machine)`; Graphviz remains deferred.
 - **`hasTag` / `can` / `matches` snapshot ergonomics** — `has_tag` / `hasTag`, `can`, and `matches` are present.
 - **Observer pattern** — `python-statemachine`'s `add_observer`; we have `subscribe`, consider a
   multi-callback observer protocol with entry/exit hooks.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <p align="center">
   <a href="https://github.com/JovaniPink/xstate-python/actions/workflows/pull_request.yaml"><img alt="Tests and code quality" src="https://github.com/JovaniPink/xstate-python/actions/workflows/pull_request.yaml/badge.svg"></a>
   <img alt="Python" src="https://img.shields.io/badge/python-3.13%2B-blue">
-  <img alt="Status" src="https://img.shields.io/badge/status-alpha%20(0.6.0)-orange">
+  <img alt="Status" src="https://img.shields.io/badge/status-alpha%20(0.7.0)-orange">
   <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-green"></a>
 </p>
 
@@ -50,7 +50,7 @@ functions, delay values, and actor logic.
 
 ## Installation
 
-The `0.6.0` package metadata is ready for release. Until the GitHub release
+The `0.7.0` package metadata is ready for release. Until the GitHub release
 publishes to PyPI, install from source:
 
 ```bash
@@ -342,6 +342,7 @@ machine = Machine(
 - Entry, exit, and transition actions
 - Named and inline guards
 - Context and `assign`
+- Higher-order actions with `choose(...)` and `pure(...)`
 - Eventless transitions via `always`
 - Final states and `onDone`
 - Shallow and deep history states
@@ -400,6 +401,8 @@ from xstate import (
     send_to,
     cancel,
     raise_,
+    choose,
+    pure,
     state_in,
     stateIn,
     to_mermaid,
@@ -443,10 +446,10 @@ poetry run ruff check src/ tests/
 
 | Area | Current state |
 |---|---|
-| PyPI release | `0.6.0` release-readiness is complete; publish via GitHub Release |
+| PyPI release | `0.7.0` release-readiness is complete; publish via GitHub Release |
 | XState v5 setup | `setup(...).create_machine(...)` and composable guards are present |
-| Snapshot queries | `tags`, `meta`, `has_tag`/`hasTag`, and `state_in`/`stateIn` are present on the 0.7.0 branch |
-| Diagrams | Dependency-free Mermaid export is present on the 0.7.0 branch |
+| Snapshot queries | `tags`, `meta`, `has_tag`/`hasTag`, and `state_in`/`stateIn` are present |
+| Diagrams | Dependency-free Mermaid export is present |
 | Async | `AsyncInterpreter`, async actors, `from_observable`, and `to_promise` are present |
 | SCXML | XML import works; safe Boolean cond subset works; `more-parallel` conformance remains open |
 | Persistence | Snapshot serialization and restore helpers are present |

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -2,7 +2,7 @@
 
 Research snapshot: June 2026. External ecosystem numbers are approximate and
 should be refreshed before publication or fundraising use. Repo capability notes
-reflect the current `master` branch after the 0.6.0 release-readiness work.
+reflect the current `master` branch after the 0.7.0 release-readiness work.
 
 ## Product Thesis
 
@@ -21,7 +21,7 @@ bridge between XState's JSON ecosystem and Python backends.
 
 | Area | Status |
 |---|---|
-| Packaging | Project metadata is modernized for Python 3.13+ and ready for the 0.6.0 PyPI release |
+| Packaging | Project metadata is modernized for Python 3.13+ and ready for the 0.7.0 PyPI release |
 | Core transition API | `Machine(config).transition(state, event)` |
 | XState JSON | Native Python dict / JSON-compatible config boundary |
 | Parser architecture | Typed schema + normalization/parser layer |
@@ -29,8 +29,8 @@ bridge between XState's JSON ecosystem and Python backends.
 | Setup API | `setup(...).create_machine(...)` exists for stricter named implementations |
 | Context policy | Default deep-copy adapter plus immutable dataclass adapter |
 | Snapshots | `MachineSnapshot = State`; immutable public containers |
-| Snapshot queries | Active `tags`, `meta`, `has_tag`/`hasTag`, and `state_in`/`stateIn` guard helpers are present on the 0.7.0 branch |
-| Diagrams | Dependency-free Mermaid `stateDiagram-v2` export is present on the 0.7.0 branch |
+| Snapshot queries | Active `tags`, `meta`, `has_tag`/`hasTag`, and `state_in`/`stateIn` guard helpers are present |
+| Diagrams | Dependency-free Mermaid `stateDiagram-v2` export is present |
 | Sync runtime | `Interpreter` with RTC queue, subscriptions, delayed transitions, and lock-serialized timer sends |
 | Async runtime | `AsyncInterpreter` with async start/send/stop, awaitable actions, and event-loop timers |
 | Actor model | `create_actor`, `ActorSystem`, spawn, parent/child tree, `send_parent`, `send_to` |
@@ -42,6 +42,7 @@ bridge between XState's JSON ecosystem and Python backends.
 
 - Hierarchical, parallel, final, and history states.
 - Entry/exit/transition actions and `assign`.
+- Higher-order action helpers with `choose(...)` and `pure(...)`.
 - Guards via `guard` or legacy `cond`.
 - Eventless transitions via `always` or legacy empty-event syntax.
 - Delayed transitions via `after`, numeric or named delays.
@@ -74,7 +75,7 @@ JavaScript and wanting the same machine shape in Python services.
 
 | Priority | Work |
 |---|---|
-| High | Publish 0.6.0 to PyPI as `xstate` |
+| High | Publish 0.7.0 to PyPI as `xstate` |
 | High | Document the public API by concept: machines, guards/actions, context, interpreter, actors, async, SCXML |
 | High | Fix the remaining SCXML `more-parallel` conformance cases |
 | Medium | Document snapshot persistence and restore helpers |
@@ -86,7 +87,7 @@ JavaScript and wanting the same machine shape in Python services.
 
 | Metric | Near-term target |
 |---|---|
-| PyPI release | `pip install xstate` works after the 0.6.0 GitHub Release |
+| PyPI release | `pip install xstate` works after the 0.7.0 GitHub Release |
 | Primary test count | Maintain 300+ focused tests |
 | SCXML pass rate | Resolve known `more-parallel` group |
 | Docs | README plus concept docs for the main public APIs |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,14 +1,14 @@
 # Python State Machine Library Comparison
 
 Research snapshot: June 2026. Competitor figures are intentionally approximate;
-the xstate-python column reflects the current `master` branch after the 0.6.0
+the xstate-python column reflects the current `master` branch after the 0.7.0
 release-readiness work.
 
 ## Feature Matrix
 
 | Feature | **transitions** | **python-statemachine** | **xstate-python** | **xstate-statemachine** | **Sismic** | **Automat** |
 |---|---|---|---|---|---|---|
-| Status | Mature / active | Mature / active | Alpha / 0.6.0 release-ready | Small active project | Mature niche | Mature focused FSM |
+| Status | Mature / active | Mature / active | Alpha / 0.7.0 release-ready | Small active project | Mature niche | Mature focused FSM |
 | Python support | Broad legacy support | Modern Python | **3.13+** | Modern Python | Modern Python | Modern Python |
 | XState JSON | No | No | **Yes, native** | Yes | No | No |
 | SCXML algorithm | No | Yes | **Yes, partial conformance** | Partial | Yes | No |
@@ -49,6 +49,7 @@ structure with a JavaScript/XState frontend or a Stately-authored design.
   actor actions.
 - Guards as named implementations, inline callables, or strict `setup`
   handlers.
+- Higher-order `choose(...)` and `pure(...)` action helpers.
 - Context updates through `assign`, with deep-copy default isolation and an
   immutable dataclass adapter.
 - Eventless transitions, final states, `onDone`, shallow/deep history, and
@@ -61,9 +62,8 @@ structure with a JavaScript/XState frontend or a Stately-authored design.
   and `invoke` reconciliation.
 - Snapshot serialization and restoration helpers for persistence flows.
 - Active snapshot `tags`, `meta`, `has_tag`/`hasTag`, and
-  `state_in`/`stateIn` guard helpers on the 0.7.0 branch.
-- Dependency-free Mermaid diagram export via `to_mermaid(machine)` on the
-  0.7.0 branch.
+  `state_in`/`stateIn` guard helpers.
+- Dependency-free Mermaid diagram export via `to_mermaid(machine)`.
 - SCXML XML import with a safe Boolean cond subset: `true`, `false`, `!`, `&&`,
   `||`, and parentheses.
 
@@ -71,10 +71,10 @@ structure with a JavaScript/XState frontend or a Stately-authored design.
 
 | Gap | Notes |
 |---|---|
-| PyPI release | 0.6.0 packaging metadata and release workflow are ready; publish via GitHub Release. |
+| PyPI release | 0.7.0 packaging metadata and release workflow are ready; publish via GitHub Release. |
 | SCXML conformance | Current full SCXML run is `45 passed`, `8 failed`; remaining failures are the known `more-parallel` cases. |
 | Full ECMAScript cond support | Intentionally not implemented; unsupported SCXML expressions raise `InvalidConfigError`. |
-| Graph/test utilities | Mermaid export exists on the 0.7.0 branch; no graph traversal/test-path helpers yet. |
+| Graph/test utilities | Mermaid export exists; no graph traversal/test-path helpers yet. |
 | Inspector protocol | No `@statelyai/inspect` compatibility yet. |
 
 ## Strategic Position

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,9 @@ minversion = "8.4"
 addopts = "-ra -q"
 testpaths = ["tests"]
 pythonpath = ["src"]
+markers = [
+    "scxml_ci: stable SCXML conformance subset run in GitHub Actions",
+]
 # `async def test_*` are collected and run without a per-test decorator.
 asyncio_mode = "auto"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xstate"
-version = "0.6.0"
+version = "0.7.0"
 description = "Statecharts and state machines for Python, inspired by XState."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/tests/test_scxml.py
+++ b/tests/test_scxml.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from pprint import PrettyPrinter
 
 import pytest
@@ -7,7 +8,7 @@ from xstate.scxml import scxml_to_machine
 
 pp = PrettyPrinter(indent=2)
 
-test_dir = "test-framework/test"
+test_dir = Path(__file__).resolve().parents[1] / "test-framework" / "test"
 
 test_groups: dict[str, list[str]] = {
     "actionSend": [
@@ -62,10 +63,24 @@ test_groups: dict[str, list[str]] = {
     ],
 }
 
+scxml_ci_groups = {
+    "actionSend",
+    "basic",
+    "cond-js",
+    "default-initial-state",
+    "documentOrder",
+    "hierarchy",
+    "hierarchy+documentOrder",
+    "parallel",
+    "parallel+interrupt",
+}
+
 test_files = [
-    (
-        f"{test_dir}/{test_group}/{test_name}.scxml",
-        f"{test_dir}/{test_group}/{test_name}.json",
+    pytest.param(
+        test_dir / test_group / f"{test_name}.scxml",
+        test_dir / test_group / f"{test_name}.json",
+        id=f"{test_group}/{test_name}",
+        marks=pytest.mark.scxml_ci if test_group in scxml_ci_groups else (),
     )
     for test_group, test_names in test_groups.items()
     for test_name in test_names
@@ -79,7 +94,7 @@ def test_scxml(scxml_source, scxml_test_source):
     try:
         state = machine.initial_state
 
-        with open(scxml_test_source) as scxml_test_file:
+        with scxml_test_source.open(encoding="utf-8") as scxml_test_file:
             scxml_test = json.load(scxml_test_file)
 
             for event_test in scxml_test.get("events"):

--- a/tests/test_scxml.py
+++ b/tests/test_scxml.py
@@ -77,7 +77,7 @@ scxml_ci_groups = {
 
 test_files = [
     pytest.param(
-        test_dir / test_group / f"{test_name}.scxml",
+        str(test_dir / test_group / f"{test_name}.scxml"),
         test_dir / test_group / f"{test_name}.json",
         id=f"{test_group}/{test_name}",
         marks=pytest.mark.scxml_ci if test_group in scxml_ci_groups else (),


### PR DESCRIPTION
## Summary

This prepares the repository for the 0.7.0 release by aligning package metadata, release notes, user-facing docs, agent context, and the CI smoke coverage around the current 0.7.0 feature set.

## Release Metadata

- Bumps the package version in `pyproject.toml` from `0.6.0` to `0.7.0`.
- Updates the README status badge, install copy, and roadmap table to describe 0.7.0 as the release-readiness target.
- Updates product/comparison docs and agent context files so the current branch no longer describes 0.7.0 features as branch-only work.

## Changelog And Docs

- Adds a `0.7.0 - 2026-07-01` changelog entry.
- Documents active snapshot `tags`, read-only `meta`, `has_tag(...)` / `hasTag(...)`, and reusable `state_in(...)` / `stateIn(...)` guards.
- Documents higher-order `choose(...)` and `pure(...)` action helpers.
- Documents dependency-free Mermaid export through `to_mermaid(machine)`.
- Adds `choose` and `pure` to the README public API and feature summaries.

## SCXML Smoke CI

- Adds an `scxml_ci` pytest marker for the stable SCXML conformance subset.
- Marks the stable SCXML groups used by CI: `actionSend`, `basic`, `cond-js`, `default-initial-state`, `documentOrder`, `hierarchy`, `hierarchy+documentOrder`, `parallel`, and `parallel+interrupt`.
- Adds a PR workflow `SCXML smoke` job that checks out submodules recursively and runs `poetry run python -m pytest tests/test_scxml.py -m scxml_ci`.
- Adds the same SCXML smoke command to the release workflow.
- Normalizes CI Poetry installation to `python -m pip install "poetry>=2.0,<3.0"`.
- Makes SCXML fixture paths repository-root relative via `pathlib.Path`, so the smoke subset is less sensitive to the current working directory.

## Why

The branch had already implemented the 0.7.0 APIs, but several release-facing docs still framed them as only existing on the 0.7.0 branch. This PR makes the release state coherent and adds a lightweight SCXML CI gate that covers the stable subset without blocking on the known `more-parallel` conformance failures.

## Validation

- `poetry check --lock` - passed.
- `poetry run python -m pytest tests/test_state_queries.py tests/test_tags.py tests/test_state_in_guard.py tests/test_choose_pure.py tests/test_mermaid.py` - 52 passed.
- `poetry run python -m pytest tests/ --ignore=tests/test_scxml.py` - 388 passed, 17 warnings.
- `poetry run python -m pytest tests/test_scxml.py -m scxml_ci` - 40 passed, 13 deselected, 95 warnings.

## Notes

- The SCXML smoke warnings are legacy `cond` deprecation warnings from the SCXML fixture set.
- The full SCXML suite still intentionally excludes the known `more-parallel` failures from this smoke gate.