### PR TITLE
[codex] Refresh agent context for 0.7 master

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ run-to-completion execution core.
 - License: MIT
 - Python: 3.13+
 - Runtime dependencies: none
-- Current status: alpha, version `0.7.0`
+- Current status: alpha, version `0.7.0` (release-ready; PyPI publish pending)
 
 The central bet is simple: charts designed in Stately or shared with a
 JavaScript frontend should load directly as Python `dict` / JSON data, with
@@ -33,12 +33,15 @@ src/xstate/
   action.py             Action constructors and interpreter-owned action types
   event.py              Event wrapper and conversion helpers
   exceptions.py         Custom exception classes
+  guards.py             Composable guards and state_in/stateIn helpers
   handlers.py           HandlerArgs and HandlerAdapter callable adaptation
   context.py            ContextAdapter policies, including dataclass contexts
   interpreter.py        Synchronous runtime, queue, subscriptions, timers
   async_interpreter.py  Asyncio runtime and awaitable action execution
   actor.py              Actor system, create_actor, invoke reconciliation
+  snapshot.py           Snapshot serialization and restoration helpers
   scheduler.py          Clock abstractions
+  mermaid.py            Dependency-free Mermaid diagram export
   scxml.py              SCXML XML to Machine config converter
   setup_api.py          setup(...).create_machine(...) strict API
 ```
@@ -66,10 +69,13 @@ Working:
   actions, event-loop timers, and per-event completion for concurrent sends.
 - Actor model: `create_actor`, `ActorSystem`, `spawn`, `from_promise`,
   `from_callback`, `from_observable`, and `to_promise`.
+- Snapshot serialization and restoration helpers for persistence and replay.
 - XState v5 alignment: `guard`, `output`, `always`, `MachineSnapshot`,
   `state.matches(...)`, `state.can(...)`, and `setup(...).create_machine(...)`.
 - XState snapshot queries: `tags`, `meta`, `state.has_tag(...)`,
   `state.hasTag(...)`, `state_in(...)`, and `stateIn(...)`.
+- Context policies through `ContextAdapter`, the default deep-copy adapter, and
+  `dataclass_context()` for immutable dataclass contexts.
 - Dependency-free Mermaid diagram export via `to_mermaid(machine)`.
 - Handler adaptation through `HandlerArgs`, with legacy callable forms still
   supported at the public `Machine(config, ...)` boundary.
@@ -81,7 +87,9 @@ Working:
 Known gaps:
 
 - Full SCXML conformance still has known `more-parallel` failures.
-- Graph/test helper APIs beyond Mermaid export are future work.
+- Publishing `0.7.0` to PyPI is still a release task after the merged
+  release-readiness work.
+- Graphviz export and graph/test helper APIs beyond Mermaid are future work.
 - SCXML condition support is intentionally not a general JavaScript evaluator.
 
 ## Important Constraints

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,12 @@ src/xstate/
   scheduler.py      Clock abstractions
   scxml.py          SCXML XML → Machine config converter with safe Boolean conds
   setup_api.py      setup(...).create_machine(...) strict API
+  machine.py        Core Machine class and transition entry point
+  interpreter.py    Synchronous runtime, queue, subscriptions, timers
+  async_interpreter.py  Asyncio runtime and awaitable action execution
+  config_parser.py  Parser for StateNode configurations
+  schema.py         TypedDict schemas for Machine, StateNode, Transition, and Invoke configs
+  exceptions.py     Custom exception classes
 ```
 
 `algorithm.py` is the heart of the library. It implements the W3C SCXML algorithm:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,7 +228,7 @@ poetry run python -m pytest tests/test_scxml.py -k cond-js
 poetry run mypy src/xstate/
 
 # Format + lint
-poetry run ruff format --check src/ tests/
+poetry run ruff format src/ tests/
 poetry run ruff check src/ tests/
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,12 +22,18 @@ src/xstate/
   state_node.py     Resolved state hierarchy model
   state.py          Public State / MachineSnapshot snapshots
   algorithm.py      SCXML execution engine (microstep/macrostep, entry/exit sets)
+  action.py         Action constructors and higher-order action helpers
   transition.py     Resolved transition model
+  context.py        ContextAdapter policies, including dataclass contexts
+  event.py          Event wrapper and conversion helpers
   handlers.py       HandlerArgs and HandlerAdapter callable adaptation
   guards.py         Composable guards and state_in/stateIn helpers
