### PR TITLE
[codex] Accept PathLike SCXML sources

### DIFF
--- a/src/xstate/scxml.py
+++ b/src/xstate/scxml.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import xml.etree.ElementTree as ET
 

--- a/src/xstate/scxml.py
+++ b/src/xstate/scxml.py
@@ -1,3 +1,4 @@
+import os
 import xml.etree.ElementTree as ET
 
 from xstate.exceptions import InvalidConfigError
@@ -240,7 +241,8 @@ def convert(element: ET.Element, parent: ET.Element | None = None) -> dict:
 elements: dict = {"scxml": convert_scxml, "state": convert_state}
 
 
-def scxml_to_machine(source: str) -> Machine:
+def scxml_to_machine(source: str | os.PathLike[str]) -> Machine:
+    """Load an SCXML document from a filesystem path."""
     tree = ET.parse(source)
     root = tree.getroot()
     result = convert(root)

--- a/tests/test_scxml.py
+++ b/tests/test_scxml.py
@@ -77,7 +77,7 @@ scxml_ci_groups = {
 
 test_files = [
     pytest.param(
-        str(test_dir / test_group / f"{test_name}.scxml"),
+        test_dir / test_group / f"{test_name}.scxml",
         test_dir / test_group / f"{test_name}.json",
         id=f"{test_group}/{test_name}",
         marks=pytest.mark.scxml_ci if test_group in scxml_ci_groups else (),
@@ -85,6 +85,13 @@ test_files = [
     for test_group, test_names in test_groups.items()
     for test_name in test_names
 ]
+
+
+@pytest.mark.scxml_ci
+def test_scxml_to_machine_accepts_path_source():
+    machine = scxml_to_machine(test_dir / "basic" / "basic0.scxml")
+
+    assert machine.initial_state.matches("a")
 
 
 @pytest.mark.parametrize("scxml_source,scxml_test_source", test_files)


### PR DESCRIPTION
## Summary

- Updates `xstate.scxml.scxml_to_machine(...)` to intentionally accept `str | os.PathLike[str]` source paths.
- Restores the SCXML fixture matrix to pass `Path` objects directly instead of coercing them to `str`.
- Adds a `scxml_ci` regression test proving `scxml_to_machine(Path(...))` works and stays covered by the SCXML smoke workflow.

## Why

PR #22 moved SCXML fixtures to repo-root-resolved `Path` values so the test framework files are located reliably in CI. A follow-up workaround converted the SCXML source path back to `str` because the public `scxml_to_machine` signature only advertised `str` input, even though `ElementTree.parse(...)` already accepts path-like sources at runtime.

That left the tests working around the public API instead of documenting it. This PR aligns the type boundary with the behavior we want: callers can pass ordinary strings or `pathlib.Path` / `os.PathLike[str]` sources directly.

## User and Developer Impact

- `pathlib.Path` callers no longer appear to be outside the supported API surface.
- The repo-relative fixture setup from PR #22 remains intact and now exercises the public API directly.
- The SCXML smoke suite will catch future regressions where `Path` sources are accidentally narrowed or coerced away.

## Validation

- `poetry run python -m pytest tests/test_scxml.py -m scxml_ci` → 41 passed
- `poetry run mypy src/xstate/` → success, no issues found in 22 source files
- `poetry run ruff check src/xstate/scxml.py tests/test_scxml.py` → all checks passed