### PR TITLE
Prepare the 0.7.1 source release candidate

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,12 @@ concurrency:
 
 jobs:
   publish:
-    if: ${{ !github.event.release.draft && !github.event.release.prerelease }}
+    if: >-
+      ${{
+        !github.event.release.draft &&
+        !github.event.release.prerelease &&
+        vars.PYPI_PUBLISH_ENABLED == 'true'
+      }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/release_preflight.yaml
+++ b/.github/workflows/release_preflight.yaml
@@ -5,7 +5,7 @@ on:
       expected_tag:
         description: Release tag expected from pyproject.toml
         required: true
-        default: v0.7.0
+        default: v0.7.1
         type: string
 
 permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,11 +7,11 @@ actor-based state machines. The project goal is to own the Python niche of
 native XState / Stately JSON compatibility while preserving a W3C SCXML-style
 run-to-completion execution core.
 
-- PyPI name: `xstate`
+- Declared distribution name: `xstate` (PyPI ownership is not established)
 - License: MIT
 - Python: 3.13+
 - Runtime dependencies: none
-- Current status: alpha, version `0.7.1`
+- Current status: alpha, `0.7.1` source release candidate
 
 The central bet is simple: charts designed in Stately or shared with a
 JavaScript frontend should load directly as Python `dict` / JSON data, with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ run-to-completion execution core.
 - License: MIT
 - Python: 3.13+
 - Runtime dependencies: none
-- Current status: alpha, version `0.7.0`
+- Current status: alpha, version `0.7.1`
 
 The central bet is simple: charts designed in Stately or shared with a
 JavaScript frontend should load directly as Python `dict` / JSON data, with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented here.
 
+## 0.7.1 - 2026-08-21
+
+### Added
+
+- Vendored the configured 56-case SCXML Test Framework fixture subset under
+  `tests/fixtures/scxml/`, including upstream provenance, license custody, and
+  an exact-inventory test.
+- Added the fixture-proven SCXML integer-data subset: non-negative integer
+  initialization, same-variable `+ 1` assignment, and strict integer equality
+  guards.
+
+### Changed
+
+- Removed the SCXML fixture submodule so local, CI, and release validation use
+  the same repository-owned test inputs without a separate checkout step.
+- Expanded the enabled `more-parallel` conformance subset from 13 to 15 cases;
+  the configured suite now covers 56 cases.
+
+### Fixed
+
+- Corrected atomic self-transition handling inside parallel states so the
+  source branch exits and re-enters without cycling active sibling regions.
+
 ## 0.7.0 - 2026-07-02
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,10 +4,11 @@
 
 A Python implementation of [XState](https://github.com/statelyai/xstate) — statecharts and
 hierarchical state machines for Python, following the W3C SCXML execution algorithm. The goal is
-a **solid, published Python statechart library** that tracks XState v5's architecture and owns
-the niche of native XState JSON compatibility.
+a **solid Python statechart library** that tracks XState v5's architecture and owns the niche of
+native XState JSON compatibility. The repository is an alpha source project; package-index
+publication is not yet verified.
 
-**PyPI name:** `xstate` | **License:** MIT | **Python:** 3.13+
+**Declared distribution name:** `xstate` (PyPI ownership unresolved) | **License:** MIT | **Python:** 3.13+
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ The critical execution order is: `main_event_loop` → `microstep` → `main_eve
 
 ---
 
-## Current state (0.7.0 on master)
+## Current state (0.7.1 release candidate)
 
 **Working:**
 - Hierarchical (compound) states
@@ -141,7 +141,8 @@ boundary.
 | 0.4.0 | v5 config alignment | Rename `cond`→`guard`, `data`→`output`, `always:`, single-object handler signatures, MachineSnapshot |
 | 0.5.0 | Actor model | `create_actor`, actor system, `from_promise`/`from_callback`, asyncio |
 | 0.6.0 | Setup & parity | `setup()`, composable guards (`and_`/`or_`/`not_`), snapshot serialization |
-| 0.7.0 | Current parity | State `tags` + `meta`, `hasTag()`, `stateIn` guard, `choose`/`pure` actions, Mermaid diagrams |
+| 0.7.0 | Snapshot and action parity | State `tags` + `meta`, `hasTag()`, `stateIn` guard, `choose`/`pure` actions, Mermaid diagrams |
+| 0.7.1 | SCXML release hardening | Vendored fixture subset, expanded parallel conformance, safe integer-data subset |
 | 0.8.0+ | Next parity + internals | `enqueueActions`, `reenter`, `stopChild`, dynamic `sendTo`, wildcard event descriptors, graph/test helpers, inspector protocol, `ParamSpec` handler typing |
 
 The differentiating niche: **XState / Stately.ai JSON compatibility** — neither `transitions`
@@ -200,8 +201,9 @@ landscape (`transitions`, `python-statemachine`, `Sismic`). Ranked by parity val
 - **Observer pattern** — `python-statemachine`'s `add_observer`; we have `subscribe`, consider a
   multi-callback observer protocol with entry/exit hooks.
 
-**Process note:** 0.7.0 scope is locked on master. Re-run ecosystem research
-before adding new comparative claims or finalizing a 0.8.0 scope.
+**Process note:** 0.7.1 scope is limited to release packaging for the merged
+SCXML fixture and parallel-conformance work. Re-run ecosystem research before
+adding new comparative claims or finalizing a 0.8.0 scope.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <p align="center">
   <a href="https://github.com/JovaniPink/xstate-python/actions/workflows/pull_request.yaml"><img alt="Tests and code quality" src="https://github.com/JovaniPink/xstate-python/actions/workflows/pull_request.yaml/badge.svg"></a>
   <img alt="Python" src="https://img.shields.io/badge/python-3.13%2B-blue">
-  <img alt="Status" src="https://img.shields.io/badge/status-alpha%20(0.7.0)-orange">
+  <img alt="Status" src="https://img.shields.io/badge/status-alpha%20(0.7.1)-orange">
   <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/license-MIT-green"></a>
 </p>
 
@@ -487,11 +487,11 @@ runtimes.
 
 ### Release preflight
 
-Before creating the GitHub Release for `0.7.0`, run the local preflight from
+Before creating the GitHub Release for `0.7.1`, run the local preflight from
 the target commit:
 
 ```bash
-poetry run python scripts/release_preflight.py v0.7.0
+poetry run python scripts/release_preflight.py v0.7.1
 ```
 
 The preflight verifies the expected tag against `pyproject.toml`, checks that
@@ -500,7 +500,7 @@ distribution without publishing. Pass `--target-ref` or `--master-ref` if the
 release target needs to be checked against different refs.
 
 The GitHub **Release Preflight** workflow exposes the same dry run through
-`workflow_dispatch`. It checks out `master`, defaults to `v0.7.0`, and calls
+`workflow_dispatch`. It checks out `master`, defaults to `v0.7.1`, and calls
 the same script without publishing. The GitHub Release publish workflow also
 delegates all validation to this script before `poetry publish`; workflow
 contract tests prevent either workflow from duplicating or drifting from the
@@ -510,7 +510,7 @@ script-owned quality gates.
 
 | Area | Current state |
 |---|---|
-| PyPI release | `0.7.0` release-readiness is complete; publish via GitHub Release |
+| PyPI release | `0.7.1` release metadata and preflight are current; publish via GitHub Release |
 | XState v5 setup | `setup(...).create_machine(...)` and composable guards are present |
 | Snapshot queries | `tags`, `meta`, `has_tag`/`hasTag`, and `state_in`/`stateIn` are present |
 | Diagrams | Dependency-free Mermaid export is present |

--- a/README.md
+++ b/README.md
@@ -50,13 +50,18 @@ functions, delay values, and actor logic.
 
 ## Installation
 
-Install the released package from PyPI:
+No JovaniPink build of this repository is currently verified as published on
+PyPI. The existing `xstate` project on PyPI is a separate `0.0.1` distribution;
+do not use `pip install xstate` expecting the code documented here.
+
+Install a reviewed source revision by replacing `<commit>` with an exact commit
+SHA:
 
 ```bash
-pip install xstate
+pip install "git+https://github.com/JovaniPink/xstate-python.git@<commit>"
 ```
 
-For an unreleased checkout, install from source:
+For development, clone the repository and use the locked Poetry environment:
 
 ```bash
 git clone https://github.com/JovaniPink/xstate-python.git
@@ -501,16 +506,17 @@ release target needs to be checked against different refs.
 
 The GitHub **Release Preflight** workflow exposes the same dry run through
 `workflow_dispatch`. It checks out `master`, defaults to `v0.7.1`, and calls
-the same script without publishing. The GitHub Release publish workflow also
-delegates all validation to this script before `poetry publish`; workflow
-contract tests prevent either workflow from duplicating or drifting from the
-script-owned quality gates.
+the same script without publishing. The GitHub Release workflow is fail-closed:
+it delegates validation to the same script but can publish only when the
+repository variable `PYPI_PUBLISH_ENABLED` is explicitly set to `true`, the
+token is configured, and ownership of the chosen PyPI project has been verified.
+Creating a tag or GitHub Release is not publication authorization.
 
 ## Roadmap
 
 | Area | Current state |
 |---|---|
-| PyPI release | `0.7.1` release metadata and preflight are current; publish via GitHub Release |
+| Package distribution | `0.7.1` source and wheel metadata are prepared; PyPI name/ownership and publication authorization remain unresolved |
 | XState v5 setup | `setup(...).create_machine(...)` and composable guards are present |
 | Snapshot queries | `tags`, `meta`, `has_tag`/`hasTag`, and `state_in`/`stateIn` are present |
 | Diagrams | Dependency-free Mermaid export is present |

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -2,7 +2,7 @@
 
 Research snapshot: June 2026. External ecosystem numbers are approximate and
 should be refreshed before publication or fundraising use. Repo capability notes
-reflect the current `master` branch after the 0.7.0 correctness and adoption
+reflect the current `master` branch after the 0.7.1 SCXML conformance
 milestone.
 
 ## Product Thesis
@@ -22,7 +22,7 @@ bridge between XState's JSON ecosystem and Python backends.
 
 | Area | Status |
 |---|---|
-| Packaging | Project metadata is modernized for Python 3.13+ and ready for the 0.7.0 PyPI release |
+| Packaging | Project metadata is modernized for Python 3.13+ and ready for the 0.7.1 PyPI release |
 | Core transition API | `Machine(config).transition(state, event)` |
 | XState JSON | Native Python dict / JSON-compatible config boundary |
 | Parser architecture | Typed schema + normalization/parser layer |
@@ -90,7 +90,7 @@ JavaScript and wanting the same machine shape in Python services.
 
 | Priority | Work |
 |---|---|
-| High | Publish 0.7.0 to PyPI as `xstate` |
+| High | Publish 0.7.1 to PyPI as `xstate` |
 | High | Expand SCXML coverage beyond the configured subset without adding JavaScript evaluation |
 | Medium | Inspector protocol compatibility |
 | Medium | More XState v5 utilities: `provide`, action helpers, graph/test helpers |
@@ -100,7 +100,7 @@ JavaScript and wanting the same machine shape in Python services.
 
 | Metric | Near-term target |
 |---|---|
-| PyPI release | `pip install xstate` works after the 0.7.0 GitHub Release |
+| PyPI release | `pip install xstate` works after the 0.7.1 GitHub Release |
 | Primary test count | Maintain 300+ focused tests |
 | SCXML pass rate | Keep the configured 56-case suite green while expanding supported coverage |
 | Docs | Keep every public runtime boundary represented by a maintained concept guide |

--- a/docs/PRODUCT.md
+++ b/docs/PRODUCT.md
@@ -22,7 +22,7 @@ bridge between XState's JSON ecosystem and Python backends.
 
 | Area | Status |
 |---|---|
-| Packaging | Project metadata is modernized for Python 3.13+ and ready for the 0.7.1 PyPI release |
+| Packaging | Python 3.13+ source and wheel metadata are prepared for 0.7.1; package-index name and ownership remain unresolved |
 | Core transition API | `Machine(config).transition(state, event)` |
 | XState JSON | Native Python dict / JSON-compatible config boundary |
 | Parser architecture | Typed schema + normalization/parser layer |
@@ -90,7 +90,7 @@ JavaScript and wanting the same machine shape in Python services.
 
 | Priority | Work |
 |---|---|
-| High | Publish 0.7.1 to PyPI as `xstate` |
+| High | Resolve the package-index name and prove publication ownership before enabling release publishing |
 | High | Expand SCXML coverage beyond the configured subset without adding JavaScript evaluation |
 | Medium | Inspector protocol compatibility |
 | Medium | More XState v5 utilities: `provide`, action helpers, graph/test helpers |
@@ -100,7 +100,7 @@ JavaScript and wanting the same machine shape in Python services.
 
 | Metric | Near-term target |
 |---|---|
-| PyPI release | `pip install xstate` works after the 0.7.1 GitHub Release |
+| Package distribution | An approved package name installs the reviewed 0.7.1 artifact after ownership and publication are verified |
 | Primary test count | Maintain 300+ focused tests |
 | SCXML pass rate | Keep the configured 56-case suite green while expanding supported coverage |
 | Docs | Keep every public runtime boundary represented by a maintained concept guide |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -2,13 +2,13 @@
 
 Research snapshot: June 2026. Competitor figures are intentionally approximate;
 the xstate-python column reflects the current `master` branch after the 0.7.1
-release-readiness work.
+source-release preparation work.
 
 ## Feature Matrix
 
 | Feature | **transitions** | **python-statemachine** | **xstate-python** | **xstate-statemachine** | **Sismic** | **Automat** |
 |---|---|---|---|---|---|---|
-| Status | Mature / active | Mature / active | Alpha / 0.7.1 release-ready | Small active project | Mature niche | Mature focused FSM |
+| Status | Mature / active | Mature / active | Alpha / 0.7.1 source candidate | Small active project | Mature niche | Mature focused FSM |
 | Python support | Broad legacy support | Modern Python | **3.13+** | Modern Python | Modern Python | Modern Python |
 | XState JSON | No | No | **Yes, native** | Yes | No | No |
 | SCXML algorithm | No | Yes | **Yes, partial conformance** | Partial | Yes | No |
@@ -71,7 +71,7 @@ structure with a JavaScript/XState frontend or a Stately-authored design.
 
 | Gap | Notes |
 |---|---|
-| PyPI release | 0.7.1 packaging metadata and release workflow are ready; publish via GitHub Release. |
+| Package distribution | 0.7.1 artifacts can be built, but PyPI name/ownership and publication authorization are unresolved. |
 | SCXML conformance | Configured SCXML suite is `56 passed`, `0 failed`; broader W3C coverage is not yet claimed. |
 | Full ECMAScript cond support | Intentionally not implemented; unsupported SCXML expressions raise `InvalidConfigError`. |
 | Graph/test utilities | Mermaid export exists; no graph traversal/test-path helpers yet. |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,14 +1,14 @@
 # Python State Machine Library Comparison
 
 Research snapshot: June 2026. Competitor figures are intentionally approximate;
-the xstate-python column reflects the current `master` branch after the 0.7.0
+the xstate-python column reflects the current `master` branch after the 0.7.1
 release-readiness work.
 
 ## Feature Matrix
 
 | Feature | **transitions** | **python-statemachine** | **xstate-python** | **xstate-statemachine** | **Sismic** | **Automat** |
 |---|---|---|---|---|---|---|
-| Status | Mature / active | Mature / active | Alpha / 0.7.0 release-ready | Small active project | Mature niche | Mature focused FSM |
+| Status | Mature / active | Mature / active | Alpha / 0.7.1 release-ready | Small active project | Mature niche | Mature focused FSM |
 | Python support | Broad legacy support | Modern Python | **3.13+** | Modern Python | Modern Python | Modern Python |
 | XState JSON | No | No | **Yes, native** | Yes | No | No |
 | SCXML algorithm | No | Yes | **Yes, partial conformance** | Partial | Yes | No |
@@ -71,7 +71,7 @@ structure with a JavaScript/XState frontend or a Stately-authored design.
 
 | Gap | Notes |
 |---|---|
-| PyPI release | 0.7.0 packaging metadata and release workflow are ready; publish via GitHub Release. |
+| PyPI release | 0.7.1 packaging metadata and release workflow are ready; publish via GitHub Release. |
 | SCXML conformance | Configured SCXML suite is `56 passed`, `0 failed`; broader W3C coverage is not yet claimed. |
 | Full ECMAScript cond support | Intentionally not implemented; unsupported SCXML expressions raise `InvalidConfigError`. |
 | Graph/test utilities | Mermaid export exists; no graph traversal/test-path helpers yet. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xstate"
-version = "0.7.0"
+version = "0.7.1"
 description = "Statecharts and state machines for Python, inspired by XState."
 readme = "README.md"
 requires-python = ">=3.13"

--- a/scripts/release_preflight.py
+++ b/scripts/release_preflight.py
@@ -99,7 +99,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     parser.add_argument(
         "expected_tag",
-        help="Release tag expected from pyproject.toml, for example v0.7.0.",
+        help="Release tag expected from pyproject.toml, for example v0.7.1.",
     )
     parser.add_argument(
         "--target-ref",

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -29,6 +29,7 @@ def assert_delegates_to_preflight(workflow: str, invocation: str) -> None:
 def test_release_workflow_delegates_validation_to_preflight_script() -> None:
     workflow = normalized_workflow("release.yaml")
 
+    assert "vars.PYPI_PUBLISH_ENABLED == 'true'" in workflow
     assert_delegates_to_preflight(
         workflow,
         (

--- a/tests/test_release_workflows.py
+++ b/tests/test_release_workflows.py
@@ -39,11 +39,11 @@ def test_release_workflow_delegates_validation_to_preflight_script() -> None:
     assert "run: poetry publish" in workflow
 
 
-def test_manual_preflight_runs_v070_dry_run_against_master() -> None:
+def test_manual_preflight_runs_v071_dry_run_against_master() -> None:
     workflow = normalized_workflow("release_preflight.yaml")
 
     assert "workflow_dispatch:" in workflow
-    assert "default: v0.7.0" in workflow
+    assert "default: v0.7.1" in workflow
     assert "ref: master" in workflow
     assert "fetch-depth: 0" in workflow
     assert_delegates_to_preflight(


### PR DESCRIPTION
## Summary

Prepare the focused `0.7.1` source and wheel metadata for the SCXML fixture-custody and parallel-conformance work already merged in #36 and #37.

This PR advances version surfaces from `0.7.0` to `0.7.1`, documents the bounded runtime changes already on `master`, and makes package-index publication fail closed until name ownership and authorization are explicitly verified. It adds no runtime behavior.

## Why

`master` owns the configured SCXML fixture subset and passes the expanded parallel cases, but package metadata and the manual preflight still identified `0.7.0`. The first draft also treated `pip install xstate` and PyPI publication as ready even though the public `xstate` project is a separate `0.0.1` distribution and JovaniPink ownership is not established.

The repaired release boundary keeps the technically complete `0.7.1` artifacts while refusing to turn unverified package-index ownership into a marketing or operational claim.

## Scope

- Bump `[project].version` to `0.7.1`.
- Add the `0.7.1` changelog entry for repository-owned SCXML fixtures, the safe fixture-proven integer subset, 15 enabled `more-parallel` cases, and corrected atomic self-transition behavior.
- Advance the manual Release Preflight default and its contract test to `v0.7.1`.
- Synchronize README, agent context, product notes, and comparison documentation.
- Replace the misleading `pip install xstate` instruction with exact-commit source installation.
- State that the declared distribution name is provisional because PyPI ownership is unresolved.
- Gate the release publish job on `vars.PYPI_PUBLISH_ENABLED == 'true'` in addition to the existing token, tag, master-ref, draft, and prerelease checks.
- Preserve historical `0.7.0` references and runtime/API behavior.

## Evidence and dependency order

- Base: `master` at `502da528777a72c3e26057fd54142c229a566bd2`.
- #36 and #37 are already merged prerequisites.
- Exact current head: `0462a3b5394ec4fd2a9feed816c56b2251f78570`.
- PyPI currently lists `xstate` `0.0.1` under a different maintainer; no JovaniPink release or ownership was verified.
- The repository currently has no GitHub releases and no `PYPI_PUBLISH_ENABLED` variable, so the publish job is fail-closed.

Intended order: merged #36 and #37 -> this source metadata PR -> post-merge preflight on exact `master` -> separate owner decision about package name, index ownership, GitHub Release, and publication.

## Validation

- Primary suite: 428 passed.
- SCXML suite: 57 passed (56 configured cases plus fixture inventory guard).
- Ruff format and lint: passed.
- MyPy: no issues in 22 source files.
- `poetry check --lock`: passed.
- `0.7.1` sdist and wheel: built successfully.
- Isolated wheel install and actor smoke test: passed.
- Workflow contract test enforces the explicit `PYPI_PUBLISH_ENABLED` gate.
- Negative release-target test: the preflight correctly rejected the unmerged branch because `HEAD` did not equal `origin/master`.
- `git diff --check`: passed.

The complete preflight must be rerun after merge against the exact merge commit, when `HEAD` and `origin/master` are equal.

## Public claim boundary

- `0.7.1` is an alpha source/wheel candidate, not a verified PyPI release.
- `pip install xstate` currently refers to a separate public distribution.
- Passing tests and building artifacts do not prove package-index ownership or authorize publication.
- The configured 56-case subset does not imply full W3C SCXML or general JavaScript-datamodel conformance.

## Non-goals

- No changes to runtime modules, fixtures, public APIs, dependencies, or supported Python versions.
- No tag, GitHub Release, PyPI ownership claim, provider-variable change, secret change, or publication.
- No package rename; the final distribution name remains an owner decision.

## Risk and rollback

- Version drift is covered by workflow tests and the shared preflight.
- Publication remains safely disabled unless an owner deliberately enables the repository variable after verifying the package destination and credentials.
- Before publication, rollback is a normal revert of the squash commit. A published package would require a follow-up version because index artifacts are immutable evidence.

## Review focus

1. Changelog accuracy without overstating SCXML conformance.
2. Consistency of the `0.7.1` source-candidate label across public and agent-facing docs.
3. Fail-closed publishing when package-index ownership is unresolved.
4. Separation of merge, preflight, tag, GitHub Release, package-index authorization, and publication.

## Unresolved owner decision

Choose and verify the final Python distribution destination: obtain authorized ownership of `xstate` or select a different package name. Only then should `PYPI_PUBLISH_ENABLED` be created and a release publication considered.
