### PR TITLE
Document machine configuration and runtime APIs

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -61,8 +61,8 @@ jobs:
       - name: Install dependencies
         run: poetry install
       - name: Check formatting
-        run: poetry run ruff format --check src/ tests/
+        run: poetry run ruff format --check src/ tests/ docs/examples/
       - name: Run lint
-        run: poetry run ruff check src/ tests/
+        run: poetry run ruff check src/ tests/ docs/examples/
       - name: Run type checks
         run: poetry run mypy src/xstate/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,9 +76,9 @@ jobs:
       - name: Run SCXML smoke suite
         run: poetry run python -m pytest tests/test_scxml.py -m scxml_ci
       - name: Check formatting
-        run: poetry run ruff format --check src/ tests/
+        run: poetry run ruff format --check src/ tests/ docs/examples/
       - name: Run lint
-        run: poetry run ruff check src/ tests/
+        run: poetry run ruff check src/ tests/ docs/examples/
       - name: Run type checks
         run: poetry run mypy src/xstate/
       - name: Publish to PyPI

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,8 +152,8 @@ poetry run python -m pytest tests/test_scxml.py -k cond-js
 poetry run mypy src/xstate/
 
 # Format and lint
-poetry run ruff format --check src/ tests/
-poetry run ruff check src/ tests/
+poetry run ruff format --check src/ tests/ docs/examples/
+poetry run ruff check src/ tests/ docs/examples/
 ```
 
 ## PR And Branch Guidance

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,8 +225,8 @@ poetry run python -m pytest tests/test_scxml.py -k cond-js
 poetry run mypy src/xstate/
 
 # Format + lint
-poetry run ruff format --check src/ tests/
-poetry run ruff check src/ tests/
+poetry run ruff format --check src/ tests/ docs/examples/
+poetry run ruff check src/ tests/ docs/examples/
 ```
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,8 +37,8 @@ Run type checking and linting:
 
 ```bash
 poetry run mypy src/xstate/
-poetry run ruff format --check src/ tests/
-poetry run ruff check src/ tests/
+poetry run ruff format --check src/ tests/ docs/examples/
+poetry run ruff check src/ tests/ docs/examples/
 ```
 
 SCXML changes need the SCXML test framework:

--- a/README.md
+++ b/README.md
@@ -377,13 +377,21 @@ Runnable examples live in [`docs/examples/`](./docs/examples):
 |---|---|
 | [`traffic_intersection.json`](./docs/examples/traffic_intersection.json) + [`traffic_intersection.py`](./docs/examples/traffic_intersection.py) | XState JSON loading, parallel regions, nested states, named delays, guards, entry actions, and deterministic clocks |
 | [`fetch_with_retry.py`](./docs/examples/fetch_with_retry.py) | `invoke`, `from_promise`, retries with `after`, context assignment, and guarded transitions |
+| [`async_workflow.py`](./docs/examples/async_workflow.py) | `AsyncInterpreter`, awaitable actions, subscriptions, and per-event completion |
 
 Run them from the repo root:
 
 ```bash
 PYTHONPATH=src python3 docs/examples/traffic_intersection.py
 PYTHONPATH=src python3 docs/examples/fetch_with_retry.py
+PYTHONPATH=src python3 docs/examples/async_workflow.py
 ```
+
+## Documentation
+
+Concept guides and the runnable-example index live in [`docs/`](./docs). Start
+with [machines and implementations](./docs/concepts/machines-and-implementations.md)
+or [runtime choices](./docs/concepts/runtimes.md).
 
 ## Public API
 
@@ -444,8 +452,8 @@ poetry run python -m pytest tests/ --ignore=tests/test_scxml.py
 poetry run mypy src/xstate/
 
 # Formatting and linting
