### PR TITLE
Harden 0.7.0 release cutover and refresh agent context

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,16 +4,67 @@ on:
     types:
       - published
 
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
 jobs:
   publish:
+    if: ${{ !github.event.release.draft && !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+      - name: Verify release target
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          python - <<'PY'
+          import os
+          import subprocess
+          import sys
+          import tomllib
+
+          with open("pyproject.toml", "rb") as pyproject:
+              version = tomllib.load(pyproject)["project"]["version"]
+
+          release_tag = os.environ["RELEASE_TAG"]
+          expected_tag = f"v{version}"
+          if release_tag != expected_tag:
+              print(
+                  f"::error::Release tag {release_tag!r} does not match "
+                  f"pyproject.toml version {version!r}; expected {expected_tag!r}."
+              )
+              sys.exit(1)
+
+          def git(*args: str) -> str:
+              return subprocess.check_output(("git", *args), text=True).strip()
+
+          release_commit = git("rev-list", "-n", "1", release_tag)
+          master_commit = git("rev-parse", "origin/master")
+          if release_commit != master_commit:
+              print(
+                  f"::error::Release tag {release_tag!r} points at "
+                  f"{release_commit}, but origin/master is {master_commit}."
+              )
+              sys.exit(1)
+          PY
+      - name: Check PyPI token
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          if [ -z "$POETRY_PYPI_TOKEN_PYPI" ]; then
+            echo "::error::PYPI_TOKEN secret is not configured or is empty."
+            exit 1
+          fi
       - name: Install Poetry
         run: python -m pip install "poetry>=2.0,<3.0"
       - name: Install dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ run-to-completion execution core.
 - License: MIT
 - Python: 3.13+
 - Runtime dependencies: none
-- Current status: alpha, version `0.7.0` (release-ready; PyPI publish pending)
+- Current status: alpha, version `0.7.0`
 
 The central bet is simple: charts designed in Stately or shared with a
 JavaScript frontend should load directly as Python `dict` / JSON data, with
@@ -87,8 +87,6 @@ Working:
 Known gaps:
 
 - Full SCXML conformance still has known `more-parallel` failures.
-- Publishing `0.7.0` to PyPI is still a release task after the merged
-  release-readiness work.
 - Graphviz export and graph/test helper APIs beyond Mermaid are future work.
 - SCXML condition support is intentionally not a general JavaScript evaluator.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented here.
 
-## 0.7.0 - 2026-07-01
+## 0.7.0 - 2026-07-02
 
 ### Added
 
@@ -15,6 +15,14 @@ All notable changes to this project will be documented here.
   selection and `pure(...)` for dynamically computed action lists.
 - Added dependency-free Mermaid `stateDiagram-v2` export with
   `to_mermaid(machine)`.
+
+### Changed
+
+- Hardened the GitHub Release publish workflow so the release tag must match the
+  package version, point at `origin/master`, and have a configured PyPI token
+  before upload.
+- Updated PyPI-facing installation docs to use `pip install xstate` for the
+  released package.
 
 ## 0.6.0 - 2026-06-28
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,30 +16,27 @@ the niche of native XState JSON compatibility.
 ```
 src/xstate/
   __init__.py       Public API: `from xstate import Machine`
-  machine.py        Machine class — entry point and pure transition API
+  machine.py        Core Machine class and transition entry point
   config_parser.py  Two-pass XState config parser and normalizer
-  schema.py         TypedDict boundary for raw XState config data
+  schema.py         TypedDict schemas for Machine, StateNode, Transition, and Invoke configs
   state_node.py     Resolved state hierarchy model
+  transition.py     Resolved transition model
   state.py          Public State / MachineSnapshot snapshots
   algorithm.py      SCXML execution engine (microstep/macrostep, entry/exit sets)
   action.py         Action constructors and higher-order action helpers
-  transition.py     Resolved transition model
-  context.py        ContextAdapter policies, including dataclass contexts
   event.py          Event wrapper and conversion helpers
+  exceptions.py     Custom exception classes
   handlers.py       HandlerArgs and HandlerAdapter callable adaptation
   guards.py         Composable guards and state_in/stateIn helpers
-  snapshot.py       Snapshot serialization and restoration helpers
-  mermaid.py        Dependency-free Mermaid diagram export
-  actor.py          Actor model, create_actor, ActorSystem, actor logic helpers
-  scheduler.py      Clock abstractions
-  scxml.py          SCXML XML → Machine config converter with safe Boolean conds
-  setup_api.py      setup(...).create_machine(...) strict API
-  machine.py        Core Machine class and transition entry point
+  context.py        ContextAdapter policies, including dataclass contexts
   interpreter.py    Synchronous runtime, queue, subscriptions, timers
   async_interpreter.py  Asyncio runtime and awaitable action execution
-  config_parser.py  Parser for StateNode configurations
-  schema.py         TypedDict schemas for Machine, StateNode, Transition, and Invoke configs
-  exceptions.py     Custom exception classes
+  actor.py          Actor model, create_actor, ActorSystem, actor logic helpers
+  snapshot.py       Snapshot serialization and restoration helpers
+  scheduler.py      Clock abstractions
+  mermaid.py        Dependency-free Mermaid diagram export
+  scxml.py          SCXML XML → Machine config converter with safe Boolean conds
+  setup_api.py      setup(...).create_machine(...) strict API
 ```
 
 `algorithm.py` is the heart of the library. It implements the W3C SCXML algorithm:
@@ -49,7 +46,7 @@ The critical execution order is: `main_event_loop` → `microstep` → `main_eve
 
 ---
 
-## Current state (0.7.0 release-ready on master)
+## Current state (0.7.0 on master)
 
 **Working:**
 - Hierarchical (compound) states
@@ -228,7 +225,7 @@ poetry run python -m pytest tests/test_scxml.py -k cond-js
 poetry run mypy src/xstate/
 
 # Format + lint
-poetry run ruff format src/ tests/
+poetry run ruff format --check src/ tests/
 poetry run ruff check src/ tests/
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,8 +50,13 @@ functions, delay values, and actor logic.
 
 ## Installation
 
-The `0.7.0` package metadata is ready for release. Until the GitHub release
-publishes to PyPI, install from source:
+Install the released package from PyPI:
+
+```bash
+pip install xstate
+```
+
+For an unreleased checkout, install from source:
 
 ```bash
 git clone https://github.com/JovaniPink/xstate-python.git


### PR DESCRIPTION
## Summary

This PR folds the final 0.7.0 release-cutover cleanup into `master` through a reviewable branch instead of leaving the work as direct commits.

## What Changed

- Hardened the GitHub Release publish workflow:
  - run only for non-draft, non-prerelease GitHub releases
  - use explicit read-only repository permissions
  - serialize release publishes by tag with a concurrency group
  - fetch full history so release tags can be compared against `origin/master`
  - verify the release tag matches the package version in `pyproject.toml`
  - verify the release tag points at the current `origin/master`
  - fail early when `PYPI_TOKEN` is missing
- Updated release-facing docs for 0.7.0:
  - README installation now points to `pip install xstate`
  - CHANGELOG records the release workflow hardening and PyPI-facing install docs
- Refreshed agent context:
  - removed stale PyPI-pending language from `AGENTS.md`
  - cleaned up duplicate and stale module entries in `CLAUDE.md`
  - restored the documented `ruff format --check` command for format verification

## Why

The release path needed a few guardrails before PyPI publishing: the workflow should only publish the intended final release tag, it should prove the tag matches the packaged version and current `master`, and it should fail clearly if the upload token is not configured.

The agent context also needed to match the post-cutover repository state so future automation does not work from stale release assumptions or duplicated architecture notes.

## Validation

- Inspected the exact diff from `ed8c0ce` to `b6f0ce8` before opening this PR.
- Confirmed the PR branch contains the two intended commits only:
  - `4ac8901 Harden 0.7.0 release publish cutover`
  - `b6f0ce8 Refresh agent context after release cutover`
- No local test suite run: changes are limited to documentation and GitHub release workflow configuration.