+  snapshot.py       Snapshot serialization and restoration helpers
   mermaid.py        Dependency-free Mermaid diagram export
   actor.py          Actor model, create_actor, ActorSystem, actor logic helpers
+  scheduler.py      Clock abstractions
   scxml.py          SCXML XML → Machine config converter with safe Boolean conds
+  setup_api.py      setup(...).create_machine(...) strict API
 ```
 
 `algorithm.py` is the heart of the library. It implements the W3C SCXML algorithm:
@@ -37,15 +43,15 @@ The critical execution order is: `main_event_loop` → `microstep` → `main_eve
 
 ---
 
-## Current state (0.7.0 release-ready)
+## Current state (0.7.0 release-ready on master)
 
 **Working:**
 - Hierarchical (compound) states
 - Parallel states (`type: "parallel"`) — independent regions, broadcast events,
   nested parallel, `onDone` when all regions reach a final state
 - Entry / exit actions
-- Guards / conditions (pure Python): `cond` as a callable `(context, event)` or a
-  string resolved from `Machine(config, guards={...})`
+- Guards / conditions (pure Python): `guard` is canonical; legacy `cond`
+  remains compatible and may emit deprecation warnings
 - Context + `assign` actions (`from xstate import assign`); event payloads reach
   guards/assigners via `event.data` (pass `transition(state, {"type": ..., ...})`)
 - Final states + `onDone` transitions
