### PR TITLE
Expand SCXML parallel conformance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,12 +81,13 @@ Working:
   supported at the public `Machine(config, ...)` boundary.
 - Public snapshot immutability: configuration is a `frozenset`, actions are a
   `tuple`, and history is exposed read-only.
-- SCXML import with a safe Python boolean condition subset:
-  `true`, `false`, `!`, `&&`, `||`, and parentheses.
+- SCXML import with safe Boolean conditions plus the fixture-proven integer
+  data subset: literal initialization, same-variable `+ 1` assignment, and
+  strict integer equality guards.
 
 Known gaps:
 
-- The configured 54-case SCXML suite passes, including the enabled
+- The configured 56-case SCXML suite passes, including all 15 enabled
   `more-parallel` cases, but broader W3C datamodel and executable-content
   conformance is not claimed.
 - Graphviz export and graph/test helper APIs beyond Mermaid are future work.

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ poetry install
 ```
 
 The core library has no runtime dependencies. The `scxml` extra is intentionally
-dependency-free on Python 3.13+; SCXML Boolean `cond` support covers the safe
-subset `true`, `false`, `!`, `&&`, `||`, and parentheses.
+dependency-free on Python 3.13+; SCXML expression support is limited to safe
+Boolean conditions and the fixture-proven integer data subset.
 
 ## Quickstart
 
@@ -445,10 +445,12 @@ are retained under `tests/fixtures/scxml/`.
 poetry run python -m pytest tests/test_scxml.py
 ```
 
-The configured conformance subset contains 54 passing cases, including all enabled
+The configured conformance subset contains 56 passing cases, including all 15 enabled
 `more-parallel` cases, plus a fixture inventory/provenance guard. This is a focused SCXML
 subset rather than a claim of full W3C conformance; broader datamodel and executable-content
-coverage remains future work. The `cond-js` subset passes with the safe Boolean evaluator.
+coverage remains future work. The `cond-js` subset passes with the safe Boolean evaluator,
+and integer data expressions remain limited to literal initialization, same-variable `+ 1`
+assignment, and strict integer equality guards.
 
 ## Developing
 
@@ -513,7 +515,7 @@ script-owned quality gates.
 | Snapshot queries | `tags`, `meta`, `has_tag`/`hasTag`, and `state_in`/`stateIn` are present |
 | Diagrams | Dependency-free Mermaid export is present |
 | Async | `AsyncInterpreter`, async actors, `from_observable`, and `to_promise` are present |
-| SCXML | Configured 54-case suite passes, including all 13 enabled `more-parallel` cases; broader W3C coverage remains open |
+| SCXML | Configured 56-case suite passes, including all 15 enabled `more-parallel` cases; broader W3C coverage remains open |
 | Persistence | Snapshot serialization and restore helpers are present |
 | Documentation | Concept guides cover machines, runtimes, actors, persistence, and SCXML import |
 | Examples | `docs/examples/` is the canonical, subprocess-tested example collection |

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -37,7 +37,7 @@ bridge between XState's JSON ecosystem and Python backends.
 | Actor model | `create_actor`, `ActorSystem`, spawn, parent/child tree, `send_parent`, `send_to` |
 | Actor logic | `from_promise`, `from_callback`, `from_observable`, `to_promise` |
 | Invoke | Child actor lifetime reconciliation with `done.invoke.*` and `error.platform.*` events |
-| SCXML XML import | Present; safe Boolean cond subset; configured 54-case suite passes |
+| SCXML XML import | Present; safe Boolean and narrow integer-data subset; configured 56-case suite passes |
 
 ## What Works Today
 
@@ -58,7 +58,7 @@ bridge between XState's JSON ecosystem and Python backends.
   `MachineSnapshot`, `create_actor`, and `setup`.
 - Primary suite passes in current Python 3.13/3.14 CI.
 - SCXML `cond-js` subset result: `4 passed`.
-- Configured SCXML result: `54 passed`, `0 failed`, including all enabled
+- Configured SCXML result: `56 passed`, `0 failed`, including all enabled
   `more-parallel` cases.
 - Concept guides cover machine configuration, runtime choices, actors,
   persistence, and SCXML import.
@@ -81,7 +81,7 @@ JavaScript and wanting the same machine shape in Python services.
 
 | Milestone | Result |
 |---|---|
-| Parallel transition domains | All 13 configured `more-parallel` cases pass; the configured SCXML suite is `54 passed`, `0 failed` |
+| Parallel transition domains | All 15 configured `more-parallel` cases pass; the configured SCXML suite is `56 passed`, `0 failed` |
 | Concept documentation | Machines, implementations, sync/async runtimes, actors, persistence, and SCXML import are documented |
 | Runnable examples | `docs/examples/` is canonical and every runner has subprocess smoke coverage |
 | Persistence adoption | Snapshot compatibility and timer/child-actor restoration limits are documented with a JSON resume example |
@@ -102,7 +102,7 @@ JavaScript and wanting the same machine shape in Python services.
 |---|---|
 | PyPI release | `pip install xstate` works after the 0.7.0 GitHub Release |
 | Primary test count | Maintain 300+ focused tests |
