### PR TITLE
Document actors and snapshot persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ Runnable examples live in [`docs/examples/`](./docs/examples):
 | [`traffic_intersection.json`](./docs/examples/traffic_intersection.json) + [`traffic_intersection.py`](./docs/examples/traffic_intersection.py) | XState JSON loading, parallel regions, nested states, named delays, guards, entry actions, and deterministic clocks |
 | [`fetch_with_retry.py`](./docs/examples/fetch_with_retry.py) | `invoke`, `from_promise`, retries with `after`, context assignment, and guarded transitions |
 | [`async_workflow.py`](./docs/examples/async_workflow.py) | `AsyncInterpreter`, awaitable actions, subscriptions, and per-event completion |
+| [`snapshot_resume.py`](./docs/examples/snapshot_resume.py) | Snapshot serialization, JSON persistence, restoration, and continued actor processing |
 
 Run them from the repo root:
 
@@ -385,13 +386,16 @@ Run them from the repo root:
 PYTHONPATH=src python3 docs/examples/traffic_intersection.py
 PYTHONPATH=src python3 docs/examples/fetch_with_retry.py
 PYTHONPATH=src python3 docs/examples/async_workflow.py
+PYTHONPATH=src python3 docs/examples/snapshot_resume.py
 ```
 
 ## Documentation
 
 Concept guides and the runnable-example index live in [`docs/`](./docs). Start
 with [machines and implementations](./docs/concepts/machines-and-implementations.md)
-or [runtime choices](./docs/concepts/runtimes.md).
+or [runtime choices](./docs/concepts/runtimes.md), then continue with
+[actors](./docs/concepts/actors.md) and
+[snapshot persistence](./docs/concepts/persistence.md).
 
 ## Public API
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,8 +8,12 @@ match the runtime boundary you need:
   XState JSON, events, actions, guards, delays, `setup()`, and pure transitions.
 - [Runtime choices](./concepts/runtimes.md): `Machine.transition`, the sync and
   async interpreters, actors, subscriptions, clocks, and run-to-completion.
+- [Actors](./concepts/actors.md): actor lifecycle, invocation, actor logic,
+  trees, and messaging.
+- [Snapshot persistence](./concepts/persistence.md): checkpoint format,
+  restoration, compatibility, and operational limits.
 - [Runnable examples](./examples/README.md): complete programs exercised by the
   test suite.
 
-Additional guides for actors, persistence, and SCXML import are being added as
-part of the current documentation milestone.
+An SCXML import guide is being added as part of the current documentation
+milestone.

--- a/docs/concepts/actors.md
+++ b/docs/concepts/actors.md
@@ -1,0 +1,103 @@
+# Actors
+
+Actors own running logic. A machine describes transitions; an actor gives that
+machine an identity, current snapshot, mailbox-like `send()` boundary, and
+lifecycle.
+
+## Machine Actors
+
+Create and start an actor from any `Machine`:
+
+```python
+from xstate import Machine, create_actor
+
+machine = Machine(config)
+actor = create_actor(machine).start()
+
+actor.send("START")
+snapshot = actor.get_snapshot()
+
+actor.stop()
+```
+
+`start()` is idempotent while the actor is running. `send()` processes an event
+through the machine's run-to-completion queue. Events sent before start or after
+stop are dropped by the machine runtime.
+
+Subscribe when another part of the application needs snapshot notifications:
+
+```python
+subscription = actor.subscribe(lambda snapshot: print(snapshot.value))
+subscription.unsubscribe()
+```
+
+The actor owns its interpreter and timers. Call `stop()` when its lifecycle is
+not already owned by a parent actor.
+
+## Invoked Actors
+
+An `invoke` declaration starts child logic while its state is active:
+
+```python
+machine = Machine(
+    {
+        "id": "loader",
+        "initial": "loading",
+        "states": {
+            "loading": {
+                "invoke": {
+                    "id": "loadUser",
+                    "src": "loadUser",
+                    "input": lambda context, _event: {
+                        "user_id": context["user_id"]
+                    },
+                    "onDone": "success",
+                    "onError": "failure",
+                }
+            },
+            "success": {"type": "final"},
+            "failure": {},
+        },
+    },
+    actors={"loadUser": load_user_logic},
+)
+```
+
+The child is reconciled with the active configuration. Entering the invoking
+state starts it; leaving that state stops it. Completion produces
+`done.invoke.<id>`, failure produces `error.platform.<id>`, and snapshot-capable
+logic can produce `snapshot.invoke.<id>`.
+
+## Actor Logic Helpers
+
+| Helper | Wraps |
+|---|---|
+| `from_promise(fn)` | A value-returning or awaitable function |
+| `from_callback(fn)` | Callback logic that may receive events and return cleanup |
+| `from_observable(source)` | An observable or async iterable snapshot source |
+| `to_promise(actor)` | Actor completion as an awaitable result |
+
+Promise input is resolved from `invoke.input` before the child starts. A
+resolved value completes the actor; an exception moves its snapshot to error
+and drives the parent's `onError` transition.
+
+See [fetch with retry](../examples/fetch_with_retry.py) for invoked promise
+logic, context assignment, guarded retry, and deterministic backoff.
+
+## Actor Trees And Messaging
+
+Machine actors can spawn children into the same `ActorSystem`. Use
+`send_parent(event)` for child-to-parent communication and
+`send_to(actor_id, event)` for a known actor in that system. These are
+interpreter-owned actions: the runtime routes them after the machine computes
+the next snapshot.
+
+Actor IDs must be unique within a system. A parent owns the lifetime of its
+spawned and invoked children; stopping the parent stops those children as well.
+
+## Choosing An Actor Boundary
+
+Use `interpret(machine)` for a standalone synchronous service. Use
+`create_actor(machine)` when identity, parent/child ownership, invocation, or
+actor messaging is part of the design. Both preserve the same machine
+configuration and transition semantics.

--- a/docs/concepts/persistence.md
+++ b/docs/concepts/persistence.md
@@ -1,0 +1,93 @@
+# Snapshot Persistence
+
+Snapshots can be serialized to plain data and restored against the same
+machine. This supports checkpoints, process handoff, and replay from an
+application-owned store.
+
+## Serialize And Restore
+
+```python
+import json
+
+from xstate import (
+    create_actor,
+    deserialize_snapshot,
+    serialize_snapshot,
+)
+
+actor = create_actor(machine).start()
+actor.send("ADVANCE")
+
+payload = json.dumps(serialize_snapshot(actor.get_snapshot()))
+actor.stop()
+
+restored = deserialize_snapshot(machine, json.loads(payload))
+resumed = create_actor(machine, snapshot=restored).start()
+```
+
+The serialized dictionary contains:
+
+| Field | Meaning |
+|---|---|
+| `value` | String or nested state value |
+| `context` | Application context |
+| `status` | `active`, `done`, or `error` |
+| `history_value` | Recorded history-state configuration by node ID |
+| `output` | Snapshot output when JSON-compatible |
+| `error` | `repr(error)` for an error snapshot |
+
+Context and output must already be JSON-compatible if the payload is sent
+through `json.dumps()`.
+
+## Compatibility Boundary
+
+Restore only into the same machine definition, or a definition whose active
+state IDs and hierarchy are intentionally compatible. Deserialization resolves
+state and history IDs through that machine's parsed state tree. It is not a
+general migration engine and does not validate arbitrary untrusted payloads.
+
+For a changed machine, migrate the stored dictionary in application code before
+calling `deserialize_snapshot()` and test that migration against representative
+checkpoints.
+
+## What Is Reconstructed
+
+The active configuration, context, and known history nodes are reconstructed.
+Snapshot status and output are derived again from the restored configuration;
+the serialized `output` field is descriptive rather than assigned independently.
+An error status is restored, with the serialized error representation exposed
+as text.
+
+The restored public snapshot keeps the normal immutable boundary:
+configuration is a `frozenset`, actions are a tuple, and history values are
+read-only.
+
+## What Is Not Persisted
+
+Serialization does not capture:
+
+- pending `after` deadlines or delayed-send remaining time;
+- running invoked or spawned child actor internals;
+- subscriptions;
+- queued events;
+- the last event object or pending side-effect actions.
+
+Starting an actor from an active restored state schedules that state's timers
+again from their full configured delay. Applications that need wall-clock timer
+continuity should persist deadlines separately and send an explicit recovery
+event after restore.
+
+Child actors are reconciled from the restored active configuration. Persist
+their domain data separately when their internal progress matters.
+
+## Operational Guidance
+
+- Treat snapshots as versioned application data even though the library payload
+  does not currently include a schema-version field.
+- Store the application and machine version alongside each payload.
+- Validate context before restore when it came from outside a trusted store.
+- Stop the old actor before starting the restored actor to avoid duplicate
+  timers, invoked work, or side effects.
+
+See [snapshot resume](../examples/snapshot_resume.py) for a JSON round-trip that
+continues processing on a new actor.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -7,6 +7,7 @@ from the repository root with `PYTHONPATH=src`:
 PYTHONPATH=src python3 docs/examples/traffic_intersection.py
 PYTHONPATH=src python3 docs/examples/fetch_with_retry.py
 PYTHONPATH=src python3 docs/examples/async_workflow.py
+PYTHONPATH=src python3 docs/examples/snapshot_resume.py
 ```
 
 ## Traffic Intersection