@@ -93,6 +99,9 @@ The critical execution order is: `main_event_loop` → `microstep` → `main_eve
   `setup(guards=..., actions=..., delays=..., actors=...).create_machine(config)`
 - **Snapshot serialization** (0.6.0, `from xstate import serialize_snapshot, deserialize_snapshot`)
   — persist and restore State; `create_actor(machine, snapshot=...)` for round-trip replay
+- **Context adapters** (0.7.0, `from xstate import dataclass_context`) — default
+  deep-copy snapshot isolation plus `ContextAdapter` / `DataclassContextAdapter`
+  hooks for immutable dataclass contexts
 - **Snapshot queries** (0.7.0) — active `tags`, read-only `meta`,
   `state.has_tag(...)`, `state.hasTag(...)`, and `state_in(...)` / `stateIn(...)`
 - **Mermaid export** (0.7.0, `from xstate import to_mermaid`) —
@@ -129,8 +138,8 @@ boundary.
 | 0.4.0 | v5 config alignment | Rename `cond`→`guard`, `data`→`output`, `always:`, single-object handler signatures, MachineSnapshot |
 | 0.5.0 | Actor model | `create_actor`, actor system, `from_promise`/`from_callback`, asyncio |
 | 0.6.0 | Setup & parity | `setup()`, composable guards (`and_`/`or_`/`not_`), snapshot serialization |
-| 0.7.0 | Next parity | State `tags` + `hasTag()`, `stateIn` guard, `choose`/`pure` actions, Mermaid diagrams |
-| 0.8.0+ | Internal refactor | `StateNodeConfigParser` factory, opt-in immutable `context_factory`, `ParamSpec` handler typing |
+| 0.7.0 | Current parity | State `tags` + `meta`, `hasTag()`, `stateIn` guard, `choose`/`pure` actions, Mermaid diagrams |
+| 0.8.0+ | Next parity + internals | `enqueueActions`, `reenter`, `stopChild`, dynamic `sendTo`, wildcard event descriptors, graph/test helpers, inspector protocol, `ParamSpec` handler typing |
 
 The differentiating niche: **XState / Stately.ai JSON compatibility** — neither `transitions`
 nor `python-statemachine` accepts XState JSON natively.
@@ -139,16 +148,16 @@ nor `python-statemachine` accepts XState JSON natively.
 
 ## Architectural debt (deferred, tracked)
 
-These items came out of an architectural review. Each is intentionally deferred with a
-target version; do not silently "fix" them outside their milestone, because they touch the
-public API or the SCXML core and need the verification gates below.
+These items came out of an architectural review. Do not silently "fix" them
+outside their milestone, because they touch the public API or the SCXML core and
+need the verification gates below.
 
 | # | Item | Where | Status / plan |
 |---|------|-------|---------------|
-| 1 | **Dynamic handler arity** — `algorithm._invoke` / `handlers.invoke_handler` inspect a callable's signature on every call to support 4 calling conventions | `algorithm.py`, `handlers.py` | Short-term approach (signature inspection cached via `functools.lru_cache`) is fine. Moving to a single `Callable[[HandlerArgs], Any]` + `ParamSpec` contract is a **breaking** API change — defer to **0.8.0+** after `setup()` is stable. |
-| 2 | **Parser/model separation** — `StateNode` is already a pure dataclass, but some normalization responsibilities still sit close to the model boundary | `state_node.py`, `config_parser.py` | Master already extracted `config_parser.StateNodeConfigParser`. Finish consolidating raw-config traversal, defaults, and transition normalization in the parser so `StateNode` stays a resolved model. Safe only **after** item 3 (typed inputs). Target **0.8.0+**. |
-| 3 | **`Any` config boundary → TypedDict** — `Machine(config: dict[str, Any])` loses all static checking | `schema.py`, `machine.py` | Master added `schema.py` with `StateNodeConfig`/`TransitionConfig`/`InvokeConfig`/`MachineConfig` TypedDicts. Next: type `Machine(config: MachineConfig)` and enable stricter mypy on `machine.py` progressively. Target **0.7.0**. |
-| 4 | **`deepcopy` context cost** — context is `deepcopy`-ed on each transition | `context.py` | Master added `ContextAdapter` (`DeepCopyContextAdapter`, `DataclassContextAdapter`). Expose the adapter as a documented `context_factory`-style hook so power users opt into immutable/cheaper structures. Target **0.7.0+**. |
+| 1 | **Dynamic handler arity** — legacy callable forms still exist at the public boundary | `algorithm.py`, `handlers.py` | `HandlerAdapter` now selects call mode at machine construction, with `invoke_handler` only as a compatibility shim for opaque callables. Moving to a single `Callable[[HandlerArgs], Any]` + `ParamSpec` contract is still a **breaking** API change; defer to **0.8.0+** and bridge with warnings. |
+| 2 | **Parser/model separation** — `StateNode` is already a pure dataclass, but some normalization responsibilities still sit close to the model boundary | `state_node.py`, `config_parser.py` | `config_parser.StateNodeConfigParser` is already extracted. Continue consolidating raw-config traversal, defaults, and transition normalization in the parser so `StateNode` stays a resolved model. Treat this as **0.8.0+** work and verify parser, transition, and SCXML import coverage. |
+| 3 | **Typed config boundary** — the public `Machine(config, ...)` boundary must still accept ordinary XState JSON-shaped dicts | `schema.py`, `machine.py` | `schema.py` now defines `StateNodeConfig`/`TransitionConfig`/`InvokeConfig`/`MachineConfig`. Future typing work should use those TypedDicts without rejecting plain dict JSON inputs, then tighten mypy progressively. |
+| 4 | **Context copy policy** — default dict contexts are still snapshot-isolated through copies | `context.py`, `machine.py`, `setup_api.py` | Public `ContextAdapter`, `DeepCopyContextAdapter`, `DataclassContextAdapter`, `dataclass_context()`, and `context_adapter=` hooks already exist. Remaining work is documentation and examples, not a parallel `context_factory` API unless a migration is deliberately planned. |
 | 5 | **IIFE lambda binding** — `(lambda e: lambda: self.send(e))(event)` | `interpreter.py` | ✅ **Done** — replaced with `functools.partial(self.send, event)` (0.6.0). |
 
 **Verification gates for any of the above:**
@@ -156,37 +165,40 @@ public API or the SCXML core and need the verification gates below.
   see "Algorithm changes require SCXML test verification" below).
 - Parser/model changes (item 2) must pass parser, transition, and SCXML import coverage; run full
   SCXML conformance only if they alter transition selection or entry/exit semantics.
-- Public-API changes (items 1, 3, 4) must keep the v0.1.0 contract or land in a minor bump
-  with a `DeprecationWarning` bridge, matching how `cond`→`guard` was handled in 0.4.0.
+- Public-API changes (items 1, 3, 4) must keep the stable
+  `Machine(config, ...)` JSON boundary or land in a minor bump with a
+  `DeprecationWarning` bridge, matching how `cond`→`guard` was handled in 0.4.0.
 
 ---
 
-## 0.7.0 feature backlog (research-informed)
+## Post-0.7.0 roadmap notes (research-informed)
 
 Targets drawn from XState v5 (https://stately.ai/docs/xstate) and the Python statechart
 landscape (`transitions`, `python-statemachine`, `Sismic`). Ranked by parity value × differentiation.
 
-**XState v5 parity gaps:**
+**Already on master:**
 - **State `tags`** — ✅ in 0.7.0: `tags: ["loading"]` in config; `state.has_tag("loading")` and `state.hasTag("loading")` on `MachineSnapshot`.
 - **`choose` action** — ✅ in 0.7.0: conditional action selection that runs the first branch whose guard passes.
 - **`pure` action** — ✅ in 0.7.0: a function returning a list of actions to run, with no side effects of its own.
 - **`stateIn` guard** — ✅ in 0.7.0: user-facing guard over the current configuration, exposed as `state_in(...)` and `stateIn(...)`.
+- **Machine / state `meta`** — ✅ in 0.7.0: per-node metadata surfaced via read-only `state.meta`.
+- **Mermaid export** — ✅ in 0.7.0 via `to_mermaid(machine)`.
+
+**Remaining XState v5 parity gaps:**
 - **`enqueueActions`** — batch/queue actions imperatively inside an action body.
 - **Transition `reenter: true`** — re-enter the source state on a self-transition (vs. internal).
 - **`stopChild` action** — explicitly stop a spawned/invoked actor.
 - **Dynamic `sendTo` targets** — `to=` resolved from `(context, event)`.
-- **Machine / state `meta`** — ✅ in 0.7.0: per-node metadata surfaced via read-only `state.meta`.
 - **Partial event descriptors / wildcard** — `on: {"UPDATE.*": ...}` style matching.
 
 **Differentiators worth owning (gaps in the Python field):**
-- **Mermaid / Graphviz diagram export** — Mermaid export is ✅ in 0.7.0 via `to_mermaid(machine)`; Graphviz remains deferred.
+- **Graphviz diagram export** — Mermaid export is present; Graphviz remains deferred.
 - **`hasTag` / `can` / `matches` snapshot ergonomics** — `has_tag` / `hasTag`, `can`, and `matches` are present.
 - **Observer pattern** — `python-statemachine`'s `add_observer`; we have `subscribe`, consider a
   multi-callback observer protocol with entry/exit hooks.
 
-**Process note:** a deep-research workflow over the four comparison libraries was scoped in this
-session (see `deep-research` skill invocation) but not yet run to completion; re-run it before
-locking the final 0.7.0 scope to confirm method signatures and catch anything new upstream.
+**Process note:** 0.7.0 scope is locked on master. Re-run ecosystem research
+before adding new comparative claims or finalizing a 0.8.0 scope.
 
 ---
 
@@ -197,19 +209,21 @@ locking the final 0.7.0 scope to confirm method signatures and catch anything ne
 poetry install
 
 # Run the test suite (primary target — no extras needed)
-python3 -m pytest tests/ --ignore=tests/test_scxml.py
+poetry run python -m pytest tests/ --ignore=tests/test_scxml.py
 
-# Run SCXML tests (needs test-framework submodule and the scxml extra)
+# Run SCXML tests (needs test-framework submodule)
 git submodule update --init
-pip install xstate[scxml]
-python3 -m pytest tests/test_scxml.py
+poetry run python -m pytest tests/test_scxml.py
+
+# Focused SCXML boolean cond subset
+poetry run python -m pytest tests/test_scxml.py -k cond-js
 
 # Type check
-mypy src/xstate/
+poetry run mypy src/xstate/
 
 # Format + lint
-ruff format src/ tests/
-ruff check src/ tests/
+poetry run ruff format --check src/ tests/
+poetry run ruff check src/ tests/
 ```
 
 ---