-poetry run ruff format --check src/ tests/
-poetry run ruff check src/ tests/
+poetry run ruff format --check src/ tests/ docs/examples/
+poetry run ruff check src/ tests/ docs/examples/
 ```
 
 ### Release preflight

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,15 @@
+# Documentation
+
+`xstate-python` loads XState-style statechart data and runs it with Python
+implementations for the live parts of a machine. Start with the concepts that
+match the runtime boundary you need:
+
+- [Machines and implementations](./concepts/machines-and-implementations.md):
+  XState JSON, events, actions, guards, delays, `setup()`, and pure transitions.
+- [Runtime choices](./concepts/runtimes.md): `Machine.transition`, the sync and
+  async interpreters, actors, subscriptions, clocks, and run-to-completion.
+- [Runnable examples](./examples/README.md): complete programs exercised by the
+  test suite.
+
+Additional guides for actors, persistence, and SCXML import are being added as
+part of the current documentation milestone.

--- a/docs/concepts/machines-and-implementations.md
+++ b/docs/concepts/machines-and-implementations.md
@@ -1,0 +1,117 @@
+# Machines And Implementations
+
+The primary compatibility boundary is a plain XState-style configuration:
+
+```python
+from xstate import Machine
+
+machine = Machine(
+    {
+        "id": "approval",
+        "initial": "draft",
+        "states": {
+            "draft": {"on": {"SUBMIT": "review"}},
+            "review": {"on": {"APPROVE": "approved"}},
+            "approved": {"type": "final"},
+        },
+    }
+)
+```
+
+The configuration can be authored as a Python dictionary or loaded from JSON.
+State structure stays declarative; Python supplies implementations for names
+that cannot be represented as data.
+
+## Pure Transitions
+
+`Machine.transition` is the pure statechart layer. It accepts an immutable
+snapshot and an event, then returns the next snapshot:
+
+```python
+state = machine.initial_state
+state = machine.transition(state, "SUBMIT")
+assert state.value == "review"
+```
+
+An event can be a string or a mapping with a `type` and payload fields:
+
+```python
+state = machine.transition(
+    state,
+    {"type": "APPROVE", "reviewer_id": 42},
+)
+```
+
+Assignments are applied while the next snapshot is computed. Side-effect
+actions are returned on `state.actions`; use an interpreter or actor when those
+actions should be executed automatically.
+
+## Named Implementations
+
+JSON refers to implementations by name. Register those names when constructing
+the machine:
+
+```python
+from xstate import HandlerArgs, Machine, assign
+
+
+def has_reviewer(args: HandlerArgs) -> bool:
+    return bool(args.event.data.get("reviewer_id"))
+
+
+machine = Machine(
+    config,
+    guards={"hasReviewer": has_reviewer},
+    actions={
+        "rememberReviewer": assign(
+            {"reviewer_id": lambda _context, event: event.data["reviewer_id"]}
+        )
+    },
+    delays={"reviewTimeout": 30_000},
+    actors={"notifyReviewer": notification_actor_logic},
+)
+```
+
+The registry names have distinct roles:
+
+| Registry | Used for |
+|---|---|
+| `actions` | Side effects and built-in action creators such as `assign` |
+| `guards` | Boolean transition conditions |
+| `delays` | Millisecond values or functions used by named `after` transitions |
+| `actors` | Actor logic referenced by `invoke.src` |
+
+Missing named guards and delays raise an implementation error when they are
+needed. Missing side-effect actions emit a warning at the compatibility
+`Machine(config, ...)` boundary.
+
+## `setup()` And Handler Arguments
+
+`setup(...)` registers implementations before creating a machine and enables a
+stricter XState v5-style authoring path:
+
+```python
+from xstate import setup
+
+machine = setup(guards={"hasReviewer": has_reviewer}).create_machine(config)
+```
+
+Prefer a single `HandlerArgs` parameter for new handlers. It exposes `context`,
+`event`, and implementation `params`. Legacy `()`, `(context)`, and
+`(context, event)` callables remain supported by `Machine(config, ...)`.
+
+## Context And Snapshots
+
+Snapshots isolate context through the configured `ContextAdapter`. The default
+adapter deep-copies context; `dataclass_context()` supports immutable dataclass
+contexts. Public snapshot containers remain immutable: configuration is a
+`frozenset`, actions are a tuple, and history values are read-only.
+
+Use `state.matches(...)`, `state.can(...)`, `state.has_tag(...)`, and
+`state.meta` to query a snapshot without reaching into algorithm internals.
+
+## Complete Example
+
+The [traffic intersection](../examples/traffic_intersection.py) loads its state
+structure from [XState JSON](../examples/traffic_intersection.json), then binds
+named actions, guards, and delays in Python.

--- a/docs/concepts/runtimes.md
+++ b/docs/concepts/runtimes.md
@@ -1,0 +1,77 @@
+# Runtime Choices
+
+The same `Machine` can be used through four runtime boundaries. Choose the
+smallest one that owns the behavior your application needs.
+
+| Boundary | Choose it when |
+|---|---|
+| `Machine.transition` | You want pure `(snapshot, event) -> snapshot` evaluation |
+| `interpret(machine)` | You need sync action execution, subscriptions, queues, or timers |
+| `interpret_async(machine)` | Actions are awaitable or events are coordinated by asyncio |
+| `create_actor(machine)` | The machine participates in an actor tree or invokes child logic |
+
+## Synchronous Interpreter
+
+The synchronous interpreter owns the current snapshot and executes actions:
+
+```python
+from xstate import interpret
+
+service = interpret(machine).start()
+subscription = service.subscribe(lambda snapshot: print(snapshot.value))
+
+service.send("SUBMIT")
+
+subscription.unsubscribe()
+service.stop()
+```
+
+Calls to `send()` are serialized. An event sent while another event is being
+processed is queued until the active macrostep completes. This preserves
+run-to-completion even when an action sends another event.
+
+The default `ThreadClock` schedules real timers. Tests and deterministic tools
+should inject `SimulatedClock` and advance it explicitly:
+
+```python
+from xstate import SimulatedClock, interpret
+
+clock = SimulatedClock()
+service = interpret(machine, clock=clock).start()
+clock.increment(1_000)
+```
+
+Stopping an interpreter cancels its active `after` timers and delayed sends,
+clears listeners, and drops later events.
+
+## Async Interpreter
+
+The async interpreter provides awaitable lifecycle and send operations:
+
+```python
+from xstate import interpret_async
+
+service = interpret_async(machine)
+await service.start()
+snapshot = await service.send({"type": "SUBMIT", "request_id": 7})
+await service.stop()
+```
+
+Actions that return awaitables are executed in declaration order and awaited
+before that event's `send()` completes. Concurrent callers receive completion
+for their own queued event. Subscribers remain synchronous observers; launch
+async work from actions rather than subscription callbacks.
+
+Async `after` transitions use the running event loop. The pure transition and
+guard layer remains synchronous.
+
+See [async workflow](../examples/async_workflow.py) for a complete program.
+
+## Actors
+
+`create_actor(machine)` wraps a machine with an XState v5-style actor API. It is
+the right boundary for parent/child relationships, `invoke`, spawning,
+`send_parent`, and `send_to`. Machine actors use the synchronous interpreter
+internally; promise and observable actor logic can settle asynchronously.
+
+Actor and persistence behavior is documented in dedicated concept guides.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -6,6 +6,7 @@ from the repository root with `PYTHONPATH=src`:
 ```bash
 PYTHONPATH=src python3 docs/examples/traffic_intersection.py
 PYTHONPATH=src python3 docs/examples/fetch_with_retry.py
