### PR TITLE
Harden test and release quality gates

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -61,8 +61,14 @@ jobs:
       - name: Install dependencies
         run: poetry install
       - name: Check formatting
-        run: poetry run ruff format --check src/ tests/ docs/examples/
+        run: poetry run ruff format --check src/ tests/ scripts/ docs/examples/
       - name: Run lint
-        run: poetry run ruff check src/ tests/ docs/examples/
+        run: poetry run ruff check src/ tests/ scripts/ docs/examples/
       - name: Run type checks
         run: poetry run mypy src/xstate/
+      - name: Check package metadata
+        run: poetry check --lock
+      - name: Build and validate distribution
+        run: |
+          poetry build
+          poetry run python scripts/validate_distribution.py

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -76,12 +76,16 @@ jobs:
       - name: Run SCXML smoke suite
         run: poetry run python -m pytest tests/test_scxml.py -m scxml_ci
       - name: Check formatting
-        run: poetry run ruff format --check src/ tests/ docs/examples/
+        run: poetry run ruff format --check src/ tests/ scripts/ docs/examples/
       - name: Run lint
-        run: poetry run ruff check src/ tests/ docs/examples/
+        run: poetry run ruff check src/ tests/ scripts/ docs/examples/
       - name: Run type checks
         run: poetry run mypy src/xstate/
+      - name: Build distribution
+        run: poetry build
+      - name: Validate built distribution
+        run: poetry run python scripts/validate_distribution.py
       - name: Publish to PyPI
         env:
           POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
-        run: poetry publish --build
+        run: poetry publish

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,8 +152,13 @@ poetry run python -m pytest tests/test_scxml.py -k cond-js
 poetry run mypy src/xstate/
 
 # Format and lint
-poetry run ruff format --check src/ tests/ docs/examples/
-poetry run ruff check src/ tests/ docs/examples/
+poetry run ruff format --check src/ tests/ scripts/ docs/examples/
+poetry run ruff check src/ tests/ scripts/ docs/examples/
+
+# Build and validate the installed wheel
+poetry check --lock
+poetry build
+poetry run python scripts/validate_distribution.py
 ```
 
 ## PR And Branch Guidance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ All notable changes to this project will be documented here.
 - Hardened SCXML import with canonical `guard` handlers, document-global ID and
   required-attribute validation, XML whitespace-aware targets, and full MyPy
   coverage.
+- Added a release artifact gate that installs the built wheel in an isolated
+  environment and checks package metadata, typing markers, imports, and a live
+  actor transition before publication.
+- Promoted unhandled test warnings to failures, raised the minimum coverage
+  threshold from 50% to 90%, and modernized canonical guards and examples to
+  the `HandlerArgs` and `guard` conventions.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,8 +225,13 @@ poetry run python -m pytest tests/test_scxml.py -k cond-js
 poetry run mypy src/xstate/
 
 # Format + lint
-poetry run ruff format --check src/ tests/ docs/examples/
-poetry run ruff check src/ tests/ docs/examples/
+poetry run ruff format --check src/ tests/ scripts/ docs/examples/
+poetry run ruff check src/ tests/ scripts/ docs/examples/
+
+# Build + validate the installed wheel
+poetry check --lock
+poetry build
+poetry run python scripts/validate_distribution.py
 ```
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,8 +37,11 @@ Run type checking and linting:
 
 ```bash
 poetry run mypy src/xstate/
-poetry run ruff format --check src/ tests/ docs/examples/
-poetry run ruff check src/ tests/ docs/examples/
+poetry run ruff format --check src/ tests/ scripts/ docs/examples/
+poetry run ruff check src/ tests/ scripts/ docs/examples/
+poetry check --lock
+poetry build
+poetry run python scripts/validate_distribution.py
 ```
 
 SCXML changes need the SCXML test framework:

--- a/README.md
+++ b/README.md
@@ -461,8 +461,13 @@ poetry run python -m pytest tests/ --ignore=tests/test_scxml.py
 poetry run mypy src/xstate/
 
 # Formatting and linting
-poetry run ruff format --check src/ tests/ docs/examples/
-poetry run ruff check src/ tests/ docs/examples/
+poetry run ruff format --check src/ tests/ scripts/ docs/examples/
+poetry run ruff check src/ tests/ scripts/ docs/examples/
+
+# Build and test the installed wheel
+poetry check --lock
+poetry build
+poetry run python scripts/validate_distribution.py
 ```
 
 ### Release preflight

--- a/docs/examples/fetch_with_retry.py
+++ b/docs/examples/fetch_with_retry.py
@@ -23,7 +23,7 @@ Run it::
     python docs/examples/fetch_with_retry.py
 """
 
-from xstate import Machine, assign, create_actor, from_promise
+from xstate import HandlerArgs, Machine, assign, create_actor, from_promise
 from xstate.scheduler import SimulatedClock
 
 # A flaky data source: fails the first two attempts, then succeeds. Stands in
@@ -41,9 +41,13 @@ def fetch_user(input):
     return {"id": input["user_id"], "name": "Ada Lovelace"}
 
 
-def can_retry(context, event):
+def can_retry(args: HandlerArgs) -> bool:
     """Guard: keep retrying until we hit the cap."""
-    return context["retries"] < context["max_retries"]
+    return args.context["retries"] < args.context["max_retries"]
+
+
+def retries_exhausted(args: HandlerArgs) -> bool:
+    return args.context["retries"] >= args.context["max_retries"]
 
 
 machine = Machine(
@@ -84,10 +88,10 @@ machine = Machine(
             },
             "retrying": {
                 "always": [
-                    {"target": "failure", "cond": "exhausted"},
+                    {"target": "failure", "guard": "exhausted"},
                 ],
                 # Back off, then try again — but only while canRetry holds.
-                "after": {"backoff": {"target": "loading", "cond": "canRetry"}},
+                "after": {"backoff": {"target": "loading", "guard": "canRetry"}},
             },
             "success": {"type": "final"},
             "failure": {"type": "final"},
@@ -95,7 +99,7 @@ machine = Machine(
     },
     guards={
         "canRetry": can_retry,
-        "exhausted": lambda c, e: c["retries"] >= c["max_retries"],
+        "exhausted": retries_exhausted,
     },
     delays={"backoff": 1000},
     actors={"fetchUser": from_promise(fetch_user)},

--- a/docs/examples/traffic_intersection.json
+++ b/docs/examples/traffic_intersection.json
@@ -46,7 +46,7 @@
               "on": {
                 "PED_REQUEST": {
                   "target": "walk",
-                  "cond": "crossingIsClear"
+                  "guard": "crossingIsClear"
                 }
               }
             },

--- a/docs/examples/traffic_intersection.py
+++ b/docs/examples/traffic_intersection.py
@@ -33,7 +33,7 @@ waiting — ideal for tests and reproducible demos.
 import json
 import os
 
-from xstate import Machine, interpret
+from xstate import HandlerArgs, Machine, interpret
 from xstate.scheduler import SimulatedClock
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -55,19 +55,24 @@ DELAYS = {
 }
 
 
-def crossing_is_clear(context, event):
+def crossing_is_clear(_args: HandlerArgs) -> bool:
     """Guard for `PED_REQUEST`: allow the walk signal only when it is safe.
 
-    Guards receive ``(context, event)``. A real controller would consult sensor
-    data on ``event.data``; here we always allow it.
+    A real controller would consult sensor data through ``HandlerArgs.event``;
+    here we always allow it.
     """
     return True
 
 
-ACTIONS = {
-    "allRed": lambda: print("   [action] all signals -> RED (emergency)"),
-    "startWalkSignal": lambda: print("   [action] WALK signal illuminated"),
-}
+def report_all_red(_args: HandlerArgs) -> None:
+    print("   [action] all signals -> RED (emergency)")
+
+
+def start_walk_signal(_args: HandlerArgs) -> None:
+    print("   [action] WALK signal illuminated")
+
+
+ACTIONS = {"allRed": report_all_red, "startWalkSignal": start_walk_signal}
 
 
 def build_machine() -> Machine:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ pythonpath = ["src"]
 markers = [
     "scxml_ci: stable SCXML conformance subset run in GitHub Actions",
 ]
+filterwarnings = ["error"]
 # `async def test_*` are collected and run without a per-test decorator.
 asyncio_mode = "auto"
 
@@ -114,7 +115,7 @@ branch = true
 exclude_lines = [
     "raise NotImplementedError"
 ]
-fail_under = 50
+fail_under = 90
 show_missing = true
 
 [build-system]

--- a/scripts/release_preflight.py
+++ b/scripts/release_preflight.py
@@ -152,6 +152,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "--check",
                 "src/",
                 "tests/",
+                "scripts/",
                 "docs/examples/",
             ),
         ),
@@ -164,11 +165,16 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "check",
                 "src/",
                 "tests/",
+                "scripts/",
                 "docs/examples/",
             ),
         ),
         ("Run type checks", ("poetry", "run", "mypy", "src/xstate/")),
         ("Build distribution", ("poetry", "build")),
+        (
+            "Validate built distribution",
+            ("poetry", "run", "python", "scripts/validate_distribution.py"),
+        ),
     )
     for label, command in steps:
         run(label, command)

--- a/scripts/validate_distribution.py
+++ b/scripts/validate_distribution.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Install the built wheel in isolation and exercise its public runtime."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import tomllib
+import venv
+from collections.abc import Sequence
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = ROOT / "pyproject.toml"
+DIST = ROOT / "dist"
+
+SMOKE_TEST = """
+import os
+from importlib.metadata import version
+from importlib.resources import files
+
+from xstate import Machine, create_actor
+from xstate.scxml import scxml_to_machine
+
+expected = os.environ["EXPECTED_XSTATE_VERSION"]
+assert version("xstate") == expected
+assert files("xstate").joinpath("py.typed").is_file()
+assert callable(scxml_to_machine)
+
+machine = Machine({
+    "id": "wheel-smoke",
+    "initial": "idle",
+    "states": {
+        "idle": {"on": {"START": "running"}},
+        "running": {},
+    },
+})
+actor = create_actor(machine).start()
+actor.send("START")
+assert actor.get_snapshot().matches("running")
+actor.stop()
+print(f"installed xstate {expected} wheel smoke passed")
+"""
+
+
+def fail(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr, flush=True)
+    raise SystemExit(1)
+
+
+def project_version() -> str:
+    with PYPROJECT.open("rb") as pyproject:
+        version = tomllib.load(pyproject).get("project", {}).get("version")
+    if not isinstance(version, str):
+        fail("pyproject.toml is missing [project].version")
+    return version
+
+
+def built_wheel(version: str) -> Path:
+    wheel = DIST / f"xstate-{version}-py3-none-any.whl"
+    if not wheel.is_file():
+        fail(f"expected built wheel {wheel}; run 'poetry build' first")
+    return wheel
+
+
+def run_checked(command: Sequence[str], *, cwd: Path, env: dict[str, str]) -> None:
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode == 0:
+        if completed.stdout:
+            print(completed.stdout.strip(), flush=True)
+        return
+
+    details = (completed.stderr or completed.stdout).strip()
+    if details:
+        print(details, file=sys.stderr, flush=True)
+    fail(f"command failed with exit code {completed.returncode}: {' '.join(command)}")
+
+
+def validate_distribution() -> None:
+    version = project_version()
+    wheel = built_wheel(version)
+
+    with tempfile.TemporaryDirectory(prefix="xstate-wheel-") as temp_dir:
+        temp = Path(temp_dir)
+        environment = temp / "venv"
+        venv.EnvBuilder(with_pip=True).create(environment)
+        python = environment / (
+            "Scripts/python.exe" if os.name == "nt" else "bin/python"
+        )
+
+        env = os.environ.copy()
+        env.pop("PYTHONPATH", None)
+        env["PYTHONNOUSERSITE"] = "1"
+        env["EXPECTED_XSTATE_VERSION"] = version
+
+        run_checked(
+            (
+                str(python),
+                "-m",
+                "pip",
+                "install",
+                "--disable-pip-version-check",
+                "--no-deps",
+                "--no-index",
+                str(wheel),
+            ),
+            cwd=temp,
+            env=env,
+        )
+        run_checked(
+            (str(python), "-c", SMOKE_TEST),
+            cwd=temp,
+            env=env,
+        )
+
+
+if __name__ == "__main__":
+    validate_distribution()

--- a/src/xstate/guards.py
+++ b/src/xstate/guards.py
@@ -10,20 +10,29 @@ uses the same matching syntax as a transition ``in`` guard.
 
 Usage::
 
-    from xstate import Machine, and_, stateIn
+    from xstate import HandlerArgs, Machine, and_, stateIn
+
+    def is_logged_in(args: HandlerArgs) -> bool:
+        return bool(args.context.get("logged_in"))
+
+    def has_permission(args: HandlerArgs) -> bool:
+        return bool(args.context.get("permission"))
 
     machine = Machine(config, guards={
-        "isLoggedIn": lambda ctx, evt: ctx.get("logged_in"),
-        "hasPermission": lambda ctx, evt: ctx.get("permission"),
+        "isLoggedIn": is_logged_in,
+        "hasPermission": has_permission,
         "canGo": and_("isLoggedIn", "hasPermission", stateIn("#ready")),
     })
 
 Or via the ``setup()`` builder (recommended)::
 
-    from xstate import setup, and_, state_in
+    from xstate import HandlerArgs, and_, setup, state_in
+
+    def is_logged_in(args: HandlerArgs) -> bool:
+        return bool(args.context.get("logged_in"))
 
     machine = setup(guards={
-        "isLoggedIn": lambda ctx, evt: ctx.get("logged_in"),
+        "isLoggedIn": is_logged_in,
         "canGo": and_("isLoggedIn", state_in("ready")),
     }).create_machine(config)
 
@@ -41,6 +50,15 @@ __all__ = ["and_", "or_", "not_", "state_in", "stateIn"]
 
 class _ComposableGuard:
     """Base class for ``and_``, ``or_``, ``not_``, and ``stateIn`` guards."""
+
+    __signature__ = inspect.Signature(
+        [
+            inspect.Parameter(
+                "args",
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            )
+        ]
+    )
 
     def _eval(
         self,
@@ -78,6 +96,15 @@ class _ComposableGuard:
 
     def __call__(self, context: Any = None, event: Any = None) -> bool:
         """Direct call without a registry or active configuration."""
+        from xstate.handlers import HandlerArgs
+
+        if isinstance(context, HandlerArgs):
+            return self._call(
+                context.context,
+                context.event,
+                {},
+                state=context.state,
+            )
         return self._call(context, event, {})
 
 

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -10,7 +10,7 @@ Covers:
 
 import pytest
 
-from xstate import Machine, and_, create_actor, not_, or_, setup
+from xstate import HandlerArgs, Machine, and_, create_actor, not_, or_, setup
 
 # ---------------------------------------------------------------------------
 # Standalone semantics
@@ -58,6 +58,12 @@ def test_and_empty_is_true():
 def test_or_empty_is_false():
     g = or_()
     assert g(None, None) is False
+
+
+def test_composable_guard_accepts_handler_args():
+    guard = and_(lambda args: args.context["ready"])
+
+    assert guard(HandlerArgs(context={"ready": True}, event=None)) is True
 
 
 # ---------------------------------------------------------------------------
@@ -118,7 +124,7 @@ def test_not_guard_in_machine_blocks():
 # ---------------------------------------------------------------------------
 
 
-def test_and_resolves_string_subguards():
+def test_event_payload_does_not_replace_context_for_string_guards():
     machine = Machine(
         {
             "id": "m",
@@ -142,9 +148,7 @@ def test_and_resolves_string_subguards():
     )
     actor = create_actor(machine).start()
     actor.send({"type": "GO", "logged_in": True, "permission": True})
-    # The event payload isn't context, so we need context in state
-    # Use a machine with context instead
-    assert actor.get_snapshot().value in ("a", "b")
+    assert actor.get_snapshot().value == "a"
 
 
 def test_and_string_guards_with_context():
@@ -166,8 +170,8 @@ def test_and_string_guards_with_context():
             },
         },
         guards={
-            "isLoggedIn": lambda c, e: c.get("logged_in"),
-            "hasPermission": lambda c, e: c.get("permission"),
+            "isLoggedIn": lambda args: args.context.get("logged_in"),
+            "hasPermission": lambda args: args.context.get("permission"),
         },
     )
     actor = create_actor(machine).start()
@@ -194,8 +198,8 @@ def test_and_string_guards_blocked_by_missing_permission():
             },
         },
         guards={
-            "isLoggedIn": lambda c, e: c.get("logged_in"),
-            "hasPermission": lambda c, e: c.get("permission"),
+            "isLoggedIn": lambda args: args.context.get("logged_in"),
+            "hasPermission": lambda args: args.context.get("permission"),
         },
     )
     actor = create_actor(machine).start()
@@ -286,8 +290,8 @@ def test_nested_not_and():
 def test_setup_with_composable_guards():
     machine = setup(
         guards={
-            "isLoggedIn": lambda c, e: c.get("logged_in"),
-            "hasPermission": lambda c, e: c.get("permission"),
+            "isLoggedIn": lambda args: args.context.get("logged_in"),
+            "hasPermission": lambda args: args.context.get("permission"),
             "canAccess": and_("isLoggedIn", "hasPermission"),
         }
     ).create_machine(
@@ -309,8 +313,8 @@ def test_setup_with_composable_guards():
 def test_setup_composable_guard_blocks():
     machine = setup(
         guards={
-            "isLoggedIn": lambda c, e: c.get("logged_in"),
-            "hasPermission": lambda c, e: c.get("permission"),
+            "isLoggedIn": lambda args: args.context.get("logged_in"),
+            "hasPermission": lambda args: args.context.get("permission"),
             "canAccess": and_("isLoggedIn", "hasPermission"),
         }
     ).create_machine(

--- a/tests/test_machine.py
+++ b/tests/test_machine.py
@@ -1,4 +1,9 @@
+from xstate import HandlerArgs
 from xstate.machine import Machine
+
+
+def no_op(_args: HandlerArgs) -> None:
+    pass
 
 
 def make_lights():
@@ -23,7 +28,8 @@ def make_lights():
                     "onDone": "green",
                 },
             },
-        }
+        },
+        actions={"enterGreen": no_op},
     )
 
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -35,7 +35,7 @@ def test_create_machine_returns_machine():
 def test_setup_guards_registered():
     machine = setup(
         guards={
-            "isReady": lambda c, e: True,
+            "isReady": lambda args: True,
         }
     ).create_machine(
         {
@@ -57,7 +57,7 @@ def test_setup_actions_registered():
 
     machine = setup(
         actions={
-            "recordCall": lambda: calls.append(True),
+            "recordCall": lambda args: calls.append(True),
         }
     ).create_machine(
         {
@@ -99,7 +99,7 @@ def test_setup_delays_registered():
 def test_multiple_create_machine_from_one_setup():
     ms = setup(
         guards={
-            "isReady": lambda c, e: True,
+            "isReady": lambda args: True,
         }
     )
     m1 = ms.create_machine(
@@ -133,7 +133,7 @@ def test_multiple_create_machine_from_one_setup():
 def test_create_machine_overrides_setup_guards():
     machine = setup(
         guards={
-            "isReady": lambda c, e: False,
+            "isReady": lambda args: False,
         }
     ).create_machine(
         {
@@ -145,7 +145,7 @@ def test_create_machine_overrides_setup_guards():
             },
         },
         guards={
-            "isReady": lambda c, e: True,
+            "isReady": lambda args: True,
         },
     )
     actor = create_actor(machine).start()
@@ -156,8 +156,8 @@ def test_create_machine_overrides_setup_guards():
 def test_setup_with_composable_guard():
     machine = setup(
         guards={
-            "isLoggedIn": lambda c, e: c.get("logged_in", False),
-            "isAdmin": lambda c, e: c.get("admin", False),
+            "isLoggedIn": lambda args: args.context.get("logged_in", False),
+            "isAdmin": lambda args: args.context.get("admin", False),
             "canEdit": and_("isLoggedIn", "isAdmin"),
         }
     ).create_machine(


### PR DESCRIPTION
## Summary

- make composable guards advertise and accept the canonical `HandlerArgs` contract
- modernize strict `setup()` fixtures and canonical examples to `HandlerArgs` and XState v5 `guard`
- replace a permissive guard assertion with an exact context-vs-event regression
- register the intended action implementation in machine tests instead of tolerating warnings
- promote every unhandled pytest warning to an error
- raise the enforced branch-coverage floor from 50% to 90% (current result: 92.04%)
- add an installed-wheel artifact validator
- run package metadata, build, and wheel validation in PR CI, release preflight, and release publishing
- lint `scripts/` everywhere contributor and CI commands are documented
- build once and publish the already-validated artifacts in the release workflow

## Why

The suite passed while emitting 17 warnings from stale strict-setup fixtures and an unregistered test action. Canonical examples also still used legacy `cond` keys and legacy registered handler forms.

A 50% coverage floor did not reflect the repository's actual 92% coverage, and the release path tested the checkout but never proved that the built wheel could be installed and run without source-tree shadowing.

This adopts the artifact-validation pattern used successfully in the neighboring projects: validate what will actually ship, not only the source workspace.

## Installed-wheel validation

`scripts/validate_distribution.py`:

- resolves the expected wheel from `pyproject.toml`
- creates a clean temporary virtual environment
- installs the local wheel with `--no-index --no-deps`
- removes `PYTHONPATH` and disables user-site imports
- verifies installed package metadata and version
- verifies the shipped `py.typed` marker
- imports the SCXML entry point
- starts a machine actor, sends an event, checks the resulting snapshot, and stops it

## Test policy

- unhandled warnings now fail immediately through pytest configuration
- explicit compatibility-warning tests remain valid because they capture their expected warnings
- coverage below 90% fails CI
- the primary and configured SCXML suites currently complete with no warning summary

## Release behavior

The release workflow now builds the distribution, validates those exact artifacts, and then runs `poetry publish`. It no longer rebuilds a different artifact during the publish command.

## Validation

- `poetry run python -m pytest tests/ --ignore=tests/test_scxml.py` (413 passed, zero warnings)
- `poetry run python -m pytest tests/test_scxml.py` (54 passed, zero warnings)
- `poetry run pytest tests/ --ignore=tests/test_scxml.py --cov --cov-report=xml` (413 passed, 92.04%)
- `poetry run mypy src/xstate/`
- `poetry run ruff format --check src/ tests/ scripts/ docs/examples/`
- `poetry run ruff check src/ tests/ scripts/ docs/examples/`
- `poetry check --lock`
- `poetry build`
- `poetry run python scripts/validate_distribution.py`
- full local release preflight with `HEAD` used as both target and master reference
- `git diff --check`