-| SCXML pass rate | Keep the configured 54-case suite green while expanding supported coverage |
+| SCXML pass rate | Keep the configured 56-case suite green while expanding supported coverage |
 | Docs | Keep every public runtime boundary represented by a maintained concept guide |
 | Examples | Keep JSON, sync, async, actor, persistence, and SCXML runners green in CI; add framework integrations next |
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -64,15 +64,15 @@ structure with a JavaScript/XState frontend or a Stately-authored design.
 - Active snapshot `tags`, `meta`, `has_tag`/`hasTag`, and
   `state_in`/`stateIn` guard helpers.
 - Dependency-free Mermaid diagram export via `to_mermaid(machine)`.
-- SCXML XML import with a safe Boolean cond subset: `true`, `false`, `!`, `&&`,
-  `||`, and parentheses.
+- SCXML XML import with safe Boolean conditions and the fixture-proven integer
+  data subset.
 
 ## Known Gaps
 
 | Gap | Notes |
 |---|---|
 | PyPI release | 0.7.0 packaging metadata and release workflow are ready; publish via GitHub Release. |
-| SCXML conformance | Configured SCXML suite is `54 passed`, `0 failed`; broader W3C coverage is not yet claimed. |
+| SCXML conformance | Configured SCXML suite is `56 passed`, `0 failed`; broader W3C coverage is not yet claimed. |
 | Full ECMAScript cond support | Intentionally not implemented; unsupported SCXML expressions raise `InvalidConfigError`. |
 | Graph/test utilities | Mermaid export exists; no graph traversal/test-path helpers yet. |
 | Inspector protocol | No `@statelyai/inspect` compatibility yet. |

--- a/docs/concepts/scxml.md
+++ b/docs/concepts/scxml.md
@@ -35,7 +35,9 @@ The current converter handles this focused XML surface:
 | `<state id="...">` | Compound or atomic state |
 | `<parallel id="...">` | Parallel state with all child regions entered |
 | `<transition event="..." target="...">` | Event transition to one or more state IDs |
-| `cond="..."` | Guard compiled from the safe Boolean subset |
+| `<datamodel><data id="x" expr="0"/></datamodel>` | Top-level context with non-negative integer literal values |
+| `cond="..."` | Guard compiled from the safe Boolean and integer-equality subset |
+| `<assign location="x" expr="x + 1"/>` | Increment a declared integer datum by exactly one |
 | `<onentry><raise .../></onentry>` | Entry raise actions |
 | `<onexit><raise .../></onexit>` | Exit raise actions |
 | `<transition><raise .../></transition>` | Transition raise actions |
@@ -48,7 +50,8 @@ Other SCXML datamodels, executable-content elements, and JavaScript semantics ar
 outside this import surface. Structural `<final>`, `<history>`, and explicit
 `<initial>` elements are also not converted yet, even though the native machine
 configuration supports equivalent statechart concepts. Do not depend on
-`<script>`, `<assign>`, `<send>`, or general ECMAScript evaluation during import.
+`<script>`, `<send>`, other assignment forms, or general ECMAScript evaluation
+during import.
 
 Malformed XML, an empty document, missing state IDs or raise events, and
 duplicate state IDs raise `InvalidConfigError` during import. State IDs are
@@ -64,13 +67,15 @@ the same whether the machine is driven through `Machine.transition(...)`,
 `interpret(...)`, or `create_actor(...)`.
 
 For `<parallel>`, entering the parallel state enters every child region. An
-external transition uses the nearest compound ancestor as its transition
-domain, so affected branches exit and re-enter correctly. Competing transitions
-are resolved by their exit sets and document order.
+atomic self-transition exits and re-enters only that branch, without cycling the
+parallel parent or its siblings. Other external transitions use the nearest
+compound ancestor as their transition domain, so affected branches exit and
+re-enter correctly. Competing transitions are resolved by their exit sets and
+document order.
 
-## Safe Conditions
+## Safe Expressions
 
-SCXML conditions support only Boolean literals and operators:
+SCXML conditions support Boolean literals and operators:
 
 ```text
 true
@@ -80,17 +85,36 @@ true && false
 true || (false && !false)
 ```
 
+When a top-level `ecmascript` datamodel declares an integer literal, conditions
+may also use one standalone comparison between that simple identifier and a
+non-negative integer with `===`:
+
+```xml
+<datamodel>
+  <data id="x" expr="0"/>
+</datamodel>
+<transition event="GO" cond="x === 2" target="ready"/>
+```
+
+The only supported `<assign>` expression increments its own declared integer
+location by exactly one. Whitespace around `+` is optional:
+
+```xml
+<assign location="x" expr="x + 1"/>
+```
+
 In XML, escape `&&` as `&amp;&amp;` inside an attribute:
 
 ```xml
 <transition event="GO" cond="true &amp;&amp; !false" target="ready"/>
 ```
 