@@ -237,13 +251,13 @@ Key functions and their SCXML algorithm counterparts:
 - `get_transition_domain` → `getTransitionDomain`
 - `get_proper_ancestors` → `getProperAncestors`
 
-### API surface (v0.1.0 public contract)
+### API surface (stable public contract)
 
 ```python
 from xstate import Machine
 
 # Construct a machine from a Python dict (XState JSON shape)
-machine = Machine(config: dict, actions: dict = {})
+machine = Machine(config, actions={}, guards={}, delays={}, actors={})
 
 # Get the initial state
 state = machine.initial_state   # State(value, configuration, context, actions)
@@ -255,7 +269,8 @@ state = machine.transition(state, "EVENT_NAME")
 state.value   # str for atomic states, dict for compound: {"parent": "child"}
 ```
 
-**Do not break this interface in 0.1.x patches.** API changes go in 0.4.0 (v5 alignment).
+**Do not break this interface.** Additive APIs are fine; breaking changes need
+a deprecation bridge and a clear minor-version migration.
 
 ---
 
@@ -274,8 +289,9 @@ PR #49 on upstream (`auphofBSF/tests/extend_testing_21w38`) was evaluated and in
 **not** adopted. Reason: it welds the codebase to Js2Py (its headline feature is pasting
 JavaScript config), contains Python-3-invalid `raise "<string>"` bugs, and adds 8k lines
 of v4-style code while the maintainer signalled the project should target v5. Its
