### PR TITLE
Document SCXML import and safe conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ Runnable examples live in [`docs/examples/`](./docs/examples):
 | [`fetch_with_retry.py`](./docs/examples/fetch_with_retry.py) | `invoke`, `from_promise`, retries with `after`, context assignment, and guarded transitions |
 | [`async_workflow.py`](./docs/examples/async_workflow.py) | `AsyncInterpreter`, awaitable actions, subscriptions, and per-event completion |
 | [`snapshot_resume.py`](./docs/examples/snapshot_resume.py) | Snapshot serialization, JSON persistence, restoration, and continued actor processing |
+| [`scxml_toggle.scxml`](./docs/examples/scxml_toggle.scxml) + [`scxml_toggle.py`](./docs/examples/scxml_toggle.py) | Path-based SCXML import, safe Boolean conditions, raise actions, and pure transitions |
 
 Run them from the repo root:
 
@@ -387,6 +388,7 @@ PYTHONPATH=src python3 docs/examples/traffic_intersection.py
 PYTHONPATH=src python3 docs/examples/fetch_with_retry.py
 PYTHONPATH=src python3 docs/examples/async_workflow.py
 PYTHONPATH=src python3 docs/examples/snapshot_resume.py
+PYTHONPATH=src python3 docs/examples/scxml_toggle.py
 ```
 
 ## Documentation
@@ -395,7 +397,9 @@ Concept guides and the runnable-example index live in [`docs/`](./docs). Start
 with [machines and implementations](./docs/concepts/machines-and-implementations.md)
 or [runtime choices](./docs/concepts/runtimes.md), then continue with
 [actors](./docs/concepts/actors.md) and
-[snapshot persistence](./docs/concepts/persistence.md).
+[snapshot persistence](./docs/concepts/persistence.md). The
+[SCXML import guide](./docs/concepts/scxml.md) covers the supported XML and safe
+condition subset.
 
 ## Public API
 
@@ -432,7 +436,8 @@ from xstate.scheduler import SimulatedClock, ThreadClock
 
 The algorithm core follows the W3C SCXML execution model. XML import is exposed
 through `xstate.scxml.scxml_to_machine(...)` and verified against the SCXML test
-framework:
+framework. See the [SCXML import guide](./docs/concepts/scxml.md) for supported
+elements, safe conditions, and current limits.
 
 ```bash
 git submodule update --init

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,8 +12,7 @@ match the runtime boundary you need:
   trees, and messaging.
 - [Snapshot persistence](./concepts/persistence.md): checkpoint format,
   restoration, compatibility, and operational limits.
+- [SCXML import](./concepts/scxml.md): path-based loading, converted elements,
+  parallel execution, safe conditions, and current limits.
 - [Runnable examples](./examples/README.md): complete programs exercised by the
   test suite.
-
-An SCXML import guide is being added as part of the current documentation
-milestone.