-The expression is parsed once when the machine is imported. It cannot read the
-event, context, or an SCXML datamodel.
+Expressions are parsed once when the machine is imported. A data comparison or
+assignment can read only its declared integer location; it cannot read events,
+properties, call functions, or evaluate JavaScript.
 
-Unsupported identifiers, property access, comparisons, and JavaScript raise
-`InvalidConfigError` instead of being evaluated:
+Undeclared identifiers, property access, other arithmetic or comparisons, and
+JavaScript raise `InvalidConfigError` instead of being evaluated:
 
 ```xml
 <transition event="GO" cond="event.name === 'GO'" target="ready"/>
@@ -106,16 +130,15 @@ except InvalidConfigError as exc:
     print(exc)
 ```
 
-An expression such as `count > 0` is rejected in the same way; defining
-`count` in an SCXML `<datamodel>` does not expand the supported subset.
+Expressions such as `count > 0`, `count + 2`, and `user.count + 1` are rejected
+in the same way; declaring data does not expand the supported grammar.
 
 ## Conformance Boundary
 
-The configured repository subset contains 54 passing conformance cases, including all 13 enabled
+The configured repository subset contains 56 passing conformance cases, including all 15 enabled
 `more-parallel` cases, plus a fixture inventory/provenance guard. This is a focused subset, not a
 claim of complete W3C SCXML conformance. The broader datamodel and executable content surface