@@ -87,3 +88,11 @@ This compact asyncio example runs an awaitable action through
 `interpret_async(machine)`. It shows awaitable lifecycle methods, synchronous
 snapshot subscriptions, event payload access through `HandlerArgs`, and the
 guarantee that `await send(...)` completes after that event's async actions.
+
+## Snapshot Resume
+
+File: [`snapshot_resume.py`](./snapshot_resume.py)
+
+This example serializes a running machine actor to JSON, stops the original,
+restores the checkpoint against the same machine, and continues processing on a
+new actor without losing state value or context.

--- a/docs/examples/snapshot_resume.py
+++ b/docs/examples/snapshot_resume.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Checkpoint a machine actor to JSON and resume it on a new actor."""
+
+import json
+
+from xstate import (
+    Machine,
+    assign,
+    create_actor,
+    deserialize_snapshot,
+    serialize_snapshot,
+)
+
+
+def build_machine() -> Machine:
+    return Machine(
+        {
+            "id": "durable-counter",
+            "context": {"count": 0},
+            "initial": "active",
+            "states": {
+                "active": {
+                    "on": {
+                        "INCREMENT": {
+                            "actions": assign(
+                                {"count": lambda context, _event: context["count"] + 1}
+                            )
+                        }
+                    }
+                }
+            },
+        }
+    )
+
+
+def main() -> None:
+    machine = build_machine()
+    original = create_actor(machine).start()
+    original.send("INCREMENT")
+    original.send("INCREMENT")
+
+    payload = json.dumps(serialize_snapshot(original.get_snapshot()))
+    original.stop()
+
+    restored = deserialize_snapshot(machine, json.loads(payload))
+    resumed = create_actor(machine, snapshot=restored).start()
+
+    assert resumed.get_snapshot().value == "active"
+    assert resumed.get_snapshot().context == {"count": 2}
+
+    resumed.send("INCREMENT")
+    assert resumed.get_snapshot().context == {"count": 3}
+
+    resumed.stop()
+    print("resumed durable counter at 3")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -15,6 +15,7 @@ ROOT = Path(__file__).resolve().parents[1]
         "traffic_intersection.py",
         "fetch_with_retry.py",
         "async_workflow.py",
+        "snapshot_resume.py",
     ],
 )
 def test_documented_example_runs(example: str) -> None:


### PR DESCRIPTION
## Summary

- add focused actor documentation for lifecycle, invocation, actor logic helpers, trees, and messaging
- add snapshot persistence guidance covering JSON round-tripping, restoration, compatibility, and operational limits
- add a runnable `snapshot_resume.py` example and execute it through the isolated subprocess smoke suite
- connect the new guides and example from the repository and documentation indexes

## Why

The public actor and persistence APIs are already available, but adopters need one place that explains which runtime owns lifecycle, how invoked actors report completion and errors, and what a durable machine checkpoint does and does not contain.

This keeps the guidance aligned with the current implementation without introducing a new API or implying persistence guarantees the runtime does not provide.

## Persistence boundaries documented

- restore snapshots against the same machine shape or an intentionally compatible definition
- timers, delayed sends, subscriptions, queued events, and child actor internals are not serialized
- active-state timers are scheduled again from their full configured delay when the restored actor starts
- output and completion are recomputed from the restored configuration
- serialized errors restore as text
- applications should version stored payloads and migrate them before deserialization when machine structure changes

## User impact

Users can now follow a tested actor lifecycle guide and run a complete JSON checkpoint/resume example. Runtime behavior and public types are unchanged.

## Validation

- `poetry run python docs/examples/snapshot_resume.py`
- `poetry run python -m pytest tests/test_examples.py -q` (4 passed)
- `poetry run python -m pytest tests/ --ignore=tests/test_scxml.py` (396 passed)
- `poetry run mypy src/xstate/`
- `poetry run ruff format --check src/ tests/ docs/examples/`
- `poetry run ruff check src/ tests/ docs/examples/`
- `git diff --check`