--- a/docs/concepts/scxml.md
+++ b/docs/concepts/scxml.md
@@ -1,0 +1,123 @@
+# SCXML Import
+
+`xstate-python` can convert an SCXML document into the same `Machine` used by
+the pure transition API, interpreters, and actors. The importer is deliberately
+focused: it supports the project test subset without evaluating arbitrary
+JavaScript or claiming complete W3C conformance.
+
+## Load From A Path
+
+Pass a filesystem path or `PathLike` object to `scxml_to_machine(...)`:
+
+```python
+from pathlib import Path
+
+from xstate.scxml import scxml_to_machine
+
+source = Path("workflow.scxml")
+machine = scxml_to_machine(source)
+
+state = machine.initial_state
+state = machine.transition(state, "NEXT")
+```
+
+The importer parses the document immediately. Keep the XML file available only
+for machine construction; the resulting machine does not read it again while
+processing events.
+
+## Converted Structure
+
+The current converter handles this focused XML surface:
+
+| SCXML | Machine configuration |
+|---|---|
+| `<scxml initial="...">` | Root machine and initial state |
+| `<state id="...">` | Compound or atomic state |
+| `<parallel id="...">` | Parallel state with all child regions entered |
+| `<transition event="..." target="...">` | Event transition to one or more state IDs |
+| `cond="..."` | Guard compiled from the safe Boolean subset |
+| `<onentry><raise .../></onentry>` | Entry raise actions |
+| `<onexit><raise .../></onexit>` | Exit raise actions |
+| `<transition><raise .../></transition>` | Transition raise actions |
+
+Transition target IDs are resolved as machine IDs. Multiple space-separated
+targets are preserved, and source/document order is preserved for transition
+selection and conflict resolution.
+
+Other SCXML datamodels, executable-content elements, and JavaScript semantics are
+outside this import surface. Structural `<final>`, `<history>`, and explicit
+`<initial>` elements are also not converted yet, even though the native machine
+configuration supports equivalent statechart concepts. Do not depend on
+`<script>`, `<assign>`, `<send>`, or general ECMAScript evaluation during import.
+
+## Transition Execution
+
+The imported machine uses the regular run-to-completion algorithm. Exit
+actions run before transition actions, entry actions run after them, and raised
+events are consumed internally before the macrostep completes. This behavior is
+the same whether the machine is driven through `Machine.transition(...)`,
+`interpret(...)`, or `create_actor(...)`.
+
+For `<parallel>`, entering the parallel state enters every child region. An
+external transition uses the nearest compound ancestor as its transition
+domain, so affected branches exit and re-enter correctly. Competing transitions
+are resolved by their exit sets and document order.
+
+## Safe Conditions
+
+SCXML conditions support only Boolean literals and operators:
+
+```text
+true
+false
+!true
+true && false
+true || (false && !false)
+```
+
+In XML, escape `&&` as `&amp;&amp;` inside an attribute:
+
+```xml
+<transition event="GO" cond="true &amp;&amp; !false" target="ready"/>
+```
+
+The expression is parsed once when the machine is imported. It cannot read the
+event, context, or an SCXML datamodel.
+
+Unsupported identifiers, property access, comparisons, and JavaScript raise
+`InvalidConfigError` instead of being evaluated:
+
+```xml
+<transition event="GO" cond="event.name === 'GO'" target="ready"/>
+```
+
+```python
+from xstate.exceptions import InvalidConfigError
+from xstate.scxml import scxml_to_machine
+
+try:
+    scxml_to_machine("unsupported.scxml")
+except InvalidConfigError as exc:
+    print(exc)
+```
+
+An expression such as `count > 0` is rejected in the same way; defining
+`count` in an SCXML `<datamodel>` does not expand the supported subset.
+
+## Conformance Boundary
+
+The configured repository suite currently reports `54 passed`, `0 failed`,
+including all 13 enabled `more-parallel` cases. This is a focused subset, not a
+claim of complete W3C SCXML conformance. The broader datamodel and executable
+content surface remains future work, and the `more-parallel` `test10` and
+`test10b` fixtures remain outside the configured set because they require
+additional assignment support.
+
+Run the self-contained [SCXML toggle example](../examples/scxml_toggle.py), or
+run the configured conformance suite after initializing its submodule:
+
+```bash
+PYTHONPATH=src python3 docs/examples/scxml_toggle.py
+git submodule update --init
+poetry run python -m pytest tests/test_scxml.py
+```

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -8,6 +8,7 @@ PYTHONPATH=src python3 docs/examples/traffic_intersection.py
 PYTHONPATH=src python3 docs/examples/fetch_with_retry.py
 PYTHONPATH=src python3 docs/examples/async_workflow.py
 PYTHONPATH=src python3 docs/examples/snapshot_resume.py