-remains future work, and the `more-parallel` `test10` and `test10b` fixtures remain outside the
-configured set because they require additional assignment support.
+remains future work.
 
 Run the self-contained [SCXML toggle example](../examples/scxml_toggle.py), or
 run the configured conformance suite against the checked-in fixture subset:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ classifiers = [
 dependencies = []
 
 [project.optional-dependencies]
-# SCXML import is dependency-free on modern Python. JavaScript-style `cond`
-# support intentionally covers a small safe boolean subset in xstate.scxml.
+# SCXML import is dependency-free on modern Python. Expression support is
+# intentionally limited to the safe, fixture-proven subset in xstate.scxml.
 scxml = []
 
 [project.urls]

--- a/src/xstate/algorithm.py
+++ b/src/xstate/algorithm.py
@@ -203,17 +203,29 @@ def is_descendent(state: StateNode, state2: StateNode | None) -> bool:
 #     tstates = getEffectiveTargetStates(t)
 #     if not tstates:
 #         return null
+#     elif isAtomicState(t.source) and tstates == {t.source}:
+#         return t.source.parent
 #     elif t.type == "internal" and isCompoundState(t.source) \
 #          and tstates.every(lambda s: isDescendant(s,t.source)):
 #         return t.source
 #     else:
 #         return findLCCA([t.source].append(tstates))
+def _is_atomic_self_transition(
+    transition: Transition, target_states: AbstractSet[StateNode]
+) -> bool:
+    return is_atomic_state(transition.source) and target_states == {transition.source}
+
+
 def get_transition_domain(
     transition: Transition, history_value: ReadOnlyHistoryValue
 ) -> StateNode | None:
     tstates = get_effective_target_states(transition, history_value=history_value)
     if not tstates:
         return None
+    if _is_atomic_self_transition(transition, tstates):
+        # A self-transition on one atomic parallel branch exits and re-enters
+        # that branch without cycling the containing parallel state or siblings.
+        return transition.source.parent
     elif (
         transition.type == "internal"
         and is_compound_state(transition.source)
@@ -470,6 +482,10 @@ def compute_exit_set(
     states_to_exit: set[StateNode] = set()
     for t in enabled_transitions:
         if t.target:
+            tstates = get_effective_target_states(t, history_value=history_value)
+            if _is_atomic_self_transition(t, tstates):
+                states_to_exit.add(t.source)
+                continue
             domain = get_transition_domain(t, history_value=history_value)
             for s in configuration:
                 if is_descendent(s, state2=domain):

--- a/src/xstate/scxml.py
+++ b/src/xstate/scxml.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import os
+import re
 import xml.etree.ElementTree as ET
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import Any, NoReturn, cast
 
+from xstate.action import assign
 from xstate.exceptions import InvalidConfigError
 from xstate.handlers import HandlerArgs
 from xstate.machine import Machine
@@ -13,6 +15,10 @@ from xstate.schema import ActionSpec, MachineConfig, StateNodeConfig, Transition
 __all__ = ["scxml_to_machine"]
 
 _STATE_TAGS = frozenset({"state", "parallel"})
+_IDENTIFIER_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+_INTEGER_RE = re.compile(r"0|[1-9][0-9]*")
+_INCREMENT_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\s*\+\s*1")
+_INTEGER_EQUALITY_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\s*===\s*(0|[1-9][0-9]*)")
 
 
 class _BooleanCondParser:
@@ -78,7 +84,7 @@ class _BooleanCondParser:
         raise InvalidConfigError(
             "Unsupported SCXML JavaScript cond expression "
             f"{self.source!r}. Supported subset: true, false, !, &&, ||, "
-            "and parentheses."
+            "parentheses, or one declared integer comparison such as x === 2."
         )
 
     @staticmethod
@@ -117,14 +123,37 @@ class _BooleanCondParser:
         return tokens
 
 
-def _eval_scxml_cond(source: str) -> Callable[[HandlerArgs | None], bool]:
-    """Compile the safe SCXML Boolean subset into a canonical guard."""
+def _eval_scxml_cond(
+    source: str, data_ids: frozenset[str] = frozenset()
+) -> Callable[[HandlerArgs | None], bool]:
+    """Compile the safe SCXML condition subset into a canonical guard."""
+    comparison = _INTEGER_EQUALITY_RE.fullmatch(source.strip())
+    if comparison is not None:
+        data_id, expected = comparison.groups()
+        expected_value = int(expected)
+        if data_id not in data_ids:
+            raise InvalidConfigError(
+                "Unsupported SCXML JavaScript cond expression "
+                f"{source!r}. Data variable {data_id!r} is not declared."
+            )
+
+        def integer_guard(args: HandlerArgs | None = None) -> bool:
+            context = args.context if args is not None else {}
+            value = context.get(data_id) if isinstance(context, Mapping) else None
+            return (
+                isinstance(value, int)
+                and not isinstance(value, bool)
+                and value == expected_value
+            )
+
+        return integer_guard
+
     result = _BooleanCondParser(source).parse()
 
-    def guard(_args: HandlerArgs | None = None) -> bool:
+    def boolean_guard(_args: HandlerArgs | None = None) -> bool:
         return result
 
-    return guard
+    return boolean_guard
 
 
 def get_tag(element: ET.Element) -> str:
@@ -148,7 +177,9 @@ def _required_attribute(element: ET.Element, name: str) -> str:
     return value
 
 
-def accumulate_states(element: ET.Element) -> dict[str, StateNodeConfig]:
+def accumulate_states(
+    element: ET.Element, data_ids: frozenset[str]
+) -> dict[str, StateNodeConfig]:
     states: dict[str, StateNodeConfig] = {}
     for state_element in get_all_state_els(element):
         state_id = _required_attribute(state_element, "id")
@@ -157,7 +188,7 @@ def accumulate_states(element: ET.Element) -> dict[str, StateNodeConfig]:
                 f"Duplicate SCXML state id {state_id!r} under "
                 f"<{get_tag(element)}> element."
             )
-        states[state_id] = convert_state(state_element)
+        states[state_id] = convert_state(state_element, data_ids)
     return states
 
 
@@ -172,21 +203,60 @@ def _validate_state_ids(element: ET.Element) -> None:
         seen.add(state_id)
 
 
+def _convert_datamodel(element: ET.Element) -> dict[str, int]:
+    datamodels = _children(element, frozenset({"datamodel"}))
+    if not datamodels:
+        return {}
+    if len(datamodels) != 1 or element.attrib.get("datamodel") != "ecmascript":
+        raise InvalidConfigError(
+            "Unsupported SCXML datamodel. Supported subset: one top-level "
+            "ecmascript <datamodel> with integer-literal <data> entries."
+        )
+
+    context: dict[str, int] = {}
+    for data_element in datamodels[0]:
+        if get_tag(data_element) != "data":
+            raise InvalidConfigError(
+                f"Unsupported SCXML <datamodel> child <{get_tag(data_element)}>."
+            )
+        data_id = _required_attribute(data_element, "id")
+        if not _IDENTIFIER_RE.fullmatch(data_id) or data_id in {"true", "false"}:
+            raise InvalidConfigError(
+                f"Unsupported SCXML <data> id {data_id!r}. "
+                "Expected a simple non-reserved identifier."
+            )
+        if data_id in context:
+            raise InvalidConfigError(f"Duplicate SCXML data id {data_id!r}.")
+        expression = _required_attribute(data_element, "expr")
+        if not _INTEGER_RE.fullmatch(expression.strip()):
+            raise InvalidConfigError(
+                f"Unsupported SCXML <data> expression {expression!r}. "
+                "Supported subset: non-negative integer literals."
+            )
+        context[data_id] = int(expression)
+    return context
+
+
 def convert_scxml(element: ET.Element) -> MachineConfig:
     _validate_state_ids(element)
-    states = accumulate_states(element)
+    context = _convert_datamodel(element)
+    data_ids = frozenset(context)
+    states = accumulate_states(element, data_ids)
     if not states:
         raise InvalidConfigError(
             "SCXML document must contain at least one <state> or <parallel>."
         )
     initial = element.attrib.get("initial") or next(iter(states))
-    return {"id": "machine", "initial": initial, "states": states}
+    result: MachineConfig = {"id": "machine", "initial": initial, "states": states}
+    if context:
+        result["context"] = context
+    return result
 
 
-def convert_state(element: ET.Element) -> StateNodeConfig:
+def convert_state(element: ET.Element, data_ids: frozenset[str]) -> StateNodeConfig:
     state_id = _required_attribute(element, "id")
     child_elements = get_all_state_els(element)
-    states = accumulate_states(element)
+    states = accumulate_states(element, data_ids)
 
     result: StateNodeConfig = {"id": state_id}
     if get_tag(element) == "parallel":
@@ -203,7 +273,7 @@ def convert_state(element: ET.Element) -> StateNodeConfig:
         TransitionConfig | str | list[TransitionConfig | str],
     ] = {}
     for transition_element in _children(element, frozenset({"transition"})):
-        transition = convert_transition(transition_element)
+        transition = convert_transition(transition_element, data_ids)
         event = transition_element.attrib.get("event")
         bucket = transition_map.setdefault(event, [])
         if not isinstance(bucket, list):
@@ -214,20 +284,22 @@ def convert_state(element: ET.Element) -> StateNodeConfig:
 
     entry_element = next(iter(_children(element, frozenset({"onentry"}))), None)
     if entry_element is not None:
-        entry = convert_executable_content(entry_element)
+        entry = convert_executable_content(entry_element, data_ids)
         if entry:
             result["entry"] = entry
 
     exit_element = next(iter(_children(element, frozenset({"onexit"}))), None)
     if exit_element is not None:
-        exit_actions = convert_executable_content(exit_element)
+        exit_actions = convert_executable_content(exit_element, data_ids)
         if exit_actions:
             result["exit"] = exit_actions
 
     return result
 
 
-def convert_transition(element: ET.Element) -> TransitionConfig:
+def convert_transition(
+    element: ET.Element, data_ids: frozenset[str]
+) -> TransitionConfig:
     result: TransitionConfig = {}
     target = element.attrib.get("target")
     if target is not None:
@@ -235,9 +307,9 @@ def convert_transition(element: ET.Element) -> TransitionConfig:
 
     condition = element.attrib.get("cond")
     if condition is not None:
-        result["guard"] = _eval_scxml_cond(condition)
+        result["guard"] = _eval_scxml_cond(condition, data_ids)
 
-    actions = convert_executable_content(element)
+    actions = convert_executable_content(element, data_ids)
     if actions:
         result["actions"] = actions
     return result
@@ -250,11 +322,45 @@ def convert_raise(element: ET.Element) -> dict[str, str]:
     }
 
 
