### PR TITLE
Vendor the exercised SCXML fixture subset

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,27 +1,3 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/python-3/.devcontainer/base.Dockerfile
+FROM mcr.microsoft.com/devcontainers/python:1-3.13-bookworm@sha256:0aa711e570b306c02946cdda67587ce8c65978dbb65691341cbcfd4854dfcfff
 
-# [Choice] Python version: 3, 3.9, 3.8, 3.7, 3.6
-ARG VARIANT="3.9"
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
-
-# [Option] Install Node.js
-ARG INSTALL_NODE="true"
-ARG NODE_VERSION="lts/*"
-RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
-
-# install poetry for vscode user
-ENV POETRY_VERSION=1.1.6 \
-   PATH=/home/vscode/.poetry/bin:$PATH
-RUN runuser -l vscode -c 'curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -'
-
-
-# [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
-# RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements_dev.txt \
-#    && rm -rf /tmp/pip-tmp
-
-# [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
-
-# [Optional] Uncomment this line to install global node packages.
-# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1
+RUN pipx install "poetry==2.4.1"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,16 +1,9 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/python-3
+// For format details, see https://containers.dev/implementors/json_reference/.
 {
 	"name": "XState Python",
 	"build": {
 		"dockerfile": "Dockerfile",
-		"context": "..",
-		"args": { 
-			// Update 'VARIANT' to pick a Python version: 3, 3.6, 3.7, 3.8, 3.9
-			"VARIANT": "3.7",
-			// Options
-			"INSTALL_NODE": "false",
-		}
+		"context": ".."
 	},
 
 	// Set *default* container specific settings.json values on container create.
@@ -29,7 +22,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "git submodule update --init && poetry install",
+	"postCreateCommand": "poetry install",
 
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Preserve third-party conformance fixtures byte-for-byte, including source whitespace.
+tests/fixtures/scxml/** -whitespace

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -12,14 +12,12 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7
-        with:
-          submodules: recursive
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry
-        run: python -m pip install "poetry>=2.0,<3.0"
+        run: python -m pip install "poetry==2.4.1"
       - name: Install dependencies
         run: poetry install
       - name: Run tests
@@ -28,14 +26,12 @@ jobs:
     name: SCXML smoke
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-        with:
-          submodules: recursive
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.13"
       - name: Install Poetry
-        run: python -m pip install "poetry>=2.0,<3.0"
+        run: python -m pip install "poetry==2.4.1"
       - name: Install dependencies
         run: poetry install
       - name: Run SCXML smoke suite
@@ -48,14 +44,12 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7
-        with:
-          submodules: recursive
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry
-        run: python -m pip install "poetry>=2.0,<3.0"
+        run: python -m pip install "poetry==2.4.1"
       - name: Install dependencies
         run: poetry install
       - name: Check formatting

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,11 +16,10 @@ jobs:
     if: ${{ !github.event.release.draft && !github.event.release.prerelease }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          submodules: recursive
           fetch-depth: 0
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.13"
       - name: Check PyPI token
@@ -32,7 +31,7 @@ jobs:
             exit 1
           fi
       - name: Install Poetry
-        run: python -m pip install "poetry>=2.0,<3.0"
+        run: python -m pip install "poetry==2.4.1"
       - name: Install dependencies
         run: poetry install
       - name: Run release preflight

--- a/.github/workflows/release_preflight.yaml
+++ b/.github/workflows/release_preflight.yaml
@@ -19,16 +19,15 @@ jobs:
   preflight:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: master
-          submodules: recursive
           fetch-depth: 0
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.13"
       - name: Install Poetry
-        run: python -m pip install "poetry>=2.0,<3.0"
+        run: python -m pip install "poetry==2.4.1"
       - name: Install dependencies
         run: poetry install
       - name: Run release preflight

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "test-framework"]
-	path = test-framework
-	url = https://gitlab.com/scion-scxml/test-framework.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,8 +141,7 @@ poetry install
 # Primary suite
 poetry run python -m pytest tests/ --ignore=tests/test_scxml.py
 
-# SCXML tests
-git submodule update --init
+# SCXML tests use the checked-in fixture subset under tests/fixtures/scxml
 poetry run python -m pytest tests/test_scxml.py
 
 # Focused SCXML boolean cond subset

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,8 +214,7 @@ poetry install
 # Run the test suite (primary target — no extras needed)
 poetry run python -m pytest tests/ --ignore=tests/test_scxml.py
 
-# Run SCXML tests (needs test-framework submodule)
-git submodule update --init
+# Run SCXML tests against the checked-in fixture subset
 poetry run python -m pytest tests/test_scxml.py
 
 # Focused SCXML boolean cond subset
@@ -248,7 +247,8 @@ library. The SCXML importer now uses a small pure-Python Boolean evaluator.
 ### Algorithm changes require SCXML test verification
 
 `xstate/algorithm.py` implements the W3C SCXML algorithm. Any change to it must be
-verified against the SCXML test framework (`test-framework/`). The reference is:
+verified against the repository-owned SCXML Test Framework fixture subset under
+`tests/fixtures/scxml/`. The reference is:
 https://www.w3.org/TR/scxml/#AlgorithmforSCXMLInterpretation
 
 Key functions and their SCXML algorithm counterparts:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,10 +44,9 @@ poetry build
 poetry run python scripts/validate_distribution.py
 ```
 
-SCXML changes need the SCXML test framework:
+SCXML changes use the checked-in, provenance-preserving fixture subset:
 
 ```bash
-git submodule update --init
 poetry run python -m pytest tests/test_scxml.py
 ```
 

--- a/README.md
+++ b/README.md
@@ -435,19 +435,20 @@ from xstate.scheduler import SimulatedClock, ThreadClock
 ## SCXML
 
 The algorithm core follows the W3C SCXML execution model. XML import is exposed
-through `xstate.scxml.scxml_to_machine(...)` and verified against the SCXML test
-framework. See the [SCXML import guide](./docs/concepts/scxml.md) for supported
-elements, safe conditions, and current limits.
+through `xstate.scxml.scxml_to_machine(...)` and verified against a focused,
+repository-owned fixture subset from the SCXML Test Framework. See the
+[SCXML import guide](./docs/concepts/scxml.md) for supported elements, safe
+conditions, and current limits. Fixture provenance and the Apache 2.0 license
+are retained under `tests/fixtures/scxml/`.
 
 ```bash
-git submodule update --init
 poetry run python -m pytest tests/test_scxml.py
 ```
 
-Current configured-suite result: `54 passed`, `0 failed`, including all enabled
-`more-parallel` cases. This is a focused SCXML subset rather than a claim of full
-W3C conformance; broader datamodel and executable-content coverage remains
-future work. The `cond-js` subset passes with the safe Boolean evaluator.
+The configured conformance subset contains 54 passing cases, including all enabled
+`more-parallel` cases, plus a fixture inventory/provenance guard. This is a focused SCXML
+subset rather than a claim of full W3C conformance; broader datamodel and executable-content
+coverage remains future work. The `cond-js` subset passes with the safe Boolean evaluator.
 
 ## Developing
 

--- a/docs/concepts/scxml.md
+++ b/docs/concepts/scxml.md
@@ -111,18 +111,16 @@ An expression such as `count > 0` is rejected in the same way; defining
 
 ## Conformance Boundary
 
-The configured repository suite currently reports `54 passed`, `0 failed`,
-including all 13 enabled `more-parallel` cases. This is a focused subset, not a
-claim of complete W3C SCXML conformance. The broader datamodel and executable
-content surface remains future work, and the `more-parallel` `test10` and
-`test10b` fixtures remain outside the configured set because they require
-additional assignment support.
+The configured repository subset contains 54 passing conformance cases, including all 13 enabled
+`more-parallel` cases, plus a fixture inventory/provenance guard. This is a focused subset, not a
+claim of complete W3C SCXML conformance. The broader datamodel and executable content surface
+remains future work, and the `more-parallel` `test10` and `test10b` fixtures remain outside the
+configured set because they require additional assignment support.
 
 Run the self-contained [SCXML toggle example](../examples/scxml_toggle.py), or
-run the configured conformance suite after initializing its submodule:
+run the configured conformance suite against the checked-in fixture subset:
 
 ```bash
 PYTHONPATH=src python3 docs/examples/scxml_toggle.py
-git submodule update --init
 poetry run python -m pytest tests/test_scxml.py
 ```

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -106,5 +106,5 @@ Files: [`scxml_toggle.scxml`](./scxml_toggle.scxml) and
 
 This self-contained pair imports a local SCXML document, exercises safe Boolean
 conditions and raise executable content, and toggles in both directions through
-the pure `Machine.transition(...)` API. It does not require the conformance test
-submodule.
+the pure `Machine.transition(...)` API. It is independent of the vendored
+conformance-test fixture subset.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
+  ],
+  "dependencyDashboard": true,
+  "packageRules": [
+    {
+      "description": "Keep devcontainer bases immutable while allowing reviewed digest refreshes",
+      "matchDatasources": ["docker"],
+      "pinDigests": true
+    }
+  ]
+}

--- a/tests/fixtures/scxml/LICENSE.txt
+++ b/tests/fixtures/scxml/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/tests/fixtures/scxml/PROVENANCE.md
+++ b/tests/fixtures/scxml/PROVENANCE.md
@@ -1,0 +1,13 @@
+# SCXML Fixture Provenance
+
+The `.scxml` and `.json` files in the child directories are an unmodified, focused subset of the
+SCXML Test Framework fixtures used by this project's configured conformance tests.
+
+- Source: `https://gitlab.com/scion-scxml/test-framework.git`
+- Source commit: `b46a10a1c3a3b1ca5c5cb4bb44ddb5c785611f41`
+- Source paths: `test/<group>/<case>.scxml` and `test/<group>/<case>.json`
+- License: Apache License 2.0; see `LICENSE.txt` in this directory.
+
+Only the cases enumerated in `tests/test_scxml.py` are vendored. The JavaScript runner, package
+manifest, lockfile, and unused fixtures are intentionally excluded so Python tests do not inherit
+the third-party Node dependency graph.

--- a/tests/fixtures/scxml/actionSend/send1.json
+++ b/tests/fixtures/scxml/actionSend/send1.json
@@ -1,0 +1,12 @@
+{
+    "initialConfiguration" : ["a"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["c"]
+        }
+    ]
+}
+
+
+

--- a/tests/fixtures/scxml/actionSend/send1.scxml
+++ b/tests/fixtures/scxml/actionSend/send1.scxml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    initial="a"
+    version="1.0">
+
+    <state id="a">
+        <transition target="b" event="t">
+            <raise event="s"/>
+        </transition>
+    </state>
+
+    <state id="b">
+        <transition target="c" event="s"/>
+    </state>
+
+    <state id="c">
+    </state>
+
+</scxml>
+
+
+
+

--- a/tests/fixtures/scxml/actionSend/send2.json
+++ b/tests/fixtures/scxml/actionSend/send2.json
@@ -1,0 +1,13 @@
+{
+    "initialConfiguration" : ["a"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["c"]
+        }
+    ]
+}
+
+
+
+

--- a/tests/fixtures/scxml/actionSend/send2.scxml
+++ b/tests/fixtures/scxml/actionSend/send2.scxml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    initial="a"
+    version="1.0">
+
+    <state id="a">
+        <onexit>
+            <raise event="s"/>
+        </onexit>
+
+        <transition target="b" event="t">
+        </transition>
+    </state>
+
+    <state id="b">
+        <transition target="c" event="s"/>
+    </state>
+
+    <state id="c">
+    </state>
+
+</scxml>
+
+
+
+
+

--- a/tests/fixtures/scxml/actionSend/send3.json
+++ b/tests/fixtures/scxml/actionSend/send3.json
@@ -1,0 +1,14 @@
+{
+    "initialConfiguration" : ["a"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["c"]
+        }
+    ]
+}
+
+
+
+
+

--- a/tests/fixtures/scxml/actionSend/send3.scxml
+++ b/tests/fixtures/scxml/actionSend/send3.scxml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    initial="a"
+    version="1.0">
+
+    <state id="a">
+        <transition target="b" event="t">
+        </transition>
+    </state>
+
+    <state id="b">
+        <onentry>
+            <raise event="s"/>
+        </onentry>
+
+        <transition target="c" event="s"/>
+    </state>
+
+    <state id="c">
+    </state>
+
+</scxml>
+
+
+
+
+
+

--- a/tests/fixtures/scxml/actionSend/send4.json
+++ b/tests/fixtures/scxml/actionSend/send4.json
@@ -1,0 +1,15 @@
+{
+    "initialConfiguration" : ["a"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["f1"]
+        }
+    ]
+}
+
+
+
+
+
+

--- a/tests/fixtures/scxml/actionSend/send4.scxml
+++ b/tests/fixtures/scxml/actionSend/send4.scxml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<!--
+    In SCION < 3 semantics:
+     This is a test to illustrate the event lifeline. In c, event "s" should no longer be in the event queue, as we are using Next Small Step semantics, so we should end up in d. This would not be true if we were using Remainder semantics. 
+    In SCION >= 3 semantics (SCXML Appendix D semantics):
+      The state machine will enter state 'b', then transition to target 'f1' will be selected over transition to target 'c', because transition to target 'f1' is an eventless transition. In the Algorithm for SCXML interpretation, transitions without events are selected before transitions with events; and transitions with events will only be selected if no eventless transitions are selected.
+     -->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    initial="a"
+    version="1.0">
+
+    <state id="a">
+        <transition target="b" event="t">
+        </transition>
+    </state>
+
+    <state id="b">
+        <onentry>
+            <raise event="s"/>
+        </onentry>
+
+        <transition target="c" event="s"/>
+        <transition target="f1"/>
+    </state>
+
+    <state id="c">
+        <transition target="f2" event="s"/>
+        <transition target="d"/>
+    </state>
+
+    <state id="f1">
+    </state>
+
+    <state id="d">
+    </state>
+
+    <state id="f2">
+    </state>
+
+</scxml>

--- a/tests/fixtures/scxml/actionSend/send4b.json
+++ b/tests/fixtures/scxml/actionSend/send4b.json
@@ -1,0 +1,16 @@
+{
+    "initialConfiguration" : ["a"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["c"]
+        }
+    ]
+}
+
+
+
+
+
+
+

--- a/tests/fixtures/scxml/actionSend/send4b.scxml
+++ b/tests/fixtures/scxml/actionSend/send4b.scxml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    initial="a"
+    version="1.0">
+
+    <state id="a">
+        <transition target="b" event="t">
+        </transition>
+    </state>
+
+    <state id="b">
+        <onentry>
+            <raise event="s"/>
+        </onentry>
+
+        <transition target="c" event="s"/>
+    </state>
+
+    <state id="c">
+    </state>
+
+</scxml>
+

--- a/tests/fixtures/scxml/actionSend/send7.json
+++ b/tests/fixtures/scxml/actionSend/send7.json
@@ -1,0 +1,9 @@
+{
+    "initialConfiguration" : ["a"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["b3"]
+        }
+    ]
+}

--- a/tests/fixtures/scxml/actionSend/send7.scxml
+++ b/tests/fixtures/scxml/actionSend/send7.scxml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<!--
+    In SCION < 3 semantics:
+      Illustrates one of the edge cases of these semantics. In SCION 2.0, "inital" attribute is no longer normalized
+      such that it is treated as a transition into an initial state. Instead, transition from "a" to "b1" is taken 
+      in the same small-step.
+      Thus event "s" is in the inner queue when machine enters "b1", which causes transition to be taken to "b1".
+    In SCION >= 3 semantics (SCXML Appendix D semantics):
+      The state machine will enter state 'b1', then transition to target 'b3' will be selected over transition to target 'b2', because transition to target 'b3' is an eventless transition. In the Algorithm for SCXML interpretation, transitions without events are selected before transitions with events; and transitions with events will only be selected if no eventless transitions are selected.
+     -->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    initial="a"
+    version="1.0">
+
+    <state id="a">
+        <transition target="b" event="t">
+            <raise event="s"/>
+        </transition>
+    </state>
+
+    <state id="b" initial="b1">
+        <state id="b1">
+            <transition event="s" target="b2"/>
+            <transition target="b3"/>
+        </state>
+
+        <state id="b2">
+        </state>
+
+        <state id="b3">
+        </state>
+    </state>
+</scxml>

--- a/tests/fixtures/scxml/actionSend/send7b.json
+++ b/tests/fixtures/scxml/actionSend/send7b.json
@@ -1,0 +1,10 @@
+{
+    "initialConfiguration" : ["a"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["b2"]
+        }
+    ]
+}
+

--- a/tests/fixtures/scxml/actionSend/send7b.scxml
+++ b/tests/fixtures/scxml/actionSend/send7b.scxml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    initial="a"
+    version="1.0">
+
+    <state id="a">
+        <transition target="b" event="t">
+            <raise event="s"/>
+        </transition>
+    </state>
+
+    <state id="b" initial="b1">
+        <state id="b1">
+            <transition event="s" target="b2"/>
+        </state>
+
+        <state id="b2">
+        </state>
+
+        <state id="b3">
+        </state>
+    </state>
+</scxml>
+

--- a/tests/fixtures/scxml/actionSend/send8.json
+++ b/tests/fixtures/scxml/actionSend/send8.json
@@ -1,0 +1,19 @@
+{
+    "initialConfiguration" : ["a"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["b3"]
+        }
+    ]
+}
+
+
+
+
+
+
+
+
+
+

--- a/tests/fixtures/scxml/actionSend/send8.scxml
+++ b/tests/fixtures/scxml/actionSend/send8.scxml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<!--
+    In SCION < 3 semantics:
+      Illustrates one of the edge cases of these semantics. Followup to send7. If we target, not the outer composite state, but the inner state directly, the event will be available in the next small step. This is an example of the way in which these semantics break the synchrony hypthosesis. 
+    In SCION >= 3 semantics (SCXML Appendix D semantics):
+      The state machine will enter state 'b1', then transition to target 'b3' will be selected over transition to target 'b2', because transition to target 'b3' is an eventless transition. In the Algorithm for SCXML interpretation, transitions without events are selected before transitions with events; and transitions with events will only be selected if no eventless transitions are selected.
+     -->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    initial="a"
+    version="1.0">
+
+    <state id="a">
+        <transition target="b1" event="t">
+            <raise event="s"/>
+        </transition>
+    </state>
+
+    <state id="b" initial="b1">
+        <state id="b1">
+            <transition event="s" target="b2"/>
+            <transition target="b3"/>
+        </state>
+
+        <state id="b2">
+        </state>
+
+        <state id="b3">
+        </state>
+    </state>
+</scxml>
+
+
+
+

--- a/tests/fixtures/scxml/actionSend/send8b.json
+++ b/tests/fixtures/scxml/actionSend/send8b.json
@@ -1,0 +1,9 @@
+{
+    "initialConfiguration" : ["a"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["b2"]
+        }
+    ]
+}

--- a/tests/fixtures/scxml/actionSend/send8b.scxml
+++ b/tests/fixtures/scxml/actionSend/send8b.scxml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    initial="a"
+    version="1.0">
+
+    <state id="a">
+        <transition target="b1" event="t">
+            <raise event="s"/>
+        </transition>
+    </state>
+
+    <state id="b" initial="b1">
+        <state id="b1">
+            <transition event="s" target="b2"/>
+        </state>
+
+        <state id="b2">
+        </state>
+
+        <state id="b3">
+        </state>
+    </state>
+</scxml>
+
+
+
+
+

--- a/tests/fixtures/scxml/actionSend/send9.json
+++ b/tests/fixtures/scxml/actionSend/send9.json
@@ -1,0 +1,18 @@
+{
+    "initialConfiguration" : ["a"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["b3"]
+        }
+    ]
+}
+
+
+
+
+
+
+
+
+

--- a/tests/fixtures/scxml/actionSend/send9.scxml
+++ b/tests/fixtures/scxml/actionSend/send9.scxml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<!--
+    Illustrates one of the edge cases of these semantics. Because initial
+    transition will be taken in its own small step, triggered event "s" will be
+    "lost" - not availble in the next small step from b1. Will therefore end up in b3.
+
+    Note the difference between this test and send7. These tests are no longer equivalent.
+    This is a semantic change from SCION 2.0
+     -->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    initial="a"
+    version="1.0">
+
+    <state id="a">
+        <transition target="b" event="t">
+            <raise event="s"/>
+        </transition>
+    </state>
+
+    <state id="b">
+        <initial>
+            <transition target="b1"/>
+        </initial>
+        <state id="b1">
+            <transition event="s" target="b2"/>
+            <transition target="b3"/>
+        </state>
+
+        <state id="b2">
+        </state>
+
+        <state id="b3">
+        </state>
+    </state>
+</scxml>
+
+
+

--- a/tests/fixtures/scxml/basic/basic0.json
+++ b/tests/fixtures/scxml/basic/basic0.json
@@ -1,0 +1,6 @@
+{
+    "initialConfiguration" : ["a"],
+    "events" : []
+}
+
+

--- a/tests/fixtures/scxml/basic/basic0.scxml
+++ b/tests/fixtures/scxml/basic/basic0.scxml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0"
+    initial="a">
+
+    <state id="a"/>
+
+</scxml>
+
+
+
+

--- a/tests/fixtures/scxml/basic/basic1.json
+++ b/tests/fixtures/scxml/basic/basic1.json
@@ -1,0 +1,12 @@
+{
+    "initialConfiguration" : ["a"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["b"]
+        }
+    ]
+}
+
+
+

--- a/tests/fixtures/scxml/basic/basic1.scxml
+++ b/tests/fixtures/scxml/basic/basic1.scxml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <state id="a">
+        <transition target="b" event="t"/>
+    </state>
+
+    <state id="b"/>
+
+</scxml>

--- a/tests/fixtures/scxml/basic/basic2.json
+++ b/tests/fixtures/scxml/basic/basic2.json
@@ -1,0 +1,16 @@
+{
+    "initialConfiguration" : ["a"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["b"]
+        },
+        {
+            "event" : { "name" : "t2" },
+            "nextConfiguration" : ["c"]
+        }
+    ]
+}
+
+
+

--- a/tests/fixtures/scxml/basic/basic2.scxml
+++ b/tests/fixtures/scxml/basic/basic2.scxml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <state id="a">
+        <transition target="b" event="t"/>
+    </state>
+
+    <state id="b">
+        <transition target="c" event="t2"/>
+    </state>
+
+    <state id="c"/>
+
+</scxml>
+
+
+
+

--- a/tests/fixtures/scxml/cond-js/TestConditionalTransition.json
+++ b/tests/fixtures/scxml/cond-js/TestConditionalTransition.json
@@ -1,0 +1,33 @@
+{
+    "initialConfiguration" : ["b"],
+    "events" : [
+        {
+            "event" : { "name" : "t1" },
+            "nextConfiguration" : ["d1"]
+        },
+        {
+            "event" : { "name" : "t2" },
+            "nextConfiguration" : ["e1"]
+        },
+        {
+            "event" : { "name" : "t3" },
+            "nextConfiguration" : ["f2"]
+        },
+        {
+            "event" : { "name" : "t4" },
+            "nextConfiguration" : ["h"]
+        },
+        {
+            "event" : { "name" : "t5" },
+            "nextConfiguration" : ["i"]
+        },
+        {
+            "event" : { "name" : "t5" },
+            "nextConfiguration" : ["last"]
+        }
+    ]
+}
+
+
+
+

--- a/tests/fixtures/scxml/cond-js/TestConditionalTransition.scxml
+++ b/tests/fixtures/scxml/cond-js/TestConditionalTransition.scxml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+-->
+<!-- 
+This is to test transitions with guard conditions, and multiple
+transitions originating from the same state. 
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0"
+    name="root">
+
+    <!-- default transition -->
+    <state id="a">
+        <transition target="b"/>
+    </state>
+
+    <!-- regular transition -->
+    <state id="b">
+        <transition target="c" event="t1"/>
+    </state>
+
+    <!-- two default transitions, first should get priority (based on document order), end in d1 -->
+    <state id="c">
+        <transition target="d1"/>
+        <transition target="d2"/>
+    </state>
+
+    <!-- two regular transitions, first should get priority, end in e1 -->
+    <state id="d1">
+        <transition target="e1" event="t2"/>
+        <transition target="e2" event="t2"/>
+    </state>
+
+    <state id="d2"/>
+
+    <!-- two transitions with guard conditions; 
+        first has priority, but will fail, so second transition should be taken,
+        end in f2 -->
+    <state id="e1">
+        <transition target="f1" event="t3" cond="false"/>
+        <transition target="f2" event="t3" cond="true"/>
+    </state>
+
+    <state id="e2"/>
+
+    <state id="f1"/>
+
+    <!-- like above, but with three transitions -->
+    <state id="f2">
+        <transition target="g1" event="t4" cond="false"/>
+        <transition target="g2" event="t4" cond="false"/>
+        <transition target="g3" event="t4" cond="true"/>
+    </state>
+
+    <state id="g1"/>
+
+    <state id="g2"/>
+
+    <state id="g3">
+
+        <initial>
+            <transition target="h"/>
+        </initial>
+
+        <!-- this one should pass -->
+        <state id="h">
+            <transition target="i" event="t5" cond="true"/>
+        </state>
+
+        <!-- this one should not pass, and the outer transition should be taken -->
+        <state id="i">
+            <transition target="j" event="t5" cond="false"/>
+        </state>
+
+        <state id="j"/>
+
+        <transition target="last" event="t5" cond="true"/>
+    </state>
+
+    <state id="last"/>
+</scxml>
+
+

--- a/tests/fixtures/scxml/cond-js/test0.json
+++ b/tests/fixtures/scxml/cond-js/test0.json
@@ -1,0 +1,12 @@
+{
+    "initialConfiguration" : ["a"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["b"]
+        }
+    ]
+}
+
+
+

--- a/tests/fixtures/scxml/cond-js/test0.scxml
+++ b/tests/fixtures/scxml/cond-js/test0.scxml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <state id="a">
+        <transition target="b" event="t" cond="true"/>
+    </state>
+
+    <state id="b"/>
+
+</scxml>
+
+
+
+

--- a/tests/fixtures/scxml/cond-js/test1.json
+++ b/tests/fixtures/scxml/cond-js/test1.json
@@ -1,0 +1,12 @@
+{
+    "initialConfiguration" : ["a"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["b"]
+        }
+    ]
+}
+
+
+

--- a/tests/fixtures/scxml/cond-js/test1.scxml
+++ b/tests/fixtures/scxml/cond-js/test1.scxml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <state id="a">
+        <transition target="f" event="t" cond="false"/>
+        <transition target="b" event="t" cond="true"/>
+    </state>
+
+    <state id="b"/>
+
+    <state id="f"/>
+
+</scxml>
+
+
+
+

--- a/tests/fixtures/scxml/cond-js/test2.json
+++ b/tests/fixtures/scxml/cond-js/test2.json
@@ -1,0 +1,12 @@
+{
+    "initialConfiguration" : ["a"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["b"]
+        }
+    ]
+}
+
+
+

--- a/tests/fixtures/scxml/cond-js/test2.scxml
+++ b/tests/fixtures/scxml/cond-js/test2.scxml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <state id="a">
+        <transition target="b" event="t" cond="true"/>
+    </state>
+
+    <state id="b"/>
+
+</scxml>
+
+
+
+

--- a/tests/fixtures/scxml/default-initial-state/initial1.json
+++ b/tests/fixtures/scxml/default-initial-state/initial1.json
@@ -1,0 +1,12 @@
+{
+    "initialConfiguration" : ["a"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["b"]
+        }
+    ]
+}
+
+
+

--- a/tests/fixtures/scxml/default-initial-state/initial1.scxml
+++ b/tests/fixtures/scxml/default-initial-state/initial1.scxml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+    <!-- notice that no id is specified here -->
+
+    <state id="a">
+        <transition target="b" event="t"/>
+    </state>
+
+    <state id="b"/>
+
+</scxml>

--- a/tests/fixtures/scxml/default-initial-state/initial2.json
+++ b/tests/fixtures/scxml/default-initial-state/initial2.json
@@ -1,0 +1,13 @@
+{
+    "initialConfiguration" : ["a"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["b"]
+        }
+    ]
+}
+
+
+
+

--- a/tests/fixtures/scxml/default-initial-state/initial2.scxml
+++ b/tests/fixtures/scxml/default-initial-state/initial2.scxml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0"
+    initial="a">
+
+    <state id="a">
+        <transition target="b" event="t"/>
+    </state>
+
+    <state id="b"/>
+
+</scxml>
+

--- a/tests/fixtures/scxml/documentOrder/documentOrder0.json
+++ b/tests/fixtures/scxml/documentOrder/documentOrder0.json
@@ -1,0 +1,12 @@
+{
+    "initialConfiguration" : ["a"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["b"]
+        }
+    ]
+}
+
+
+

--- a/tests/fixtures/scxml/documentOrder/documentOrder0.scxml
+++ b/tests/fixtures/scxml/documentOrder/documentOrder0.scxml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <state id="a">
+        <transition target="b" event="t"/>
+        <transition target="c" event="t"/>
+    </state>
+    
+    <state id="b"/>
+
+    <state id="c"/>
+</scxml>
+
+
+
+

--- a/tests/fixtures/scxml/hierarchy+documentOrder/test0.json
+++ b/tests/fixtures/scxml/hierarchy+documentOrder/test0.json
@@ -1,0 +1,12 @@
+{
+    "initialConfiguration" : ["a1"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["a2"]
+        }
+    ]
+}
+
+
+

--- a/tests/fixtures/scxml/hierarchy+documentOrder/test0.scxml
+++ b/tests/fixtures/scxml/hierarchy+documentOrder/test0.scxml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <state id="a">
+        <state id="a1">
+            <transition target="a2" event="t"/>
+            <transition target="c" event="t"/>
+        </state>
+
+        <state id="a2">
+        </state>
+
+        <transition target="b" event="t"/>
+    </state>
+
+    <state id="b"/>
+    
+    <state id="c"/>
+
+
+</scxml>
+
+

--- a/tests/fixtures/scxml/hierarchy+documentOrder/test1.json
+++ b/tests/fixtures/scxml/hierarchy+documentOrder/test1.json
@@ -1,0 +1,12 @@
+{
+    "initialConfiguration" : ["a1"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["b"]
+        }
+    ]
+}
+
+
+

--- a/tests/fixtures/scxml/hierarchy+documentOrder/test1.scxml
+++ b/tests/fixtures/scxml/hierarchy+documentOrder/test1.scxml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <state id="a">
+        <state id="a1">
+            <transition target="b" event="t"/>
+            <transition target="c" event="t"/>
+        </state>
+
+        <state id="a2">
+        </state>
+
+        <transition target="a2" event="t"/>
+    </state>
+
+    <state id="b"/>
+    
+    <state id="c"/>
+
+
+</scxml>
+

--- a/tests/fixtures/scxml/hierarchy/hier0.json
+++ b/tests/fixtures/scxml/hierarchy/hier0.json
@@ -1,0 +1,12 @@
+{
+    "initialConfiguration" : ["a1"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["a2"]
+        }
+    ]
+}
+
+
+

--- a/tests/fixtures/scxml/hierarchy/hier0.scxml
+++ b/tests/fixtures/scxml/hierarchy/hier0.scxml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <state id="a">
+        <state id="a1">
+            <transition target="a2" event="t"/>
+        </state>
+
+        <state id="a2">
+        </state>
+    </state>
+
+
+</scxml>

--- a/tests/fixtures/scxml/hierarchy/hier1.json
+++ b/tests/fixtures/scxml/hierarchy/hier1.json
@@ -1,0 +1,12 @@
+{
+    "initialConfiguration" : ["a1"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["a2"]
+        }
+    ]
+}
+
+
+

--- a/tests/fixtures/scxml/hierarchy/hier1.scxml
+++ b/tests/fixtures/scxml/hierarchy/hier1.scxml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <state id="a">
+        <state id="a1">
+            <transition target="a2" event="t"/>
+        </state>
+
+        <state id="a2">
+        </state>
+
+        <transition target="b" event="t"/>
+    </state>
+
+    <state id="b"/>
+
+
+</scxml>
+

--- a/tests/fixtures/scxml/hierarchy/hier2.json
+++ b/tests/fixtures/scxml/hierarchy/hier2.json
@@ -1,0 +1,12 @@
+{
+    "initialConfiguration" : ["a1"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["b"]
+        }
+    ]
+}
+
+
+

--- a/tests/fixtures/scxml/hierarchy/hier2.scxml
+++ b/tests/fixtures/scxml/hierarchy/hier2.scxml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <state id="a">
+        <state id="a1">
+            <transition target="b" event="t"/>
+        </state>
+
+        <state id="a2">
+        </state>
+
+        <transition target="a2" event="t"/>
+    </state>
+
+    <state id="b"/>
+
+
+</scxml>
+
+

--- a/tests/fixtures/scxml/more-parallel/test0.json
+++ b/tests/fixtures/scxml/more-parallel/test0.json
@@ -1,0 +1,10 @@
+{
+    "initialConfiguration" : ["a","b"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["a","b"]
+        }
+
+    ]
+}

--- a/tests/fixtures/scxml/more-parallel/test0.scxml
+++ b/tests/fixtures/scxml/more-parallel/test0.scxml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <parallel id="p">
+        <state id="a">
+            <transition target="a" event="t"/>
+        </state>
+
+        <state id="b"/>
+    </parallel>
+
+</scxml>
+
+

--- a/tests/fixtures/scxml/more-parallel/test1.json
+++ b/tests/fixtures/scxml/more-parallel/test1.json
@@ -1,0 +1,10 @@
+{
+    "initialConfiguration" : ["a1","b1"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["a1","b1"]
+        }
+
+    ]
+}

--- a/tests/fixtures/scxml/more-parallel/test1.scxml
+++ b/tests/fixtures/scxml/more-parallel/test1.scxml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <parallel id="p">
+        <state id="a">
+
+            <transition event="t" target="a"/>
+
+            <state id="a1"/>
+
+            <state id="a2"/>
+        </state>
+
+        <state id="b">
+
+            <state id="b1"/>
+
+            <state id="b2"/>
+        </state>
+    </parallel>
+
+
+</scxml>
+
+

--- a/tests/fixtures/scxml/more-parallel/test2.json
+++ b/tests/fixtures/scxml/more-parallel/test2.json
@@ -1,0 +1,20 @@
+{
+    "initialConfiguration" : ["a1","b1"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["a1","b1"]
+        }
+
+    ],
+    "legacySemantics" : {
+        "initialConfiguration" : ["a1","b1"],
+        "events" : [ 
+            {
+                "event" : { "name" : "t" },
+                "nextConfiguration" : ["a1","b2"]
+            }
+
+        ]
+    }
+}

--- a/tests/fixtures/scxml/more-parallel/test2.scxml
+++ b/tests/fixtures/scxml/more-parallel/test2.scxml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <parallel id="p">
+        <state id="a">
+
+            <transition event="t" target="a"/>
+
+            <state id="a1"/>
+
+            <state id="a2"/>
+        </state>
+
+        <state id="b">
+
+            <state id="b1">
+                <transition event="t" target="b2"/>
+            </state>
+
+            <state id="b2"/>
+        </state>
+    </parallel>
+
+
+</scxml>
+
+
+

--- a/tests/fixtures/scxml/more-parallel/test2b.json
+++ b/tests/fixtures/scxml/more-parallel/test2b.json
@@ -1,0 +1,11 @@
+{
+    "initialConfiguration" : ["a1","b1"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["a1","b2"]
+        }
+
+    ]
+}
+

--- a/tests/fixtures/scxml/more-parallel/test2b.scxml
+++ b/tests/fixtures/scxml/more-parallel/test2b.scxml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <parallel id="p">
+        <state id="b">
+
+            <state id="b1">
+                <transition event="t" target="b2"/>
+            </state>
+
+            <state id="b2"/>
+        </state>
+        <state id="a">
+
+            <transition event="t" target="a"/>
+
+            <state id="a1"/>
+
+            <state id="a2"/>
+        </state>
+
+    </parallel>
+
+
+</scxml>
+
+
+
+

--- a/tests/fixtures/scxml/more-parallel/test3.json
+++ b/tests/fixtures/scxml/more-parallel/test3.json
@@ -1,0 +1,21 @@
+{
+    "initialConfiguration" : ["a1","b1"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["a2","b1"]
+        }
+
+    ],
+    "legacySemantics" : {
+        "initialConfiguration" : ["a1","b1"],
+        "events" : [ 
+            {
+                "event" : { "name" : "t" },
+                "nextConfiguration" : ["a1","b2"]
+            }
+
+        ]
+    }
+}
+

--- a/tests/fixtures/scxml/more-parallel/test3.scxml
+++ b/tests/fixtures/scxml/more-parallel/test3.scxml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0" >
+
+    <parallel id="p">
+        <state id="a">
+
+            <transition event="t" target="a2"/>
+
+            <state id="a1"/>
+
+            <state id="a2"/>
+        </state>
+
+        <state id="b">
+
+            <state id="b1">
+                <transition event="t" target="b2"/>
+            </state>
+
+            <state id="b2"/>
+        </state>
+    </parallel>
+
+
+</scxml>

--- a/tests/fixtures/scxml/more-parallel/test3b.json
+++ b/tests/fixtures/scxml/more-parallel/test3b.json
@@ -1,0 +1,12 @@
+{
+    "initialConfiguration" : ["a1","b1"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["a1","b2"]
+        }
+
+    ]
+}
+
+

--- a/tests/fixtures/scxml/more-parallel/test3b.scxml
+++ b/tests/fixtures/scxml/more-parallel/test3b.scxml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <parallel id="p">
+        <state id="b">
+
+            <state id="b1">
+                <transition event="t" target="b2"/>
+            </state>
+
+            <state id="b2"/>
+        </state>
+        <state id="a">
+
+            <transition event="t" target="a2"/>
+
+            <state id="a1"/>
+
+            <state id="a2"/>
+        </state>
+
+    </parallel>
+
+
+</scxml>
+

--- a/tests/fixtures/scxml/more-parallel/test4.json
+++ b/tests/fixtures/scxml/more-parallel/test4.json
@@ -1,0 +1,12 @@
+{
+    "initialConfiguration" : ["a1","b1"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["a1","b1"]
+        }
+
+    ]
+}
+
+

--- a/tests/fixtures/scxml/more-parallel/test4.scxml
+++ b/tests/fixtures/scxml/more-parallel/test4.scxml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <parallel id="p">
+        <state id="a">
+
+            <transition event="t" target="a"/>
+
+            <state id="a1"/>
+
+            <state id="a2"/>
+        </state>
+
+        <state id="b">
+
+            <transition event="t" target="b"/>
+
+            <state id="b1"/>
+
+            <state id="b2"/>
+        </state>
+    </parallel>
+
+
+</scxml>
+
+
+
+
+

--- a/tests/fixtures/scxml/more-parallel/test5.json
+++ b/tests/fixtures/scxml/more-parallel/test5.json
@@ -1,0 +1,13 @@
+{
+    "initialConfiguration" : ["a1","b1"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["a2","b1"]
+        }
+
+    ]
+}
+
+
+

--- a/tests/fixtures/scxml/more-parallel/test5.scxml
+++ b/tests/fixtures/scxml/more-parallel/test5.scxml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <parallel id="p">
+        <state id="a">
+
+            <transition event="t" target="a2"/>
+
+            <state id="a1"/>
+
+            <state id="a2"/>
+        </state>
+
+        <state id="b">
+
+            <transition event="t" target="b2"/>
+
+            <state id="b1"/>
+
+            <state id="b2"/>
+        </state>
+    </parallel>
+
+
+</scxml>

--- a/tests/fixtures/scxml/more-parallel/test6.json
+++ b/tests/fixtures/scxml/more-parallel/test6.json
@@ -1,0 +1,20 @@
+{
+    "initialConfiguration" : ["a11","b11"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["a22","b11"]
+        }
+
+    ],
+    "legacySemantics" : {
+        "initialConfiguration" : ["a11","b11"],
+        "events" : [ 
+            {
+                "event" : { "name" : "t" },
+                "nextConfiguration" : ["a11","b12"]
+            }
+
+        ]
+    }
+}

--- a/tests/fixtures/scxml/more-parallel/test6.scxml
+++ b/tests/fixtures/scxml/more-parallel/test6.scxml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <parallel id="p">
+        <state id="a">
+
+            <transition event="t" target="a22"/>
+
+            <state id="a1">
+                <state id="a11"/>
+                <state id="a12"/>
+            </state>
+
+            <state id="a2">
+                <state id="a21"/>
+                <state id="a22"/>
+            </state>
+        </state>
+
+        <state id="b">
+
+            <state id="b1">
+                <state id="b11">
+                    <transition event="t" target="b12"/>
+                </state>
+                <state id="b12"/>
+            </state>
+
+            <state id="b2">
+                <state id="b21"/>
+                <state id="b22"/>
+            </state>
+        </state>
+    </parallel>
+
+
+</scxml>

--- a/tests/fixtures/scxml/more-parallel/test6b.json
+++ b/tests/fixtures/scxml/more-parallel/test6b.json
@@ -1,0 +1,11 @@
+{
+    "initialConfiguration" : ["a11","b11"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["a11","b12"]
+        }
+
+    ]
+}
+

--- a/tests/fixtures/scxml/more-parallel/test6b.scxml
+++ b/tests/fixtures/scxml/more-parallel/test6b.scxml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <parallel id="p">
+        <state id="b">
+
+            <state id="b1">
+                <state id="b11">
+                    <transition event="t" target="b12"/>
+                </state>
+                <state id="b12"/>
+            </state>
+
+            <state id="b2">
+                <state id="b21"/>
+                <state id="b22"/>
+            </state>
+        </state>
+        <state id="a">
+
+            <transition event="t" target="a22"/>
+
+            <state id="a1">
+                <state id="a11"/>
+                <state id="a12"/>
+            </state>
+
+            <state id="a2">
+                <state id="a21"/>
+                <state id="a22"/>
+            </state>
+        </state>
+
+    </parallel>
+
+
+</scxml>
+

--- a/tests/fixtures/scxml/more-parallel/test7.json
+++ b/tests/fixtures/scxml/more-parallel/test7.json
@@ -1,0 +1,11 @@
+{
+    "initialConfiguration" : ["a11","b11"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["a22","b11"]
+        }
+
+    ]
+}
+

--- a/tests/fixtures/scxml/more-parallel/test7.scxml
+++ b/tests/fixtures/scxml/more-parallel/test7.scxml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <parallel id="p">
+        <state id="a">
+
+            <transition event="t" target="a22"/>
+
+            <state id="a1">
+                <state id="a11"/>
+                <state id="a12"/>
+            </state>
+
+            <state id="a2">
+                <state id="a21"/>
+                <state id="a22"/>
+            </state>
+        </state>
+
+        <state id="b">
+
+            <transition event="t" target="b22"/>
+
+            <state id="b1">
+                <state id="b11"/>
+                <state id="b12"/>
+            </state>
+
+            <state id="b2">
+                <state id="b21"/>
+                <state id="b22"/>
+            </state>
+        </state>
+    </parallel>
+
+
+</scxml>

--- a/tests/fixtures/scxml/more-parallel/test8.json
+++ b/tests/fixtures/scxml/more-parallel/test8.json
@@ -1,0 +1,10 @@
+{
+    "initialConfiguration" : ["x"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["a22","b11"]
+        }
+
+    ]
+}

--- a/tests/fixtures/scxml/more-parallel/test8.scxml
+++ b/tests/fixtures/scxml/more-parallel/test8.scxml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+    
+    <state id="x">
+        <transition event="t" target="a22"/>
+    </state>
+
+    <parallel id="p">
+        <state id="a">
+            <state id="a1">
+                <state id="a11"/>
+                <state id="a12"/>
+            </state>
+
+            <state id="a2">
+                <state id="a21"/>
+                <state id="a22"/>
+            </state>
+        </state>
+
+        <state id="b">
+
+            <state id="b1">
+                <state id="b11"/>
+                <state id="b12"/>
+            </state>
+
+            <state id="b2">
+                <state id="b21"/>
+                <state id="b22"/>
+            </state>
+        </state>
+    </parallel>
+</scxml>

--- a/tests/fixtures/scxml/more-parallel/test9.json
+++ b/tests/fixtures/scxml/more-parallel/test9.json
@@ -1,0 +1,12 @@
+{
+    "initialConfiguration" : ["x"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["a22","b22"]
+        }
+
+    ]
+}
+
+

--- a/tests/fixtures/scxml/more-parallel/test9.scxml
+++ b/tests/fixtures/scxml/more-parallel/test9.scxml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+    
+    <state id="x">
+        <transition event="t" target="a22 b22"/>
+    </state>
+
+    <parallel id="p">
+        <state id="a">
+            <state id="a1">
+                <state id="a11"/>
+                <state id="a12"/>
+            </state>
+
+            <state id="a2">
+                <state id="a21"/>
+                <state id="a22"/>
+            </state>
+        </state>
+
+        <state id="b">
+
+            <state id="b1">
+                <state id="b11"/>
+                <state id="b12"/>
+            </state>
+
+            <state id="b2">
+                <state id="b21"/>
+                <state id="b22"/>
+            </state>
+        </state>
+    </parallel>
+</scxml>
+

--- a/tests/fixtures/scxml/parallel+interrupt/test0.json
+++ b/tests/fixtures/scxml/parallel+interrupt/test0.json
@@ -1,0 +1,10 @@
+{
+    "initialConfiguration" : ["c","d"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["a1"]
+        }
+
+    ]
+}

--- a/tests/fixtures/scxml/parallel+interrupt/test0.scxml
+++ b/tests/fixtures/scxml/parallel+interrupt/test0.scxml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<!-- 
+orthogonal preemption - inner or states interrupt one-another 
+in our semantics, source state is at the same level of hierarchy, so document order will resolve conflict. a1 will win.
+--> 
+<scxml
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0"
+    initial="b">
+
+    <parallel id="b">
+        <state id="c">
+            <transition event="t" target="a1"/>
+        </state>
+
+        <state id="d">
+            <transition event="t" target="a2"/>
+        </state>
+
+    </parallel>
+
+    <state id="a1"/>
+
+    <state id="a2"/>
+</scxml>
+
+
+

--- a/tests/fixtures/scxml/parallel+interrupt/test1.json
+++ b/tests/fixtures/scxml/parallel+interrupt/test1.json
@@ -1,0 +1,11 @@
+{
+    "initialConfiguration" : ["c1","d1"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["c2","d1"]
+        }
+
+    ]
+}
+

--- a/tests/fixtures/scxml/parallel+interrupt/test1.scxml
+++ b/tests/fixtures/scxml/parallel+interrupt/test1.scxml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<!-- 
+orthogonal preemption - transition originating at inner OR state interrupts transition originating at orthogonal OR state.
+first OR state should win, as the transitions originate at the same level of hierarchy, and wins by document order
+--> 
+<scxml
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0"
+    initial="b">
+
+    <parallel id="b">
+        <state id="c" initial="c1">
+            <state id="c1">
+                <transition event="t" target="c2"/>
+            </state>
+
+            <state id="c2"/>
+        </state>
+
+        <state id="d" initial="d1">
+            <state id="d1">
+                <transition event="t" target="a1"/>
+            </state>
+        </state>
+
+    </parallel>
+
+    <state id="a1"/>
+</scxml>
+

--- a/tests/fixtures/scxml/parallel+interrupt/test10.json
+++ b/tests/fixtures/scxml/parallel+interrupt/test10.json
@@ -1,0 +1,20 @@
+{
+    "initialConfiguration" : ["b1","b2"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["c1","c2"]
+        }
+
+    ]
+}
+
+
+
+
+
+
+
+
+
+

--- a/tests/fixtures/scxml/parallel+interrupt/test10.scxml
+++ b/tests/fixtures/scxml/parallel+interrupt/test10.scxml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<!-- 
+no conflict here
+initial: [b1,b2]
+after t: [c1,c2]
+--> 
+<scxml
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0"
+    initial="a">
+
+    <state id="a" initial="b">
+
+        <transition event="t" target="c"/>
+
+        <parallel id="b">
+            <state id="b1">
+            </state>
+
+            <state id="b2">
+            </state>
+        </parallel>
+
+        <parallel id="c">
+            <state id="c1">
+            </state>
+
+            <state id="c2">
+            </state>
+        </parallel>
+    </state>
+
+</scxml>
+
+
+
+
+
+
+

--- a/tests/fixtures/scxml/parallel+interrupt/test2.json
+++ b/tests/fixtures/scxml/parallel+interrupt/test2.json
@@ -1,0 +1,12 @@
+{
+    "initialConfiguration" : ["c1","d1"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["a1"]
+        }
+
+    ]
+}
+
+

--- a/tests/fixtures/scxml/parallel+interrupt/test2.scxml
+++ b/tests/fixtures/scxml/parallel+interrupt/test2.scxml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<!-- 
+orthogonal preemption - transition originating at inner OR state interrupts transition originating at orthogonal OR state.
+again, first OR state should win, as the transitions originate at the same level of hierarchy, and wins by document order
+--> 
+<scxml
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0"
+    initial="b">
+
+
+    <parallel id="b">
+
+        <state id="c" initial="c1">
+            <state id="c1">
+                <transition event="t" target="a1"/>
+            </state>
+
+            <state id="c2"/>
+        </state>
+
+        <state id="d" initial="d1">
+            <state id="d1">
+                <transition event="t" target="d2"/>
+            </state>
+
+            <state id="d2"/>
+        </state>
+
+    </parallel>
+
+    <state id="a1"/>
+</scxml>
+
+

--- a/tests/fixtures/scxml/parallel+interrupt/test3.json
+++ b/tests/fixtures/scxml/parallel+interrupt/test3.json
@@ -1,0 +1,13 @@
+{
+    "initialConfiguration" : ["e","f","d"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["a1"]
+        }
+
+    ]
+}
+
+
+

--- a/tests/fixtures/scxml/parallel+interrupt/test3.scxml
+++ b/tests/fixtures/scxml/parallel+interrupt/test3.scxml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- 
+orthogonal preemption - inner or states interrupt one-another 
+in our semantics, source state is at the same level of hierarchy, so document order will resolve conflict. a1 will win.
+--> 
+<scxml
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0"
+    initial="b">
+
+    <parallel id="b">
+        <parallel id="c">
+            <state id="e">
+                <transition event="t" target="a1"/>
+            </state>
+
+            <state id="f">
+                <transition event="t" target="a2"/>
+            </state>
+
+            <transition event="t" target="a3"/>
+        </parallel>
+
+        <state id="d">
+            <transition event="t" target="a4"/>
+        </state>
+
+    </parallel>
+
+    <state id="a1"/>
+
+    <state id="a2"/>
+
+    <state id="a3"/>
+
+    <state id="a4"/>
+
+</scxml>

--- a/tests/fixtures/scxml/parallel+interrupt/test4.json
+++ b/tests/fixtures/scxml/parallel+interrupt/test4.json
@@ -1,0 +1,14 @@
+{
+    "initialConfiguration" : ["e","f","g"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["a1"]
+        }
+
+    ]
+}
+
+
+
+

--- a/tests/fixtures/scxml/parallel+interrupt/test4.scxml
+++ b/tests/fixtures/scxml/parallel+interrupt/test4.scxml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<!-- 
+     orthogonal preemption - inner or states interrupt one-another 
+--> 
+<scxml
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0"
+    initial="b">
+
+    <parallel id="b">
+        <parallel id="p">
+            <state id="e">
+                <transition event="t" target="a1"/>
+            </state>
+
+            <state id="f">
+                <transition event="t" target="a2"/>
+            </state>
+
+            <transition event="t" target="a3"/>
+        </parallel>
+
+
+        <state id="d" initial="g">
+            <state id="g">
+                <transition event="t" target="h"/>
+            </state>
+
+            <state id="h"/>
+        </state>
+
+    </parallel>
+
+    <state id="a1"/>
+
+    <state id="a2"/>
+
+    <state id="a3"/>
+
+    <state id="a4"/>
+
+</scxml>
+

--- a/tests/fixtures/scxml/parallel+interrupt/test5.json
+++ b/tests/fixtures/scxml/parallel+interrupt/test5.json
@@ -1,0 +1,15 @@
+{
+    "initialConfiguration" : ["e","f","g"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["e","f","h"]
+        }
+
+    ]
+}
+
+
+
+
+

--- a/tests/fixtures/scxml/parallel+interrupt/test5.scxml
+++ b/tests/fixtures/scxml/parallel+interrupt/test5.scxml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<!-- 
+     orthogonal preemption - inner or states interrupt one-another 
+--> 
+<scxml
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0"
+    initial="b">
+
+    <parallel id="b">
+        <state id="d" initial="g">
+            <state id="g">
+                <transition event="t" target="h"/>
+            </state>
+
+            <state id="h"/>
+        </state>
+
+        <parallel id="p">
+            <state id="e">
+                <transition event="t" target="a1"/>
+            </state>
+
+            <state id="f">
+                <transition event="t" target="a2"/>
+            </state>
+
+            <transition event="t" target="a3"/>
+        </parallel>
+    </parallel>
+
+    <state id="a1"/>
+
+    <state id="a2"/>
+
+    <state id="a3"/>
+
+    <state id="a4"/>
+
+</scxml>
+
+

--- a/tests/fixtures/scxml/parallel+interrupt/test6.json
+++ b/tests/fixtures/scxml/parallel+interrupt/test6.json
@@ -1,0 +1,16 @@
+{
+    "initialConfiguration" : ["g","e1","f1"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["h","e2","f2"]
+        }
+
+    ]
+}
+
+
+
+
+
+

--- a/tests/fixtures/scxml/parallel+interrupt/test6.scxml
+++ b/tests/fixtures/scxml/parallel+interrupt/test6.scxml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<!-- 
+     orthogonal preemption - inner or states interrupt one-another 
+    no conflicts here
+    initial configuration: [g,e1,f1]
+    given event t: [h,e2,f2]
+TODO: move this to basic parallel group
+--> 
+<scxml
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0"
+    initial="b">
+
+    <parallel id="b">
+        <state id="c" initial="g">
+            <state id="g">
+                <transition event="t" target="h"/>
+            </state>
+
+            <state id="h"/>
+        </state>
+
+        <parallel id="d">
+            <state id="e" initial="e1">
+                <state id="e1">
+                    <transition event="t" target="e2"/>
+                </state>
+
+                <state id="e2"/>
+            </state>
+
+            <state id="f" initial="f1">
+                <state id="f1">
+                    <transition event="t" target="f2"/>
+                </state>
+
+                <state id="f2"/>
+            </state>
+
+        </parallel>
+
+    </parallel>
+
+</scxml>
+
+
+

--- a/tests/fixtures/scxml/parallel+interrupt/test7.json
+++ b/tests/fixtures/scxml/parallel+interrupt/test7.json
@@ -1,0 +1,27 @@
+{
+    "initialConfiguration" : ["c","e1","f1"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["a1"]
+        }
+
+    ],
+    "legacySemantics" : {
+        "initialConfiguration" : ["c","e1","f1"],
+        "events" : [ 
+            {
+                "event" : { "name" : "t" },
+                "nextConfiguration" : ["c","e2","f2"]
+            }
+
+        ]
+    }
+}
+
+
+
+
+
+
+

--- a/tests/fixtures/scxml/parallel+interrupt/test7.scxml
+++ b/tests/fixtures/scxml/parallel+interrupt/test7.scxml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<!-- 
+  orthogonal preemption - inner or states interrupt one-another 
+    conflict between transition originating in state c, and transitions originating in e1 and f1, as transition from c interrupt the others
+
+  In SCION <= 4:   
+    transitions in e1 and f1 will win, as they are deeper in the hierarchy (even though they come later in document order
+
+  In SCION > 4 (SCXML semantics): 
+    transition originating in c will win, as orthogonal component c precedes orthogonal component d in document order (even though transitions originating in d are deeper in the state hierarchy)
+--> 
+<scxml
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0"
+    initial="b">
+
+    <parallel id="b">
+        <state id="c">
+            <transition event="t" target="a1"/>
+        </state>
+
+        <parallel id="d">
+            <state id="e" initial="e1">
+                <state id="e1">
+                    <transition event="t" target="e2"/>
+                </state>
+
+                <state id="e2"/>
+            </state>
+
+            <state id="f" initial="f1">
+                <state id="f1">
+                    <transition event="t" target="f2"/>
+                </state>
+
+                <state id="f2"/>
+            </state>
+
+        </parallel>
+
+    </parallel>
+
+    <state id="a1"/>
+
+</scxml>
+
+
+
+

--- a/tests/fixtures/scxml/parallel+interrupt/test8.json
+++ b/tests/fixtures/scxml/parallel+interrupt/test8.json
@@ -1,0 +1,18 @@
+{
+    "initialConfiguration" : ["b1","b2"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["c1","c2"]
+        }
+
+    ]
+}
+
+
+
+
+
+
+
+

--- a/tests/fixtures/scxml/parallel+interrupt/test8.scxml
+++ b/tests/fixtures/scxml/parallel+interrupt/test8.scxml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<!-- 
+no conflict here
+initial: [b1,b2]
+after t: [c1,c2]
+--> 
+<scxml
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0"
+    initial="a">
+
+    <state id="a" initial="b">
+        <parallel id="b">
+            <state id="b1">
+            </state>
+
+            <state id="b2">
+            </state>
+
+            <transition event="t" target="c"/>
+        </parallel>
+
+        <parallel id="c">
+            <state id="c1">
+            </state>
+
+            <state id="c2">
+            </state>
+        </parallel>
+    </state>
+
+</scxml>
+
+
+
+
+

--- a/tests/fixtures/scxml/parallel+interrupt/test9.json
+++ b/tests/fixtures/scxml/parallel+interrupt/test9.json
@@ -1,0 +1,19 @@
+{
+    "initialConfiguration" : ["b1","b2"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["c1","c2"]
+        }
+
+    ]
+}
+
+
+
+
+
+
+
+
+

--- a/tests/fixtures/scxml/parallel+interrupt/test9.scxml
+++ b/tests/fixtures/scxml/parallel+interrupt/test9.scxml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<!-- 
+no conflict here
+initial: [b1,b2]
+after t: [c1,c2]
+--> 
+<scxml
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0"
+    initial="a">
+
+    <state id="a" initial="b">
+        <parallel id="b">
+            <state id="b1">
+                <transition event="t" target="c"/>
+            </state>
+
+            <state id="b2">
+            </state>
+        </parallel>
+
+        <parallel id="c">
+            <state id="c1">
+            </state>
+
+            <state id="c2">
+            </state>
+        </parallel>
+    </state>
+
+</scxml>
+
+
+
+
+
+

--- a/tests/fixtures/scxml/parallel/test0.json
+++ b/tests/fixtures/scxml/parallel/test0.json
@@ -1,0 +1,7 @@
+{
+    "initialConfiguration" : ["a","b"],
+    "events" : [ ]
+}
+
+
+

--- a/tests/fixtures/scxml/parallel/test0.scxml
+++ b/tests/fixtures/scxml/parallel/test0.scxml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <parallel id="p">
+        <state id="a"/>
+
+        <state id="b"/>
+    </parallel>
+
+
+</scxml>
+
+

--- a/tests/fixtures/scxml/parallel/test1.json
+++ b/tests/fixtures/scxml/parallel/test1.json
@@ -1,0 +1,13 @@
+{
+    "initialConfiguration" : ["a1","b1"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["a2","b2"]
+        }
+
+    ]
+}
+
+
+

--- a/tests/fixtures/scxml/parallel/test1.scxml
+++ b/tests/fixtures/scxml/parallel/test1.scxml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <parallel id="p">
+        <state id="a">
+            <initial>
+                <transition target="a1"/>
+            </initial>
+
+            <state id="a1">
+                <transition event="t" target="a2"/>
+            </state>
+
+            <state id="a2"/>
+        </state>
+
+        <state id="b">
+            <initial>
+                <transition target="b1"/>
+            </initial>
+
+            <state id="b1">
+                <transition event="t" target="b2"/>
+            </state>
+
+            <state id="b2"/>
+        </state>
+    </parallel>
+
+
+</scxml>
+
+

--- a/tests/fixtures/scxml/parallel/test2.json
+++ b/tests/fixtures/scxml/parallel/test2.json
@@ -1,0 +1,14 @@
+{
+    "initialConfiguration" : ["s3","s4","s7","s8"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["s5","s6","s9","s10"]
+        }
+
+    ]
+}
+
+
+
+

--- a/tests/fixtures/scxml/parallel/test2.scxml
+++ b/tests/fixtures/scxml/parallel/test2.scxml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<!-- nested orthogonality 
+initial configuration: [s3,s4,s7,s8]
+after event t: [s5,s6,s9,s10]
+-->
+<scxml
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <parallel id="p1">
+        <state id="s1" initial="p2">
+            <parallel id="p2">
+                <state id="s3"/>
+
+                <state id="s4"/>
+
+                <transition target="p3" event="t"/>
+            </parallel>
+
+            <parallel id="p3">
+                <state id="s5"/>
+
+                <state id="s6"/>
+            </parallel>
+
+        </state>
+
+        <state id="s2" initial="p4">
+            <parallel id="p4">
+                <state id="s7"/>
+
+                <state id="s8"/>
+
+                <transition target="p5" event="t"/>
+            </parallel>
+
+            <parallel id="p5">
+                <state id="s9"/>
+
+                <state id="s10"/>
+            </parallel>
+        </state>
+
+    </parallel>
+
+</scxml>
+

--- a/tests/fixtures/scxml/parallel/test3.json
+++ b/tests/fixtures/scxml/parallel/test3.json
@@ -1,0 +1,15 @@
+{
+    "initialConfiguration" : ["s3.1","s4","s7","s8"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["s3.2","s4","s9","s10"]
+        }
+
+    ]
+}
+
+
+
+
+

--- a/tests/fixtures/scxml/parallel/test3.scxml
+++ b/tests/fixtures/scxml/parallel/test3.scxml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<!-- nested orthogonality 
+initial configuration: [s3.1,s4,s7,s8]
+after event t: [s3.2,s4,s9,s10]
+-->
+<scxml
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0"
+    initial="p1">
+
+    <parallel id="p1">
+        <state id="s1" initial="p2">
+            <parallel id="p2">
+                <state id="s3" initial="s3.1">
+                    <state id="s3.1">
+                        <transition target="s3.2" event="t"/>
+                    </state>
+
+                    <state id="s3.2"/>
+                </state>
+
+                <state id="s4">
+                </state>
+
+            </parallel>
+
+            <parallel id="p3">
+                <state id="s5">
+                </state>
+
+                <state id="s6">
+                </state>
+            </parallel>
+
+        </state>
+
+        <state id="s2" initial="p4">
+            <parallel id="p4">
+                <state id="s7">
+                </state>
+
+                <state id="s8">
+                </state>
+
+                <transition target="p5" event="t"/>
+            </parallel>
+
+            <parallel id="p5">
+                <state id="s9">
+                </state>
+
+                <state id="s10">
+                </state>
+            </parallel>
+        </state>
+
+    </parallel>
+
+</scxml>
+

--- a/tests/test_ci_workflow_contract.py
+++ b/tests/test_ci_workflow_contract.py
@@ -8,15 +8,18 @@ def read_workflow(name: str) -> str:
     return (WORKFLOWS / name).read_text(encoding="utf-8")
 
 
-def test_all_python_workflows_use_current_action_runtime_majors() -> None:
+def test_all_python_workflows_pin_action_revisions() -> None:
     workflow_text = "\n".join(
         path.read_text(encoding="utf-8") for path in sorted(WORKFLOWS.glob("*.yaml"))
     )
 
-    assert "actions/checkout@v4" not in workflow_text
-    assert "actions/setup-python@v5" not in workflow_text
-    assert workflow_text.count("actions/checkout@v7") == 5
-    assert workflow_text.count("actions/setup-python@v7") == 5
+    checkout = "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+    setup_python = "actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97"
+    assert workflow_text.count(checkout) == 5
+    assert workflow_text.count(setup_python) == 5
+    assert "actions/checkout@v" not in workflow_text
+    assert "actions/setup-python@v" not in workflow_text
+    assert "submodules:" not in workflow_text
 
 
 def test_coverage_gate_does_not_depend_on_an_external_upload() -> None:

--- a/tests/test_scxml.py
+++ b/tests/test_scxml.py
@@ -8,7 +8,7 @@ from xstate.scxml import scxml_to_machine
 
 pp = PrettyPrinter(indent=2)
 
-test_dir = Path(__file__).resolve().parents[1] / "test-framework" / "test"
+test_dir = Path(__file__).resolve().parent / "fixtures" / "scxml"
 
 test_groups: dict[str, list[str]] = {
     "actionSend": [
@@ -86,6 +86,22 @@ test_files = [
     for test_group, test_names in test_groups.items()
     for test_name in test_names
 ]
+
+
+@pytest.mark.scxml_ci
+def test_vendored_scxml_fixture_inventory_is_exact() -> None:
+    expected = {
+        test_dir / test_group / f"{test_name}{suffix}"
+        for test_group, test_names in test_groups.items()
+        for test_name in test_names
+        for suffix in (".json", ".scxml")
+    }
+    actual = set(test_dir.glob("*/*.json")) | set(test_dir.glob("*/*.scxml"))
+
+    assert actual == expected
+    provenance = (test_dir / "PROVENANCE.md").read_text(encoding="utf-8")
+    assert "b46a10a1c3a3b1ca5c5cb4bb44ddb5c785611f41" in provenance
+    assert (test_dir / "LICENSE.txt").is_file()
 
 
 @pytest.mark.scxml_ci


### PR DESCRIPTION
## Summary

- remove the vulnerable 2018 SCXML Test Framework submodule and its unused Node/Grunt dependency graph
- vendor only the 53 SCXML/JSON fixture pairs exercised by Python tests
- retain the Apache 2.0 license, upstream URL, and exact source commit `b46a10a1c3a3b1ca5c5cb4bb44ddb5c785611f41`
- add an exact fixture inventory and provenance guard to the hosted SCXML smoke gate
- update development and conformance documentation
- pin every GitHub Action plus the maintained devcontainer base and Poetry 2.4.1
- add Renovate coverage for immutable refs

## Boundary

This branch is based on exact `master` commit `94674b25f031979dee912d50121eebaa44ae593f`. Vendored fixture bytes are unchanged from the pinned upstream commit. The JavaScript runner, package manifest, lockfile, and unused cases are intentionally excluded. Runtime library behavior is unchanged.

## Validation

- 106 fixture files compared byte-for-byte with the pinned submodule source
- canonical release preflight passed:
  - package metadata/lock check
  - 417 primary tests
  - 55 SCXML smoke checks: 54 conformance cases plus the exact inventory/provenance guard
  - Ruff format and lint
  - mypy across 22 source files
  - sdist and wheel build
  - installed-wheel smoke
- pinned devcontainer build passed and installed Poetry 2.4.1
- offline OSV Scanner 2.5.0: 15 Poetry-lock packages, clean
- JSON, YAML, and staged-diff integrity checks

## Review focus

- completeness of the 53-case fixture inventory
- Apache license and commit provenance
- removal of all submodule checkout paths
- devcontainer modernization

Rollback is a single revert of `c3fe29fcf57847f103613781c35eccd33831343c`.