-**test corpus** (`test_history.py`, `test_state_in.py`) is the valuable artifact and should
-be ported as behavior targets in 0.2.0.
+**test corpus** (`test_history.py`, `test_state_in.py`) is the valuable artifact.
+Some history/state-in behavior is already covered; treat the rest as historical
+reference before porting more tests.
 
 ---
 
@@ -284,9 +300,11 @@ be ported as behavior targets in 0.2.0.
 The JS library lives at https://github.com/statelyai/xstate (packages/core).
 
 Key v5 concepts for Python alignment:
-- `createMachine` + `setup()` replace `Machine()` (0.6.0+)
+- `createMachine` maps to `setup(...).create_machine(...)` (0.6.0+);
+  `Machine(config, ...)` remains the stable JSON boundary
 - `createActor(logic)` replaces `interpret(machine)` (0.5.0)
-- All handlers use single-object signature: `guard({"context": c, "event": e})`  (0.4.0)
+- Prefer `handler(HandlerArgs(...))`; legacy and keyword-only handler
+  signatures are compatibility forms
 - `State` → `MachineSnapshot` with `{status, value, context, output, error}` (0.4.0)
 - `cond` → `guard`, `data` → `output`, `on: {'': ...}` → `always:` (0.4.0)
 - Actor system: every actor belongs to a system, accessible via `system.get(id)` (0.5.0)
@@ -307,4 +325,4 @@ replace `algorithm.py` — evolve it.
 | `xstate` (this) | 194 | **XState JSON native; SCXML algorithm core** |
 
 Our bet: own native XState JSON compatibility + SCXML algorithm correctness.
-Ship a `SKILL.md` with the library once 0.1.0 API is stable (agensi.io-compatible).
+Consider shipping a `SKILL.md` with the library once the 0.7+ public docs settle.


### PR DESCRIPTION
## Summary

- Refreshes `AGENTS.md` so the compact agent-facing context reflects the merged 0.7.0 release-readiness state on `master`.
- Expands `CLAUDE.md` with current module coverage and removes stale framing that treated 0.7.0 features as branch-only or future backlog work.
- Tightens roadmap, architectural-debt, API-boundary, and XState-alignment notes so future AI-agent sessions preserve the stable `Machine(config, ...)` JSON boundary and do not chase completed 0.7 work.

## Why

The June 29/0.7.0 merge train moved query helpers, Mermaid export, `choose(...)`, `pure(...)`, schema typing, and context adapter work onto `master`, but parts of the agent-facing docs still described that state as branch work or as future 0.7 scope. That wording can mislead future Codex/Claude sessions into reopening completed milestones, proposing obsolete APIs like a parallel `context_factory`, or treating old v0.1/v0.4 migration notes as current guidance.

## Notable updates

- Marks `0.7.0` as release-ready on `master` while calling out that PyPI publication remains a release task.
- Adds missing architecture-map entries for current modules such as `guards.py`, `snapshot.py`, `mermaid.py`, `context.py`, and `setup_api.py`.
- Documents current capabilities: snapshot serialization, context adapters, state tags/meta, `stateIn`, `choose`/`pure`, and Mermaid export.
- Reframes the 0.7 feature backlog into post-0.7 roadmap notes with completed work separated from remaining parity gaps.
- Updates architectural-debt notes to reflect that `HandlerAdapter`, `StateNodeConfigParser`, TypedDict schemas, and `ContextAdapter` have already landed.
- Replaces stale API guidance about v0.1/v0.4 with the stable `Machine(config, actions=..., guards=..., delays=..., actors=...)` contract.

## Validation

- `git diff --check`
- Targeted `rg` scan for stale phrases such as `0.7.0 branch`, `branch in progress`, `feature backlog`, `v0.1.0 contract`, and `deep-research`

No Python test suite run; this is docs-only.