-def convert_executable_content(element: ET.Element) -> list[ActionSpec]:
-    return [
-        convert_raise(raise_element)
-        for raise_element in _children(element, frozenset({"raise"}))
-    ]
+def convert_assign(element: ET.Element, data_ids: frozenset[str]) -> ActionSpec:
+    location = _required_attribute(element, "location")
+    if not _IDENTIFIER_RE.fullmatch(location) or location not in data_ids:
+        raise InvalidConfigError(
+            f"Unsupported SCXML <assign> location {location!r}. "
+            "Expected a declared simple data identifier."
+        )
+    expression = _required_attribute(element, "expr")
+    match = _INCREMENT_RE.fullmatch(expression.strip())
+    if match is None or match.group(1) != location:
+        raise InvalidConfigError(
+            f"Unsupported SCXML <assign> expression {expression!r}. "
+            "Supported subset: incrementing the assigned variable by one, "
+            "for example x + 1."
+        )
+
+    def increment(args: HandlerArgs | None = None) -> int:
+        context = args.context if args is not None else {}
+        value = context.get(location) if isinstance(context, Mapping) else None
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise InvalidConfigError(
+                f"SCXML <assign> location {location!r} must contain an integer."
+            )
+        return value + 1
+
+    return cast(ActionSpec, assign({location: increment}))
+
+
+def convert_executable_content(
+    element: ET.Element, data_ids: frozenset[str]
+) -> list[ActionSpec]:
+    actions: list[ActionSpec] = []
+    for child in element:
+        tag = get_tag(child)
+        if tag == "raise":
+            actions.append(convert_raise(child))
+        elif tag == "assign":
+            actions.append(convert_assign(child, data_ids))
+    return actions
 
 
 def convert(element: ET.Element) -> MachineConfig:

--- a/tests/fixtures/scxml/more-parallel/test10.json
+++ b/tests/fixtures/scxml/more-parallel/test10.json
@@ -1,0 +1,34 @@
+{
+    "initialConfiguration" : ["a","b"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t1" },
+            "nextConfiguration" : ["a","b"]
+        },
+        {
+            "event" : { "name" : "t2" },
+            "nextConfiguration" : ["a","b"]
+        },
+        {
+            "event" : { "name" : "t3" },
+            "nextConfiguration" : ["a","b"]
+        }
+    ],
+    "legacySemantics" : {
+        "initialConfiguration" : ["a","b"],
+        "events" : [ 
+            {
+                "event" : { "name" : "t1" },
+                "nextConfiguration" : ["a","b"]
+            },
+            {
+                "event" : { "name" : "t2" },
+                "nextConfiguration" : ["c"]
+            },
+            {
+                "event" : { "name" : "t3" },
+                "nextConfiguration" : ["d"]
+            }
+        ]
+    }
+}

