### PR TITLE
Fix SCXML state action ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ All notable changes to this project will be documented here.
 - Corrected SCXML transition-domain resolution so external transitions inside
   parallel states re-enter every affected region and resolve conflicts in
   document order.
+- Made state entry actions run in document order and exit actions run in
+  reverse document order, including nested and parallel configurations.
 
 ## 0.6.0 - 2026-06-28
 

--- a/src/xstate/algorithm.py
+++ b/src/xstate/algorithm.py
@@ -359,8 +359,7 @@ def enter_states(
         history_value=history_value,
     )
 
-    # TODO: sort
-    for s in list(states_to_enter):
+    for s in sorted(states_to_enter, key=lambda state: state.order):
         configuration.add(s)
         states_to_invoke.add(s)
 
@@ -368,7 +367,6 @@ def enter_states(
         #     initializeDataModel(datamodel.s,doc.s)
         #     s.isFirstEntry = false
 
-        # TODO: sort
         for action in s.entry:
             context = execute_content(
                 action,
@@ -417,8 +415,14 @@ def exit_states(
     context: dict | None = None,
     event: Event | None = None,
 ):
-    states_to_exit = compute_exit_set(
-        enabled_transitions, configuration=configuration, history_value=history_value
+    states_to_exit = sorted(
+        compute_exit_set(
+            enabled_transitions,
+            configuration=configuration,
+            history_value=history_value,
+        ),
+        key=lambda state: state.order,
+        reverse=True,
     )
     for s in states_to_exit:
         states_to_invoke.discard(s)

--- a/tests/test_action_ordering.py
+++ b/tests/test_action_ordering.py
@@ -1,0 +1,164 @@
+from collections.abc import Callable
+
+import pytest
+
+from xstate import HandlerArgs, Machine, interpret
+
+
+def recorder(log: list[str], label: str) -> Callable[[HandlerArgs], None]:
+    def record(_args: HandlerArgs) -> None:
+        log.append(label)
+
+    return record
+
+
+def test_nested_actions_follow_exit_transition_entry_order() -> None:
+    log: list[str] = []
+    labels = (
+        "left.enter",
+        "child.enter",
+        "child.exit",
+        "left.exit",
+        "transition",
+        "right.enter",
+    )
+    machine = Machine(
+        {
+            "id": "nested-order",
+            "initial": "left",
+            "states": {
+                "left": {
+                    "entry": "left.enter",
+                    "exit": "left.exit",
+                    "initial": "child",
+                    "states": {
+                        "child": {
+                            "entry": "child.enter",
+                            "exit": "child.exit",
+                            "on": {
+                                "GO": {
+                                    "target": "#right",
+                                    "actions": "transition",
+                                }
+                            },
+                        }
+                    },
+                },
+                "right": {"id": "right", "entry": "right.enter"},
+            },
+        },
+        actions={label: recorder(log, label) for label in labels},
+    )
+    service = interpret(machine).start()
+
+    assert log == ["left.enter", "child.enter"]
+
+    log.clear()
+    service.send("GO")
+
+    assert log == [
+        "child.exit",
+        "left.exit",
+        "transition",
+        "right.enter",
+    ]
+
+
+@pytest.mark.parametrize(
+    "region_order",
+    [("alpha", "beta"), ("beta", "alpha")],
+)
+def test_parallel_entries_follow_region_document_order(
+    region_order: tuple[str, str],
+) -> None:
+    log: list[str] = []
+    actions = {"active.enter": recorder(log, "active.enter")}
+    regions = {}
+    for region in region_order:
+        actions[f"{region}.enter"] = recorder(log, f"{region}.enter")
+        actions[f"{region}.idle.enter"] = recorder(log, f"{region}.idle.enter")
+        regions[region] = {
+            "entry": f"{region}.enter",
+            "initial": "idle",
+            "states": {"idle": {"entry": f"{region}.idle.enter"}},
+        }
+
+    machine = Machine(
+        {
+            "id": "parallel-entry-order",
+            "initial": "active",
+            "states": {
+                "active": {
+                    "type": "parallel",
+                    "entry": "active.enter",
+                    "states": regions,
+                }
+            },
+        },
+        actions=actions,
+    )
+
+    interpret(machine).start()
+
+    assert log == [
+        "active.enter",
+        f"{region_order[0]}.enter",
+        f"{region_order[0]}.idle.enter",
+        f"{region_order[1]}.enter",
+        f"{region_order[1]}.idle.enter",
+    ]
+
+
+@pytest.mark.parametrize(
+    "region_order",
+    [("alpha", "beta"), ("beta", "alpha")],
+)
+def test_parallel_exits_follow_reverse_region_document_order(
+    region_order: tuple[str, str],
+) -> None:
+    log: list[str] = []
+    labels = ["active.exit", "transition", "done.enter"]
+    regions = {}
+    for region in region_order:
+        labels.extend((f"{region}.exit", f"{region}.idle.exit"))
+        regions[region] = {
+            "exit": f"{region}.exit",
+            "initial": "idle",
+            "states": {"idle": {"exit": f"{region}.idle.exit"}},
+        }
+
+    machine = Machine(
+        {
+            "id": "parallel-exit-order",
+            "initial": "active",
+            "states": {
+                "active": {
+                    "type": "parallel",
+                    "exit": "active.exit",
+                    "on": {
+                        "STOP": {
+                            "target": "#done",
+                            "actions": "transition",
+                        }
+                    },
+                    "states": regions,
+                },
+                "done": {"id": "done", "entry": "done.enter"},
+            },
+        },
+        actions={label: recorder(log, label) for label in labels},
+    )
+    service = interpret(machine).start()
+
+    log.clear()
+    service.send("STOP")
+
+    assert log == [
+        f"{region_order[1]}.idle.exit",
+        f"{region_order[1]}.exit",
+        f"{region_order[0]}.idle.exit",
+        f"{region_order[0]}.exit",
+        "active.exit",
+        "transition",
+        "done.enter",
+    ]


### PR DESCRIPTION
## Summary

- execute state entry actions in parser document order
- execute state exit actions in reverse document order
- remove the two unresolved ordering TODOs from the SCXML algorithm core
- add observable regressions for nested transitions and parallel regions declared in both orders
- record the correctness fix in the existing untagged 0.7.0 changelog entry

## Why

The entry and exit sets are intentionally represented as sets while they are computed. Iterating those sets directly made side-effect ordering depend on Python object iteration rather than statechart document order.

SCXML requires deterministic ordering: ancestors and earlier document states enter first, while descendants and later document states exit first. This is observable whenever states declare entry or exit actions, especially across parallel regions.

## Behavior covered

- nested external transition: child exit, parent exit, transition action, target entry
- parallel entry: enclosing state, first declared region and leaf, then second declared region and leaf
- parallel exit: second declared region and leaf exit before the first, then enclosing state
- both parallel region declaration orders produce the corresponding deterministic trace

## Scope

This changes only state action ordering inside the existing microstep algorithm. Transition selection, transition domains, context updates, handler adaptation, snapshots, and public APIs are unchanged.

## Validation

- `poetry run python -m pytest tests/test_action_ordering.py -q` (5 passed)
- `poetry run python -m pytest tests/ --ignore=tests/test_scxml.py` (402 passed)
- `poetry run python -m pytest tests/test_scxml.py` (54 passed)
- `poetry run mypy src/xstate/`
- `poetry run ruff format --check src/ tests/ docs/examples/`
- `poetry run ruff check src/ tests/ docs/examples/`
- `git diff --check`