+PYTHONPATH=src python3 docs/examples/async_workflow.py
 ```
 
 ## Traffic Intersection
@@ -77,3 +78,12 @@ What to look for:
 This example is intentionally a Python dict because it contains live callables
 for `input`, guards, actions, and the promise actor. Pure state structure can
 still live in JSON when those live pieces are referenced by name.
+
+## Async Workflow
+
+File: [`async_workflow.py`](./async_workflow.py)
+
+This compact asyncio example runs an awaitable action through
+`interpret_async(machine)`. It shows awaitable lifecycle methods, synchronous
+snapshot subscriptions, event payload access through `HandlerArgs`, and the
+guarantee that `await send(...)` completes after that event's async actions.

--- a/docs/examples/async_workflow.py
+++ b/docs/examples/async_workflow.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Run a machine with an awaitable action through AsyncInterpreter."""
+
+import asyncio
+
+from xstate import HandlerArgs, Machine, interpret_async
+
+
+async def main() -> None:
+    completed_jobs: list[int] = []
+
+    async def record_job(args: HandlerArgs) -> None:
+        await asyncio.sleep(0)
+        completed_jobs.append(args.event.data["job_id"])
+
+    machine = Machine(
+        {
+            "id": "async-workflow",
+            "initial": "idle",
+            "states": {
+                "idle": {
+                    "on": {
+                        "RUN": {
+                            "target": "done",
+                            "actions": "recordJob",
+                        }
+                    }
+                },
+                "done": {"type": "final"},
+            },
+        },
+        actions={"recordJob": record_job},
+    )
+
+    observed: list[object] = []
+    service = interpret_async(machine)
+    await service.start()
+    subscription = service.subscribe(lambda snapshot: observed.append(snapshot.value))
+
+    snapshot = await service.send({"type": "RUN", "job_id": 42})
+
+    assert snapshot.value == "done"
+    assert snapshot.status == "done"
+    assert completed_jobs == [42]
+    assert observed == ["idle", "done"]
+
+    subscription.unsubscribe()
+    await service.stop()
+    print("completed async job 42")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/release_preflight.py
+++ b/scripts/release_preflight.py
@@ -144,9 +144,29 @@ def main(argv: Sequence[str] | None = None) -> int:
         ),
         (
             "Check formatting",
-            ("poetry", "run", "ruff", "format", "--check", "src/", "tests/"),
+            (
+                "poetry",
+                "run",
+                "ruff",
+                "format",
+                "--check",
+                "src/",
+                "tests/",
+                "docs/examples/",
+            ),
         ),
-        ("Run lint", ("poetry", "run", "ruff", "check", "src/", "tests/")),
+        (
+            "Run lint",
+            (
+                "poetry",
+                "run",
+                "ruff",
+                "check",
+                "src/",
+                "tests/",
+                "docs/examples/",
+            ),
+        ),
         ("Run type checks", ("poetry", "run", "mypy", "src/xstate/")),
         ("Build distribution", ("poetry", "build")),
     )

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,29 @@
+"""Smoke tests for the canonical runnable examples."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize(
+    "example",
+    [
+        "traffic_intersection.py",
+        "fetch_with_retry.py",
+        "async_workflow.py",
+    ],
+)
+def test_documented_example_runs(example: str) -> None:
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "docs" / "examples" / example)],
+        cwd=ROOT,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout


### PR DESCRIPTION
## Summary

- establish a repository-native documentation index and concept-guide structure
- document XState JSON loading, named implementations, pure transitions, snapshots, and `setup()`
- compare the pure machine API, sync interpreter, async interpreter, and actor runtime boundaries
- add a runnable asyncio example with an awaited action and per-event completion
- smoke-test every canonical documented example in an isolated subprocess
- extend local, CI, and release Ruff checks to cover `docs/examples/`

## Why

The README describes the surface area, but users still have to infer which runtime owns actions, queues, timers, async work, and actors. These guides make that decision explicit while keeping the core XState/Stately JSON compatibility story front and center.

Runnable examples are now treated as maintained code. The primary test suite executes them, and the same Ruff scope is used locally, in pull requests, and during release preflight.

## User Impact

There are no runtime API changes. Users gain:

- a clear starting point for JSON-authored machines and Python implementation registries
- guidance on when to use `Machine.transition`, `interpret`, `interpret_async`, or `create_actor`
- an asyncio example that demonstrates awaited actions and synchronous snapshot subscriptions
- examples that are continuously checked instead of relying on manual execution

## Validation

- `poetry run python -m pytest tests/ --ignore=tests/test_scxml.py` — 395 passed
- `poetry run python -m pytest tests/test_examples.py -q` — 3 passed
- `poetry run python docs/examples/async_workflow.py`
- `poetry run mypy src/xstate/`
- `poetry run ruff format --check src/ tests/ docs/examples/`
- `poetry run ruff check src/ tests/ docs/examples/`
- `git diff --check`

## Scope

This PR covers machines, implementation registries, sync/async runtimes, and the documentation/test infrastructure. Actor, persistence, and SCXML concept guides remain separate sequential PRs.