--- a/tests/fixtures/scxml/more-parallel/test10.scxml
+++ b/tests/fixtures/scxml/more-parallel/test10.scxml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <datamodel>
+        <data id="x" expr="0"/>
+    </datamodel>
+
+    <parallel id="p">
+        <onentry>
+            <assign location="x" expr="x +1"/>
+        </onentry>
+        <onexit>
+            <assign location="x" expr="x + 1"/>
+        </onexit>
+
+        <state id="a">
+            <onentry>
+                <assign location="x" expr="x + 1"/>
+            </onentry>
+            <onexit>
+                <assign location="x" expr="x + 1"/>
+            </onexit>
+
+            <!-- we've entered p, a, so x === 2 here -->
+
+            <transition target="a" event="t1" cond="x === 2"/>
+        </state>
+
+        <state id="b"/>
+
+        <!-- we've exited and re-entered p, a, so x === 6 here -->
+        <transition target="c" event="t2" cond="x === 6"/>
+    </parallel>
+
+    <state id="c">
+        <!-- we've exited p, a here, so x === 8 -->
+        <transition target="d" event="t3" cond="x === 8"/>
+    </state>
+
+    <state id="d"/>
+
+</scxml>
+
+
+

--- a/tests/fixtures/scxml/more-parallel/test10b.json
+++ b/tests/fixtures/scxml/more-parallel/test10b.json
@@ -1,0 +1,34 @@
+{
+    "initialConfiguration" : ["a","b"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t1" },
+            "nextConfiguration" : ["a","b"]
+        },
+        {
+            "event" : { "name" : "t2" },
+            "nextConfiguration" : ["c"]
+        },
+        {
+            "event" : { "name" : "t3" },
+            "nextConfiguration" : ["d"]
+        }
+    ],
+    "legacySemantics" : {
+      "initialConfiguration" : ["a","b"],
+      "events" : [ 
+          {
+              "event" : { "name" : "t1" },
+              "nextConfiguration" : ["a","b"]
+          },
+          {
+              "event" : { "name" : "t2" },
+              "nextConfiguration" : ["a","b"]
+          },
+          {
+              "event" : { "name" : "t3" },
+              "nextConfiguration" : ["a","b"]
+          }
+      ]
+    }
+}

--- a/tests/fixtures/scxml/more-parallel/test10b.scxml
+++ b/tests/fixtures/scxml/more-parallel/test10b.scxml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <datamodel>
+        <data id="x" expr="0"/>
+    </datamodel>
+
+    <parallel id="p">
+        <onentry>
+            <assign location="x" expr="x +1"/>
+        </onentry>
+        <onexit>
+            <assign location="x" expr="x + 1"/>
+        </onexit>
+
+        <state id="a">
+            <onentry>
+                <assign location="x" expr="x + 1"/>
+            </onentry>
+            <onexit>
+                <assign location="x" expr="x + 1"/>
+            </onexit>
+
+            <!-- we've entered p, a, so x === 2 here -->
+
+            <transition target="a" event="t1" cond="x === 2"/>
+        </state>
+
+        <state id="b"/>
+
+        <!-- we've exited and re-entered a, without exiting and re-entering p, so x === 4 here -->
+        <transition target="c" event="t2" cond="x === 4"/>
+    </parallel>
+
+    <state id="c">
+        <!-- we've exited p and a here, so x === 8 -->
+        <transition target="d" event="t3" cond="x === 6"/>
+    </state>
+
+    <state id="d"/>
+
+</scxml>
+
+
+

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -184,6 +184,46 @@ def test_external_region_transition_reenters_parallel_siblings():
     service.stop()
 
 
+def test_atomic_self_transition_does_not_cycle_parallel_parent_or_sibling():
+    calls: list[str] = []
+    machine = Machine(
+        {
+            "id": "atomic-self",
+            "initial": "running",
+            "states": {
+                "running": {
+                    "type": "parallel",
+                    "entry": lambda: calls.append("enterParallel"),
+                    "exit": lambda: calls.append("exitParallel"),
+                    "states": {
+                        "a": {
+                            "id": "a",
+                            "entry": lambda: calls.append("enterA"),
+                            "exit": lambda: calls.append("exitA"),
+                            "on": {"RESET": "#a"},
+                        },
+                        "b": {
+                            "id": "b",
+                            "entry": lambda: calls.append("enterB"),
+                            "exit": lambda: calls.append("exitB"),
+                        },
+                    },
+                }
+            },
+        }
+    )
+    state = machine.initial_state
+    calls.clear()
+
+    state = machine.transition(state, "RESET")
+
+    assert state.value == {"running": {"a": {}, "b": {}}}
+    assert calls == []
+    for action in state.actions:
+        action()
+    assert calls == ["exitA", "enterA"]
+
+
 def _parallel_conflict_machine(first_region: str) -> Machine:
     a = {
         "initial": "a1",

--- a/tests/test_scxml.py
+++ b/tests/test_scxml.py
@@ -58,8 +58,8 @@ test_groups: dict[str, list[str]] = {
         "test7",
         "test8",
         "test9",
-        # "test10", # TODO: needs assign()
-        # "test10b", # TODO: needs assign()
+        "test10",
+        "test10b",
     ],
 }
 

