### PR TITLE
Upgrade CI action runtimes and remove broken coverage upload

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -12,10 +15,10 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry
@@ -25,15 +28,20 @@ jobs:
       - name: Run tests
         run: poetry run pytest tests/ --ignore=tests/test_scxml.py --cov --cov-report=xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        if: matrix.python-version == '3.13'
+        uses: codecov/codecov-action@v7
+        with:
+          fail_ci_if_error: true
+          files: ./coverage.xml
+          use_oidc: true
   scxml-smoke:
     name: SCXML smoke
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.13"
       - name: Install Poetry
@@ -50,10 +58,10 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -5,9 +5,6 @@ on:
 
 jobs:
   test:
-    permissions:
-      contents: read
-      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -27,13 +24,6 @@ jobs:
         run: poetry install
       - name: Run tests
         run: poetry run pytest tests/ --ignore=tests/test_scxml.py --cov --cov-report=xml
-      - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.13'
-        uses: codecov/codecov-action@v7
-        with:
-          fail_ci_if_error: true
-          files: ./coverage.xml
-          use_oidc: true
   scxml-smoke:
     name: SCXML smoke
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,11 +16,11 @@ jobs:
     if: ${{ !github.event.release.draft && !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: recursive
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.13"
       - name: Check PyPI token

--- a/.github/workflows/release_preflight.yaml
+++ b/.github/workflows/release_preflight.yaml
@@ -19,12 +19,12 @@ jobs:
   preflight:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: master
           submodules: recursive
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.13"
       - name: Install Poetry

--- a/README.md
+++ b/README.md
@@ -470,6 +470,20 @@ poetry build
 poetry run python scripts/validate_distribution.py
 ```
 
+### Continuous integration
+
+Pull requests run the primary suite on Python 3.13 and 3.14, the stable SCXML
+smoke subset, and the complete formatting, lint, type, metadata, build, and
+installed-wheel checks. The Python 3.13 lane uploads its single coverage report
+with Codecov's GitHub OIDC flow and fails if the upload is rejected; the test
+suite independently enforces the 90% coverage floor before that upload.
+
+The workflows use the Node-runtime-v7 releases of checkout, setup-python, and
+Codecov. Coverage authentication does not depend on a long-lived repository
+secret. Release and manual preflight workflows use the same checkout and Python
+setup majors so validation and publication do not drift onto deprecated action
+runtimes.
+
 ### Release preflight
 
 Before creating the GitHub Release for `0.7.0`, run the local preflight from

--- a/README.md
+++ b/README.md
@@ -474,14 +474,12 @@ poetry run python scripts/validate_distribution.py
 
 Pull requests run the primary suite on Python 3.13 and 3.14, the stable SCXML
 smoke subset, and the complete formatting, lint, type, metadata, build, and
-installed-wheel checks. The Python 3.13 lane uploads its single coverage report
-with Codecov's GitHub OIDC flow and fails if the upload is rejected; the test
-suite independently enforces the 90% coverage floor before that upload.
+installed-wheel checks. The test suite enforces the 90% coverage floor directly,
+so pull-request acceptance does not depend on an external coverage service.
 
-The workflows use the Node-runtime-v7 releases of checkout, setup-python, and
-Codecov. Coverage authentication does not depend on a long-lived repository
-secret. Release and manual preflight workflows use the same checkout and Python
-setup majors so validation and publication do not drift onto deprecated action
+The workflows use the Node-runtime-v7 releases of checkout and setup-python.
+Release and manual preflight workflows use the same checkout and Python setup
+majors so validation and publication do not drift onto deprecated action
 runtimes.
 
 ### Release preflight

--- a/tests/test_ci_workflow_contract.py
+++ b/tests/test_ci_workflow_contract.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+def read_workflow(name: str) -> str:
+    return (WORKFLOWS / name).read_text(encoding="utf-8")
+
+
+def test_all_python_workflows_use_current_action_runtime_majors() -> None:
+    workflow_text = "\n".join(
+        path.read_text(encoding="utf-8") for path in sorted(WORKFLOWS.glob("*.yaml"))
+    )
+
+    assert "actions/checkout@v4" not in workflow_text
+    assert "actions/setup-python@v5" not in workflow_text
+    assert workflow_text.count("actions/checkout@v7") == 5
+    assert workflow_text.count("actions/setup-python@v7") == 5
+
+
+def test_coverage_upload_is_single_lane_oidc_and_fail_closed() -> None:
+    workflow = read_workflow("pull_request.yaml")
+
+    assert "id-token: write" in workflow
+    assert "codecov/codecov-action@v7" in workflow
+    assert "if: matrix.python-version == '3.13'" in workflow
+    assert "fail_ci_if_error: true" in workflow
+    assert "files: ./coverage.xml" in workflow
+    assert "use_oidc: true" in workflow

--- a/tests/test_ci_workflow_contract.py
+++ b/tests/test_ci_workflow_contract.py
@@ -19,12 +19,9 @@ def test_all_python_workflows_use_current_action_runtime_majors() -> None:
     assert workflow_text.count("actions/setup-python@v7") == 5
 
 
-def test_coverage_upload_is_single_lane_oidc_and_fail_closed() -> None:
+def test_coverage_gate_does_not_depend_on_an_external_upload() -> None:
     workflow = read_workflow("pull_request.yaml")
 
-    assert "id-token: write" in workflow
-    assert "codecov/codecov-action@v7" in workflow
-    assert "if: matrix.python-version == '3.13'" in workflow
-    assert "fail_ci_if_error: true" in workflow
-    assert "files: ./coverage.xml" in workflow
-    assert "use_oidc: true" in workflow
+    assert "--cov --cov-report=xml" in workflow
+    assert "codecov/codecov-action" not in workflow
+    assert "id-token: write" not in workflow


### PR DESCRIPTION
## Summary

- upgrade `actions/checkout` and `actions/setup-python` to their v7 Node-runtime releases across pull-request, release, and release-preflight workflows
- remove the nonfunctional Codecov upload while retaining the repository-enforced 90% coverage gate
- document and regression-test the resulting CI contract

## Why

The previous workflow appeared green while Codecov logged `Token required - not valid tokenless upload`; the action's default behavior swallowed the error. A hosted trial of OIDC on commit `b5f4023` successfully issued an identity token and found `coverage.xml`, but Codecov returned `Repository not found`, confirming that the external integration is not configured for this repository.

The test suite already enforces the 90% coverage floor. Removing the broken upload makes CI honest and removes an unnecessary external dependency instead of adding a long-lived secret or preserving a permanently failing step.

## Scope and non-scope

This changes CI action runtimes and removes a broken coverage publishing step. It does not change the xstate runtime API, SCXML behavior, package version, release trigger, or PyPI credentials. No release or publication was triggered.

## Local validation

- primary test suite: 417 passed
- configured SCXML suite: 54 passed
- workflow contract tests: 2 passed after the final narrowing
- mypy: 22 source files clean
- Ruff format and lint: clean
- `poetry check --lock`: clean
- sdist and wheel build: passed
- installed-wheel smoke validation: passed
- `git diff --check`: clean

## Hosted acceptance gate

Merge only if all four checks on exact head `c3de600` are green and GitHub reports no deprecated Node runtime annotation.

## Risk and rollback

The repository will no longer publish coverage to Codecov. The enforced 90% pull-request threshold remains in the primary test command, so this does not weaken acceptance. Rollback is a revert of these two commits; no application or package state is mutated.

## Review focus

- consistent v7 checkout and Python setup majors across all Python workflows
- preservation of the enforced coverage threshold without an unconfigured external service
- regression coverage for the workflow contract