+PYTHONPATH=src python3 docs/examples/scxml_toggle.py
 ```
 
 ## Traffic Intersection
@@ -96,3 +97,13 @@ File: [`snapshot_resume.py`](./snapshot_resume.py)
 This example serializes a running machine actor to JSON, stops the original,
 restores the checkpoint against the same machine, and continues processing on a
 new actor without losing state value or context.
+
+## SCXML Toggle
+
+Files: [`scxml_toggle.scxml`](./scxml_toggle.scxml) and
+[`scxml_toggle.py`](./scxml_toggle.py)
+
+This self-contained pair imports a local SCXML document, exercises safe Boolean
+conditions and raise executable content, and toggles in both directions through
+the pure `Machine.transition(...)` API. It does not require the conformance test
+submodule.

--- a/docs/examples/scxml_toggle.py
+++ b/docs/examples/scxml_toggle.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Import and run a self-contained SCXML toggle machine."""
+
+from pathlib import Path
+
+from xstate.scxml import scxml_to_machine
+
+
+def main() -> None:
+    source = Path(__file__).with_name("scxml_toggle.scxml")
+    machine = scxml_to_machine(source)
+
+    state = machine.initial_state
+    assert state.matches("off")
+
+    state = machine.transition(state, "TOGGLE")
+    assert state.matches("on")
+
+    state = machine.transition(state, "TOGGLE")
+    assert state.matches("off")
+
+    print("SCXML toggle returned to off")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/examples/scxml_toggle.scxml
+++ b/docs/examples/scxml_toggle.scxml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scxml xmlns="http://www.w3.org/2005/07/scxml" initial="off">
+  <state id="off">
+    <onentry>
+      <raise event="entered.off"/>
+    </onentry>
+    <transition event="TOGGLE" cond="true &amp;&amp; !false" target="on"/>
+  </state>
+  <state id="on">
+    <transition event="TOGGLE" cond="true || false" target="off">
+      <raise event="toggled.off"/>
+    </transition>
+    <onexit>
+      <raise event="exited.on"/>
+    </onexit>
+  </state>
+</scxml>

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -16,6 +16,7 @@ ROOT = Path(__file__).resolve().parents[1]
         "fetch_with_retry.py",
         "async_workflow.py",
         "snapshot_resume.py",
+        "scxml_toggle.py",
     ],
 )
 def test_documented_example_runs(example: str) -> None:


### PR DESCRIPTION
## Summary

- add a focused SCXML import guide covering path loading, converted elements, transition execution, parallel semantics, and safe conditions
- document the importer boundary separately from the richer native machine configuration surface
- add a self-contained SCXML toggle document and Python runner with no conformance-submodule dependency
- execute the new runner through the isolated example smoke suite
- link the guide and example from the README and documentation indexes

## Why

SCXML import is a useful adoption path, but users need a precise contract. The runtime supports a broader statechart model than the XML converter currently recognizes, and the condition evaluator is intentionally much smaller than JavaScript.

This PR makes those boundaries explicit while giving users a runnable local example that exercises the supported path.

## Supported surface documented

- filesystem path and `PathLike` input
- `<scxml>`, `<state>`, `<parallel>`, and `<transition>`
- event targets, multiple target IDs, document-order selection, and parallel region behavior
- `<raise>` in transition, `<onentry>`, and `<onexit>` content
- safe conditions using `true`, `false`, `!`, `&&`, `||`, and parentheses

## Limits documented

- unsupported JavaScript and datamodel expressions raise `InvalidConfigError`
- `<script>`, `<assign>`, `<send>`, general ECMAScript, and broader executable content are not imported
- structural `<final>`, `<history>`, and explicit `<initial>` elements are not converted yet
- the configured result is `54 passed, 0 failed`, including all 13 enabled `more-parallel` cases, but this is not a claim of complete W3C conformance
- `more-parallel/test10` and `test10b` remain outside the configured subset pending assignment support

## User impact

Users can import and run a local SCXML file using a tested example, understand how parallel transitions execute, and know immediately which conditions and XML elements are safe to rely on. No public API or runtime behavior changes.

## Validation

- `poetry run python docs/examples/scxml_toggle.py`
- `poetry run python -m pytest tests/test_examples.py -q` (5 passed)
- `poetry run python -m pytest tests/ --ignore=tests/test_scxml.py` (397 passed)
- `poetry run python -m pytest tests/test_scxml.py` (54 passed)
- `poetry run mypy src/xstate/`
- `poetry run ruff format --check src/ tests/ docs/examples/`
- `poetry run ruff check src/ tests/ docs/examples/`
- `git diff --check`