--- a/tests/test_scxml_import.py
+++ b/tests/test_scxml_import.py
@@ -74,6 +74,56 @@ def test_imported_multi_target_transition_accepts_xml_whitespace(
     }
 
 
+def test_imported_assign_subset_preserves_parallel_entry_exit_order() -> None:
+    source = (
+        Path(__file__).resolve().parent
+        / "fixtures"
+        / "scxml"
+        / "more-parallel"
+        / "test10b.scxml"
+    )
+    machine = scxml_to_machine(source)
+
+    state = machine.initial_state
+    assert state.context == {"x": 2}
+
+    state = machine.transition(state, "t1")
+    assert state.value == {"p": {"a": {}, "b": {}}}
+    assert state.context == {"x": 4}
+
+    state = machine.transition(state, "t2")
+    assert state.matches("c")
+    assert state.context == {"x": 6}
+
+    state = machine.transition(state, "t3")
+    assert state.matches("d")
+    assert state.context == {"x": 6}
+
+
+def test_imported_integer_guard_does_not_treat_boolean_as_integer(
+    tmp_path: Path,
+) -> None:
+    source = write_scxml(
+        tmp_path,
+        """<scxml xmlns="http://www.w3.org/2005/07/scxml" datamodel="ecmascript">
+  <datamodel>
+    <data id="x" expr="0"/>
+  </datamodel>
+  <state id="waiting">
+    <transition event="GO" cond="x === 1" target="done"/>
+  </state>
+  <state id="done"/>
+</scxml>""",
+    )
+    machine = scxml_to_machine(source)
+    state = machine.initial_state
+    state.context["x"] = True
+
+    state = machine.transition(state, "GO")
+
+    assert state.matches("waiting")
+
+
 def test_import_defaults_to_first_state(tmp_path: Path) -> None:
     source = write_scxml(
         tmp_path,
@@ -145,4 +195,44 @@ def test_import_wraps_malformed_xml(tmp_path: Path) -> None:
     source = write_scxml(tmp_path, "<scxml><state id='open'></scxml>")
 
     with pytest.raises(InvalidConfigError, match="Invalid SCXML XML"):
+        scxml_to_machine(source)
+
+
+@pytest.mark.parametrize(
+    ("data_expression", "assign_location", "assign_expression", "condition", "message"),
+    [
+        ("1 + 1", "x", "x + 1", "true", "<data> expression"),
+        ("0", "x", "x + 2", "true", "<assign> expression"),
+        ("0", "x", "1 + x", "true", "<assign> expression"),
+        ("0", "x.count", "x.count + 1", "true", "<assign> location"),
+        ("0", "missing", "missing + 1", "true", "<assign> location"),
+        ("0", "x", "x + 1", "x == 1", "cond expression"),
+        ("0", "x", "x + 1", "x === 1 &amp;&amp; true", "cond expression"),
+        ("0", "x", "x + 1", "event === 1", "not declared"),
+    ],
+)
+def test_import_rejects_expressions_outside_assign_subset(
+    tmp_path: Path,
+    data_expression: str,
+    assign_location: str,
+    assign_expression: str,
+    condition: str,
+    message: str,
+) -> None:
+    source = write_scxml(
+        tmp_path,
+        f"""<scxml xmlns="http://www.w3.org/2005/07/scxml" datamodel="ecmascript">
+  <datamodel>
+    <data id="x" expr="{data_expression}"/>
+  </datamodel>
+  <state id="only">
+    <onentry>
+      <assign location="{assign_location}" expr="{assign_expression}"/>
+    </onentry>
+    <transition event="GO" cond="{condition}"/>
+  </state>
+</scxml>""",
+    )
+
+    with pytest.raises(InvalidConfigError, match=message):
         scxml_to_machine(source)


### PR DESCRIPTION
## Summary

- Support the fixture-proven SCXML integer-data subset: non-negative literal initialization, same-variable `+ 1` assignment, and standalone strict integer equality guards.
- Correct atomic self-transition handling so one active parallel branch exits and re-enters without cycling the parallel parent or sibling branches.
- Enable upstream `more-parallel/test10` and `test10b`, retaining byte-identical Apache-2.0 fixtures under the repository's existing provenance boundary.
- Document the expanded but deliberately narrow import surface and update the configured SCXML counts to 56 cases, including all 15 `more-parallel` cases.

## Why

`more-parallel/test10` and `test10b` were intentionally disabled because the importer did not initialize SCXML data, convert `<assign>`, or evaluate their integer guards. Once that data flow was present, the fixtures exposed a second issue: the transition-domain calculation treated an atomic self-transition as cycling the containing parallel state, which executed parent and sibling exit/entry behavior and produced the wrong counter sequence.

The change implements only the syntax and transition behavior evidenced by these two fixtures. It does not add a JavaScript evaluator or claim broader SCXML datamodel support.

## User and developer impact

- The two previously excluded parallel conformance cases now load and execute through the public `Machine.transition(...)` path.
- Imported charts can use the narrowly documented integer initialization, increment, and equality forms.
- Unsupported expressions fail during import with `InvalidConfigError` instead of being ignored or evaluated.
- There are no new runtime dependencies and no change to the public `Machine(config, ...)` boundary.

## Implementation

### Fail-closed SCXML expression subset

- Accept one top-level `datamodel="ecmascript"` block containing simple identifiers initialized from non-negative integer literals.
- Accept `<assign location="x" expr="x + 1"/>` only when the expression increments that same declared location by exactly one.
- Accept one standalone declared-variable comparison such as `x === 2`; the existing Boolean-only parser remains unchanged.
- Reject undeclared variables, property/index locations, alternate arithmetic, comparison composition, unsupported datamodels, and non-integer assignment state.
- Convert `raise` and `assign` executable content in document order.

### Atomic self-transition boundary

- Detect an atomic transition whose effective target is its source.
- Exit and re-enter only that atomic source, preserving the containing parallel state and sibling configuration.
- Cover the native engine behavior independently from the SCXML fixtures so the transition-domain rule cannot regress invisibly.

### Fixture provenance

- Vendor `test10.scxml`, `test10.json`, `test10b.scxml`, and `test10b.json` from SCXML Test Framework commit `b46a10a1c3a3b1ca5c5cb4bb44ddb5c785611f41`.
- Confirm all four files are byte-identical to that upstream commit.
- Keep the existing Apache-2.0 license and `tests/fixtures/scxml/PROVENANCE.md` ownership boundary.

## Scope

- SCXML XML conversion and its focused expression validation.
- Atomic self-transition entry/exit behavior.
- Two vendored fixture pairs, focused regression coverage, inventory enablement, and current documentation.

## Non-scope

- General ECMAScript or Python expression evaluation.
- Property access, function calls, event access, arbitrary arithmetic, or mutable object paths.
- Broader SCXML datamodel or executable-content conformance.
- Dependency, package-version, release, deployment, or publication changes.
- Complete W3C SCXML conformance claims.

## Evidence and validation

Local validation on commit `730f1396baf7ab3ac9082f82fb137e20d2475ddf`:

- Primary suite: `428 passed`.
- SCXML suite: `57 passed` — 56 configured cases plus the fixture inventory/provenance guard.
- Ruff formatting: passed across 68 files.
- Ruff lint: passed.
- MyPy: passed across 22 source files.
- `poetry check --lock`: passed.
- Source distribution and wheel build: passed.
- Installed-wheel smoke validation: passed for `xstate 0.7.0`.
- GitHub Actions: Python 3.13, Python 3.14, SCXML smoke, and code-quality checks passed on the exact PR head.

## Risks and mitigations

- **Run-to-completion core:** `algorithm.py` is correctness-critical, and the atomic self-transition rule affects native machines as well as imported SCXML. A dedicated native parallel regression test plus the complete primary and SCXML suites cover the entry/exit boundary.
- **Expression-surface creep:** accepting more syntax could accidentally become an evaluator. Full-match regular expressions, declared-location checks, integer type checks, and explicit rejection cases keep the grammar closed.
- **Fixture drift:** the inventory guard, pinned provenance commit, retained license, and byte comparison constrain the vendored source.
- **Documentation drift:** README, product/comparison docs, concept documentation, packaging comments, and `AGENTS.md` are updated together with the enabled-case counts.

## Diff-size justification

The PR changes 15 files with 530 additions and 58 deletions. Of those additions, 194 lines are unmodified upstream fixture bytes. The remaining size is concentrated in the fail-closed parser boundary, focused acceptance/rejection tests, one native transition regression, and documentation required to state the new support limits accurately. The runtime change remains localized to `src/xstate/scxml.py` and a 16-line transition-domain adjustment in `src/xstate/algorithm.py`.

## Rollback

Revert commit `730f1396baf7ab3ac9082f82fb137e20d2475ddf`. That removes the parser and transition-domain changes, disables the two cases, removes the four vendored fixture files, and restores the prior documented 54-case boundary. No data migration, dependency rollback, or external cleanup is required.

## Review focus

1. Confirm the accepted grammar is no broader than the two fixtures require.
2. Verify unsupported expressions and locations fail at import time with clear `InvalidConfigError` messages.
3. Confirm atomic self-transitions execute only source exit/entry actions while preserving the parallel parent and siblings.
4. Verify executable-content ordering and context snapshot behavior remain run-to-completion safe.
5. Confirm fixture bytes, provenance, license, and configured-suite counts are consistent.

## Unresolved decisions

None required for this PR. Additional assignment forms, data types, nested locations, and broader executable content remain explicitly deferred to separately evidenced work.

## Merge order and release boundary

This is a standalone PR against `master` with no prerequisite or follow-up merge ordering. It is intentionally draft for review and validation only; merging does not publish PyPI artifacts or deploy any runtime.
