### PR TITLE
Add end-to-end generics to the public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,8 @@ PYTHONPATH=src python3 docs/examples/scxml_toggle.py
 
 Concept guides and the runnable-example index live in [`docs/`](./docs). Start
 with [machines and implementations](./docs/concepts/machines-and-implementations.md)
-or [runtime choices](./docs/concepts/runtimes.md), then continue with
+or [static typing](./docs/concepts/typing.md) and
+[runtime choices](./docs/concepts/runtimes.md), then continue with
 [actors](./docs/concepts/actors.md) and
 [snapshot persistence](./docs/concepts/persistence.md). The
 [SCXML import guide](./docs/concepts/scxml.md) covers the supported XML and safe

--- a/docs/concepts/typing.md
+++ b/docs/concepts/typing.md
@@ -1,0 +1,137 @@
+# Static typing
+
+The public API is generic without adding runtime schemas or validation. Existing
+unparameterized `Machine(...)` calls remain `Any`-compatible. Add type arguments
+when a consumer wants mypy to check context, event objects, output, snapshots,
+and runtime sends end to end.
+
+`EventDataT` is the complete external event mapping, including its required
+`type` discriminator. This matches [XState event objects](https://stately.ai/docs/transitions),
+not a payload nested below `type`.
+
+## Machine and handlers
+
+```python
+from typing import Literal, TypedDict, assert_type
+
+from xstate import HandlerArgs, Machine, MachineConfig, State
+
+
+class Context(TypedDict):
+    count: int
+
+
+class AddEvent(TypedDict):
+    type: Literal["ADD"]
+    by: int
+
+
+class FinishEvent(TypedDict):
+    type: Literal["FINISH"]
+
+
+type CounterEvent = AddEvent | FinishEvent
+
+
+class Output(TypedDict):
+    total: int
+
+
+def final_output(
+    args: HandlerArgs[Context, CounterEvent, Output],
+) -> Output:
+    return {"total": args.context["count"]}
+
+
+config: MachineConfig[Context, CounterEvent, Output] = {
+    "id": "counter",
+    "context": {"count": 0},
+    "initial": "active",
+    "states": {
+        "active": {"on": {"FINISH": "done"}},
+        "done": {"type": "final", "output": final_output},
+    },
+}
+
+machine: Machine[Context, CounterEvent, Output] = Machine(config)
+snapshot = machine.transition(machine.initial_state, {"type": "FINISH"})
+
+assert_type(snapshot, State[Context, CounterEvent, Output])
+assert_type(snapshot.context, Context)
+assert_type(snapshot.output, Output | None)
+```
+
+`HandlerArgs.event` also represents runtime-generated done and error events, so
+its data is typed as the union of external event data, machine or actor output,
+and `BaseException`. Narrow by event name or data shape before reading fields.
+
+Canonical handler protocols are exported as `ActionHandler`, `GuardHandler`,
+`DelayHandler`, `AssignmentHandler`, and `OutputHandler`. Annotating a handler
+with one of these protocols makes an incorrect return type fail at type-check
+time. Legacy zero-, one-, two-, and keyword-argument callables remain accepted
+at runtime.
+
+## Setup and interpreters
+
+```python
+from typing import assert_type
+
+from xstate import AsyncInterpreter, Interpreter, MachineSetup, interpret, interpret_async, setup
+
+configured: MachineSetup[Context, CounterEvent, Output] = setup()
+machine = configured.create_machine(config)
+
+service = interpret(machine)
+assert_type(service, Interpreter[Context, CounterEvent, Output])
+assert_type(
+    service.send({"type": "ADD", "by": 2}),
+    State[Context, CounterEvent, Output],
+)
+
+async_service = interpret_async(machine)
+assert_type(async_service, AsyncInterpreter[Context, CounterEvent, Output])
+
+
+async def finish() -> None:
+    result = await async_service.send({"type": "FINISH"})
+    assert_type(result, State[Context, CounterEvent, Output])
+```
+
+Subscriptions receive the same typed `State`, so a listener can be declared as
+`Callable[[State[Context, CounterEvent, Output]], None]` without casts.
+
+## Actors
+
+```python
+import asyncio
+from typing import assert_type
+
+from xstate import Actor, ActorSnapshot, EventInput, create_actor, from_promise, to_promise
+
+machine_actor = create_actor(machine)
+assert_type(
+    machine_actor,
+    Actor[
+        EventInput[CounterEvent],
+        State[Context, CounterEvent, Output],
+        Output,
+    ],
+)
+
+
+def calculate(input: int) -> Output:
+    return {"total": input}
+
+
+promise_actor = create_actor(from_promise(calculate), input=3)
+assert_type(promise_actor, Actor[object, ActorSnapshot[Output], Output])
+assert_type(to_promise(promise_actor), asyncio.Future[Output])
+```
+
+Known machine, promise, callback, and observable logic preserves precise actor
+types. `ActorSystem.get()` is intentionally widened because one system may hold
+heterogeneous actors.
+
+Raw JSON dictionaries, string events, and unparameterized machines remain valid.
+These annotations guide static consumers only; they do not generate code or add
+a runtime validation dependency.

--- a/src/xstate/__init__.py
+++ b/src/xstate/__init__.py
@@ -10,7 +10,12 @@ from xstate.action import (  # noqa
 )
 from xstate.actor import (  # noqa
     Actor,
+    ActorSnapshot,
     ActorSystem,
+    CallbackHandler,
+    CallbackLogic,
+    ObservableLogic,
+    PromiseLogic,
     create_actor,
     from_callback,
     from_observable,
@@ -24,29 +29,52 @@ from xstate.context import (  # noqa
     DeepCopyContextAdapter,
     dataclass_context,
 )
-from xstate.event import Event, to_event  # noqa
+from xstate.event import Event, EventInput, RuntimeEventPayload, to_event  # noqa
 from xstate.exceptions import (  # noqa
     InvalidConfigError,
     UnregisteredImplementationError,
     XStateError,
 )
 from xstate.guards import and_, not_, or_, state_in, stateIn  # noqa
-from xstate.handlers import HandlerArgs  # noqa
+from xstate.handlers import (  # noqa
+    ActionHandler,
+    AssignmentHandler,
+    DelayHandler,
+    GuardHandler,
+    HandlerArgs,
+    OutputHandler,
+)
 from xstate.interpreter import Interpreter, interpret  # noqa
 from xstate.machine import Machine  # noqa
 from xstate.mermaid import to_mermaid  # noqa
 from xstate.scheduler import Clock, SimulatedClock, ThreadClock  # noqa
+from xstate.schema import (  # noqa
+    ActionSpec,
+    HandlerSpec,
+    InvokeConfig,
+    MachineConfig,
+    StateNodeConfig,
+    StateValue,
+    TransitionConfig,
+    TransitionTarget,
+)
 from xstate.setup_api import MachineSetup, setup  # noqa
 from xstate.snapshot import deserialize_snapshot, serialize_snapshot  # noqa
-from xstate.state import MachineSnapshot  # noqa
+from xstate.state import MachineSnapshot, State  # noqa
 
 __all__ = [
     # Core
     "Machine",
     "MachineSnapshot",
+    "State",
     "setup",
     "MachineSetup",
     "HandlerArgs",
+    "ActionHandler",
+    "AssignmentHandler",
+    "DelayHandler",
+    "GuardHandler",
+    "OutputHandler",
     # Interpreter
     "interpret",
     "Interpreter",
@@ -56,7 +84,12 @@ __all__ = [
     # Actor model (v5)
     "create_actor",
     "Actor",
+    "ActorSnapshot",
     "ActorSystem",
+    "PromiseLogic",
+    "CallbackLogic",
+    "ObservableLogic",
+    "CallbackHandler",
     "from_promise",
     "from_callback",
     "from_observable",
@@ -78,7 +111,18 @@ __all__ = [
     "dataclass_context",
     # Event
     "Event",
+    "EventInput",
+    "RuntimeEventPayload",
     "to_event",
+    # Typed config boundary
+    "ActionSpec",
+    "HandlerSpec",
+    "TransitionTarget",
+    "StateValue",
+    "TransitionConfig",
+    "InvokeConfig",
+    "StateNodeConfig",
+    "MachineConfig",
     # Exceptions
     "XStateError",
     "InvalidConfigError",

--- a/src/xstate/actor.py
+++ b/src/xstate/actor.py
@@ -41,10 +41,10 @@ from __future__ import annotations
 import asyncio
 import inspect
 import threading
-from collections.abc import AsyncIterable, Callable
-from typing import Any, Literal, Protocol, cast
+from collections.abc import AsyncIterable, Awaitable, Callable
+from typing import Any, Literal, Protocol, cast, overload
 
-from xstate.event import Event
+from xstate.event import Event, EventInput
 from xstate.interpreter import NOT_STARTED, RUNNING, STOPPED, Interpreter, Subscription
 from xstate.machine import Machine
 from xstate.scheduler import Clock
@@ -60,6 +60,7 @@ __all__ = [
     "ActorLogic",
     "ActorSnapshotValue",
     "SubscriptionProtocol",
+    "CallbackHandler",
     "from_promise",
     "from_callback",
     "from_observable",
@@ -77,7 +78,7 @@ class SubscriptionProtocol(Protocol):
 # ---------------------------------------------------------------------------
 
 
-class PromiseLogic:
+class PromiseLogic[InputT = Any, OutputT = Any]:
     """Logic that runs ``fn(input)`` once and resolves with its return value.
 
     Created with :func:`from_promise`.  On success the actor snapshot becomes
@@ -89,7 +90,7 @@ class PromiseLogic:
         self.fn = fn
 
 
-class CallbackLogic:
+class CallbackLogic[SendEventT = Any, InputT = Any]:
     """Logic that bridges an external event source.
 
     Created with :func:`from_callback`.  On start the actor calls
@@ -103,7 +104,7 @@ class CallbackLogic:
         self.fn = fn
 
 
-class ObservableLogic:
+class ObservableLogic[InputT = Any, OutputT = Any]:
     """Logic that emits each value from an async iterable.
 
     Created with :func:`from_observable`.  On start the actor iterates the
@@ -122,7 +123,19 @@ class ObservableLogic:
 ActorLogic = Machine | PromiseLogic | CallbackLogic | ObservableLogic
 
 
-def from_promise(fn: Callable[..., Any]) -> PromiseLogic:
+@overload
+def from_promise[InputT, OutputT](
+    fn: Callable[[InputT], OutputT | Awaitable[OutputT]],
+) -> PromiseLogic[InputT, OutputT]: ...
+
+
+@overload
+def from_promise[OutputT](
+    fn: Callable[[], OutputT | Awaitable[OutputT]],
+) -> PromiseLogic[None, OutputT]: ...
+
+
+def from_promise(fn: Callable[..., Any]) -> PromiseLogic[Any, Any]:
     """Create promise actor logic from ``fn`` (XState v5 ``fromPromise``).
 
     ``fn`` may be synchronous (resolves eagerly on start) or an ``async def``
@@ -131,14 +144,46 @@ def from_promise(fn: Callable[..., Any]) -> PromiseLogic:
     return PromiseLogic(fn)
 
 
-def from_callback(fn: Callable[..., Any]) -> CallbackLogic:
+class CallbackHandler[SendEventT = Any, InputT = Any](Protocol):
+    def __call__(
+        self,
+        *,
+        send_back: Callable[[Any], None],
+        receive: Callable[[Callable[[SendEventT], None]], None],
+        input: InputT,
+    ) -> Callable[[], None] | None: ...
+
+
+@overload
+def from_callback[SendEventT, InputT](
+    fn: CallbackHandler[SendEventT, InputT],
+) -> CallbackLogic[SendEventT, InputT]: ...
+
+
+@overload
+def from_callback(fn: Callable[..., Any]) -> CallbackLogic[Any, Any]: ...
+
+
+def from_callback(fn: Callable[..., Any]) -> CallbackLogic[Any, Any]:
     """Create callback actor logic from ``fn`` (XState v5 ``fromCallback``)."""
     return CallbackLogic(fn)
 
 
+@overload
+def from_observable[InputT, OutputT](
+    fn: Callable[[InputT], AsyncIterable[OutputT]],
+) -> ObservableLogic[InputT, OutputT]: ...
+
+
+@overload
+def from_observable[OutputT](
+    fn: AsyncIterable[OutputT],
+) -> ObservableLogic[None, OutputT]: ...
+
+
 def from_observable(
     fn: Callable[..., AsyncIterable[Any]] | AsyncIterable[Any],
-) -> ObservableLogic:
+) -> ObservableLogic[Any, Any]:
     """Create observable actor logic from ``fn`` (XState v5 ``fromObservable``).
 
     ``fn`` is a callable returning an async iterable (e.g. an async generator
@@ -198,7 +243,7 @@ def _call_with_supported_kwargs(fn: Callable[..., Any], **kwargs: Any) -> Any:
 # ---------------------------------------------------------------------------
 
 
-class ActorSnapshot:
+class ActorSnapshot[OutputT = Any, ContextT = Any]:
     """Minimal snapshot for promise/callback actors.
 
     Mirrors the fields a machine :class:`~xstate.state.State` exposes
@@ -209,14 +254,14 @@ class ActorSnapshot:
     def __init__(
         self,
         status: Literal["active", "done", "error"],
-        output: Any | None = None,
+        output: OutputT | None = None,
         error: Any | None = None,
-        context: Any | None = None,
+        context: ContextT | None = None,
     ):
         self.status: Literal["active", "done", "error"] = status
-        self.output = output
+        self.output: OutputT | None = output
         self.error = error
-        self.context = context
+        self.context: ContextT | None = context
         self.value = status
 
     def __repr__(self) -> str:
@@ -476,7 +521,9 @@ class _ObservableBackend(_ListenerBackend):
 
 
 ActorBackend = _MachineBackend | _PromiseBackend | _CallbackBackend | _ObservableBackend
-ActorSnapshotValue = State | ActorSnapshot
+type ActorSnapshotValue[ContextT = Any, EventDataT = Any, OutputT = Any] = (
+    State[ContextT, EventDataT, OutputT] | ActorSnapshot[OutputT]
+)
 
 
 def _build_backend(
@@ -510,7 +557,7 @@ class ActorSystem:
     """
 
     def __init__(self) -> None:
-        self._actors: dict[str, Actor] = {}
+        self._actors: dict[str, Actor[Any, Any, Any]] = {}
         self._anonymous_count = 0
         self._lock = threading.RLock()
 
@@ -531,11 +578,11 @@ class ActorSystem:
         self._anonymous_count += 1
         return candidate
 
-    def _register(self, actor: Actor) -> None:
+    def _register(self, actor: Actor[Any, Any, Any]) -> None:
         with self._lock:
             self._register_unlocked(actor)
 
-    def _register_unlocked(self, actor: Actor) -> None:
+    def _register_unlocked(self, actor: Actor[Any, Any, Any]) -> None:
         actor_id = actor.id
         if actor_id in self._actors and self._actors[actor_id] is not actor:
             raise ValueError(
@@ -543,19 +590,19 @@ class ActorSystem:
             )
         self._actors[actor_id] = actor
 
-    def _unregister(self, actor: Actor) -> None:
+    def _unregister(self, actor: Actor[Any, Any, Any]) -> None:
         with self._lock:
             actor_id = actor.id
             if self._actors.get(actor_id) is actor:
                 del self._actors[actor_id]
 
-    def get(self, actor_id: str) -> Actor | None:
+    def get(self, actor_id: str) -> Actor[Any, Any, Any] | None:
         """Return the actor registered under *actor_id*, or ``None``."""
         with self._lock:
             return self._actors.get(actor_id)
 
 
-class Actor:
+class Actor[SendEventT = Any, SnapshotT = Any, OutputT = Any]:
     """A running instance of actor logic with an address in a system.
 
     Lifecycle (``start`` / ``stop`` / ``status``), messaging (``send``),
@@ -571,7 +618,7 @@ class Actor:
         id: str | None = None,
         clock: Clock | None = None,
         system: ActorSystem | None = None,
-        parent: Actor | None = None,
+        parent: Actor[Any, Any, Any] | None = None,
         input: Any = None,
         snapshot: Any = None,
     ) -> None:
@@ -582,9 +629,9 @@ class Actor:
             self._clock = clock
             self._input = input
             self._snapshot = snapshot
-            self._children: dict[str, Actor] = {}
+            self._children: dict[str, Actor[Any, Any, Any]] = {}
             # invocation id -> child actor spawned by an `invoke:` on a state
-            self._invoked: dict[str, Actor] = {}
+            self._invoked: dict[str, Actor[Any, Any, Any]] = {}
             self._invocation_sub: SubscriptionProtocol | None = None
             self._syncing = False
             self._backend: ActorBackend = _build_backend(self, logic, clock, input)
@@ -601,11 +648,11 @@ class Actor:
         return self._system
 
     @property
-    def parent(self) -> Actor | None:
+    def parent(self) -> Actor[Any, Any, Any] | None:
         return self._parent
 
     @property
-    def children(self) -> dict[str, Actor]:
+    def children(self) -> dict[str, Actor[Any, Any, Any]]:
         return dict(self._children)
 
     # -- lifecycle ----------------------------------------------------------
@@ -614,12 +661,14 @@ class Actor:
     def status(self) -> str:
         return self._backend.status
 
-    def start(self, initial_state: State | None = None) -> Actor:
+    def start(
+        self, initial_state: SnapshotT | None = None
+    ) -> Actor[SendEventT, SnapshotT, OutputT]:
         if self._backend.status == STOPPED:
             # Match XState: a stopped actor does not restart.
             return self
         effective = initial_state if initial_state is not None else self._snapshot
-        self._backend.start(effective)
+        self._backend.start(cast(Any, effective))
         # For machine actors that declare any `invoke:`, reconcile child actors
         # on every state change (the immediate subscribe call handles the
         # initial state). Invoke-free machines skip this entirely.
@@ -633,7 +682,7 @@ class Actor:
             )
         return self
 
-    def stop(self) -> Actor:
+    def stop(self) -> Actor[SendEventT, SnapshotT, OutputT]:
         if self._backend.status == STOPPED:
             return self
         # Stop children (including invoked ones) before tearing down self.
@@ -652,27 +701,81 @@ class Actor:
 
     # -- messaging ----------------------------------------------------------
 
-    def send(self, event: object) -> ActorSnapshotValue:
+    def send(self, event: SendEventT) -> SnapshotT:
         """Deliver *event* to this actor (run-to-completion for machines)."""
         self._backend.send(event)
         return self.get_snapshot()
 
-    def subscribe(self, listener: Callable[[Any], None]) -> SubscriptionProtocol:
+    def subscribe(self, listener: Callable[[SnapshotT], None]) -> SubscriptionProtocol:
         """Observe snapshot changes. Returns a subscription with ``unsubscribe``."""
-        return self._backend.subscribe(listener)
+        return self._backend.subscribe(cast(Callable[[Any], None], listener))
 
     # -- snapshot -----------------------------------------------------------
 
-    def get_snapshot(self) -> ActorSnapshotValue:
+    def get_snapshot(self) -> SnapshotT:
         """Return the current snapshot (XState v5 ``actor.getSnapshot()``)."""
-        return self._backend.snapshot
+        return cast(SnapshotT, self._backend.snapshot)
 
     @property
-    def state(self) -> ActorSnapshotValue:
+    def state(self) -> SnapshotT:
         """Alias for :meth:`get_snapshot`."""
-        return self._backend.snapshot
+        return cast(SnapshotT, self._backend.snapshot)
 
     # -- actor tree ---------------------------------------------------------
+
+    @overload
+    def spawn[ChildContextT, ChildEventDataT, ChildOutputT](
+        self,
+        logic: Machine[ChildContextT, ChildEventDataT, ChildOutputT],
+        *,
+        id: str | None = None,
+        input: Any = None,
+        clock: Clock | None = None,
+    ) -> Actor[
+        EventInput[ChildEventDataT],
+        State[ChildContextT, ChildEventDataT, ChildOutputT],
+        ChildOutputT,
+    ]: ...
+
+    @overload
+    def spawn[InputT, ChildOutputT](
+        self,
+        logic: PromiseLogic[InputT, ChildOutputT],
+        *,
+        id: str | None = None,
+        input: InputT = ...,
+        clock: Clock | None = None,
+    ) -> Actor[object, ActorSnapshot[ChildOutputT], ChildOutputT]: ...
+
+    @overload
+    def spawn[ChildSendEventT, InputT](
+        self,
+        logic: CallbackLogic[ChildSendEventT, InputT],
+        *,
+        id: str | None = None,
+        input: InputT = ...,
+        clock: Clock | None = None,
+    ) -> Actor[ChildSendEventT, ActorSnapshot[None], None]: ...
+
+    @overload
+    def spawn[InputT, ChildOutputT](
+        self,
+        logic: ObservableLogic[InputT, ChildOutputT],
+        *,
+        id: str | None = None,
+        input: InputT = ...,
+        clock: Clock | None = None,
+    ) -> Actor[object, ActorSnapshot[ChildOutputT], ChildOutputT]: ...
+
+    @overload
+    def spawn(
+        self,
+        logic: ActorLogic,
+        *,
+        id: str | None = None,
+        input: Any = None,
+        clock: Clock | None = None,
+    ) -> Actor[Any, Any, Any]: ...
 
     def spawn(
         self,
@@ -681,7 +784,7 @@ class Actor:
         id: str | None = None,
         input: Any = None,
         clock: Clock | None = None,
-    ) -> Actor:
+    ) -> Actor[Any, Any, Any]:
         """Create a child actor from *logic* in this actor's system.
 
         The child is registered as a child of this actor and shares the system,
@@ -796,18 +899,90 @@ class Actor:
             if status == "done":
                 sent["done"] = True
                 self.send(
-                    Event(f"done.invoke.{inv_id}", getattr(snapshot, "output", None))
+                    cast(
+                        SendEventT,
+                        Event(
+                            f"done.invoke.{inv_id}",
+                            getattr(snapshot, "output", None),
+                        ),
+                    )
                 )
             elif status == "error":
                 sent["done"] = True
                 self.send(
-                    Event(f"error.platform.{inv_id}", getattr(snapshot, "error", None))
+                    cast(
+                        SendEventT,
+                        Event(
+                            f"error.platform.{inv_id}",
+                            getattr(snapshot, "error", None),
+                        ),
+                    )
                 )
 
         return listener
 
     def __repr__(self) -> str:
         return f"<Actor id={self._id!r} status={self.status!r}>"
+
+
+@overload
+def create_actor[ContextT, EventDataT, OutputT](
+    logic: Machine[ContextT, EventDataT, OutputT],
+    *,
+    id: str | None = None,
+    clock: Clock | None = None,
+    system: ActorSystem | None = None,
+    input: Any = None,
+    snapshot: State[ContextT, EventDataT, OutputT] | None = None,
+) -> Actor[EventInput[EventDataT], State[ContextT, EventDataT, OutputT], OutputT]: ...
+
+
+@overload
+def create_actor[InputT, OutputT](
+    logic: PromiseLogic[InputT, OutputT],
+    *,
+    id: str | None = None,
+    clock: Clock | None = None,
+    system: ActorSystem | None = None,
+    input: InputT = ...,
+    snapshot: ActorSnapshot[OutputT] | None = None,
+) -> Actor[object, ActorSnapshot[OutputT], OutputT]: ...
+
+
+@overload
+def create_actor[SendEventT, InputT](
+    logic: CallbackLogic[SendEventT, InputT],
+    *,
+    id: str | None = None,
+    clock: Clock | None = None,
+    system: ActorSystem | None = None,
+    input: InputT = ...,
+    snapshot: ActorSnapshot[None] | None = None,
+) -> Actor[SendEventT, ActorSnapshot[None], None]: ...
+
+
+@overload
+def create_actor[InputT, OutputT](
+    logic: ObservableLogic[InputT, OutputT],
+    *,
+    id: str | None = None,
+    clock: Clock | None = None,
+    system: ActorSystem | None = None,
+    input: InputT = ...,
+    snapshot: ActorSnapshot[OutputT] | None = None,
+) -> Actor[object, ActorSnapshot[OutputT], OutputT]: ...
+
+
+@overload
+def create_actor(
+    logic: ActorLogic,
+    *,
+    id: str | None = None,
+    clock: Clock | None = None,
+    system: ActorSystem | None = None,
+    input: Any = None,
+    snapshot: Any = None,
+) -> Actor[Any, Any, Any]: ...
 
 
 def create_actor(
@@ -818,7 +993,7 @@ def create_actor(
     system: ActorSystem | None = None,
     input: Any = None,
     snapshot: Any = None,
-) -> Actor:
+) -> Actor[Any, Any, Any]:
     """Create an :class:`Actor` from actor *logic* (XState v5 ``createActor``).
 
     *logic* is a :class:`~xstate.machine.Machine`, :func:`from_promise` logic, or
@@ -832,7 +1007,9 @@ def create_actor(
     )
 
 
-def to_promise(actor: Actor) -> asyncio.Future[Any]:
+def to_promise[OutputT](
+    actor: Actor[Any, Any, OutputT],
+) -> asyncio.Future[OutputT]:
     """Adapt *actor* to an :class:`asyncio.Future` (XState v5 ``toPromise``).
 
     The future resolves with the actor's ``output`` when its snapshot reaches
@@ -849,14 +1026,14 @@ def to_promise(actor: Actor) -> asyncio.Future[Any]:
             "async context, e.g. within asyncio.run(...)."
         ) from None
 
-    future: asyncio.Future[Any] = loop.create_future()
+    future: asyncio.Future[OutputT] = loop.create_future()
 
     def _settle(snapshot: Any) -> None:
         if future.done():
             return
         status = getattr(snapshot, "status", None)
         if status == "done":
-            future.set_result(getattr(snapshot, "output", None))
+            future.set_result(cast(OutputT, getattr(snapshot, "output", None)))
         elif status == "error":
             error = getattr(snapshot, "error", None)
             future.set_exception(

--- a/src/xstate/async_interpreter.py
+++ b/src/xstate/async_interpreter.py
@@ -43,28 +43,35 @@ from __future__ import annotations
 import asyncio
 import inspect
 from collections import deque
-from collections.abc import Callable
-from typing import Any
+from collections.abc import Awaitable, Callable
+from typing import Any, cast
 
 from xstate.action import CANCEL_TYPE, SEND_TYPE, Action
-from xstate.event import Event as _Event
+from xstate.event import Event, EventInput, RuntimeEventPayload
 from xstate.interpreter import NOT_STARTED, RUNNING, STOPPED, resolve_delay_ms
 from xstate.machine import Machine
 from xstate.state import State
 
 __all__ = ["AsyncSubscription", "AsyncInterpreter", "interpret_async"]
 
-_QueuedEvent = tuple[Any, "asyncio.Future[State]"]
+type _QueuedEvent[ContextT, EventDataT, OutputT] = tuple[
+    EventInput[EventDataT],
+    asyncio.Future[State[ContextT, EventDataT, OutputT]],
+]
 
 
-class AsyncSubscription:
+class AsyncSubscription[ContextT = Any, EventDataT = Any, OutputT = Any]:
     """Handle returned by :meth:`AsyncInterpreter.subscribe`; call ``unsubscribe``."""
 
     def __init__(
-        self, interpreter: AsyncInterpreter, listener: Callable[[State], None]
+        self,
+        interpreter: AsyncInterpreter[ContextT, EventDataT, OutputT],
+        listener: Callable[[State[ContextT, EventDataT, OutputT]], None],
     ):
         self._interpreter = interpreter
-        self._listener: Callable[[State], None] | None = listener
+        self._listener: (
+            Callable[[State[ContextT, EventDataT, OutputT]], None] | None
+        ) = listener
 
     def unsubscribe(self) -> None:
         if self._listener is not None:
@@ -72,7 +79,7 @@ class AsyncSubscription:
             self._listener = None
 
 
-class AsyncInterpreter:
+class AsyncInterpreter[ContextT = Any, EventDataT = Any, OutputT = Any]:
     """An asyncio-native running instance of a :class:`~xstate.machine.Machine`.
 
     Lifecycle and messaging are coroutines (``start`` / ``send`` / ``stop``);
@@ -81,15 +88,17 @@ class AsyncInterpreter:
     loop is running when the service is started.
     """
 
-    machine: Machine
-    state: State
+    machine: Machine[ContextT, EventDataT, OutputT]
+    state: State[ContextT, EventDataT, OutputT]
 
-    def __init__(self, machine: Machine):
+    def __init__(self, machine: Machine[ContextT, EventDataT, OutputT]):
         self.machine = machine
         self.state = machine.initial_state
         self._status = NOT_STARTED
-        self._listeners: set[Callable[[State], None]] = set()
-        self._event_queue: deque[_QueuedEvent] = deque()
+        self._listeners: set[Callable[[State[ContextT, EventDataT, OutputT]], None]] = (
+            set()
+        )
+        self._event_queue: deque[_QueuedEvent[ContextT, EventDataT, OutputT]] = deque()
         self._processing = False
         self._processing_task: asyncio.Task[Any] | None = None
         # `after`-event name -> asyncio.Task running the delay
@@ -107,20 +116,22 @@ class AsyncInterpreter:
     def initialized(self) -> bool:
         return self._status == RUNNING
 
-    async def start(self, initial_state: State | None = None) -> AsyncInterpreter:
+    async def start(
+        self, initial_state: State[ContextT, EventDataT, OutputT] | None = None
+    ) -> AsyncInterpreter[ContextT, EventDataT, OutputT]:
         """Start the service. Idempotent while already running."""
         if self._status == RUNNING:
             return self
         if initial_state is not None:
             self.state = initial_state
-        self.state.event = _Event("xstate.init")
+        self.state.event = Event("xstate.init")
         self._status = RUNNING
         self._sync_delays()
         await self._execute(self.state)
         self._notify(self.state)
         return self
 
-    async def stop(self) -> AsyncInterpreter:
+    async def stop(self) -> AsyncInterpreter[ContextT, EventDataT, OutputT]:
         """Stop the service: cancel pending timers and drop all listeners."""
         for task in self._scheduled.values():
             task.cancel()
@@ -135,13 +146,17 @@ class AsyncInterpreter:
 
     # -- events -------------------------------------------------------------
 
-    async def send(self, event: Any) -> State:
+    async def send(
+        self, event: EventInput[EventDataT]
+    ) -> State[ContextT, EventDataT, OutputT]:
         """Send an event. Events sent during processing are queued (RTC)."""
         if self._status != RUNNING:
             # Match XState: events before start / after stop are dropped.
             return self.state
 
-        future: asyncio.Future[State] = asyncio.get_running_loop().create_future()
+        future: asyncio.Future[State[ContextT, EventDataT, OutputT]] = (
+            asyncio.get_running_loop().create_future()
+        )
         self._event_queue.append((event, future))
         if self._processing:
             # Same-task re-entrant sends from an action must not await their own
@@ -171,7 +186,9 @@ class AsyncInterpreter:
             self._processing_task = None
         return future.result()
 
-    def _resolve_queued_events(self, state: State) -> None:
+    def _resolve_queued_events(
+        self, state: State[ContextT, EventDataT, OutputT]
+    ) -> None:
         while self._event_queue:
             _event, future = self._event_queue.popleft()
             if not future.done():
@@ -184,9 +201,12 @@ class AsyncInterpreter:
                 future.set_exception(exc)
                 future.exception()
 
-    async def _process(self, event: Any) -> None:
+    async def _process(self, event: EventInput[EventDataT]) -> None:
         next_state = self.machine.transition(self.state, event)
-        next_state.event = self.machine._to_event(event)
+        next_state.event = cast(
+            Event[RuntimeEventPayload[EventDataT, OutputT]],
+            self.machine._to_event(event),
+        )
         self.state = next_state
         self._sync_delays()
         await self._execute(next_state)
@@ -194,7 +214,9 @@ class AsyncInterpreter:
 
     # -- subscriptions ------------------------------------------------------
 
-    def subscribe(self, listener: Callable[[State], None]) -> AsyncSubscription:
+    def subscribe(
+        self, listener: Callable[[State[ContextT, EventDataT, OutputT]], None]
+    ) -> AsyncSubscription[ContextT, EventDataT, OutputT]:
         """Register a listener called with the current state and on each change.
 
         Listeners are synchronous observers (as in XState); perform async work
@@ -205,7 +227,7 @@ class AsyncInterpreter:
             listener(self.state)
         return AsyncSubscription(self, listener)
 
-    def _notify(self, state: State) -> None:
+    def _notify(self, state: State[ContextT, EventDataT, OutputT]) -> None:
         for listener in list(self._listeners):
             listener(state)
 
@@ -216,7 +238,7 @@ class AsyncInterpreter:
         CANCEL_TYPE: "_execute_cancel",
     }
 
-    async def _execute(self, state: State) -> None:
+    async def _execute(self, state: State[ContextT, EventDataT, OutputT]) -> None:
         """Run resolved action callables; await any that return a coroutine."""
         for action in state.actions:
             if isinstance(action, Action):
@@ -246,7 +268,7 @@ class AsyncInterpreter:
             # by the Task itself so stop() can still cancel anonymous sends.
             self._send_timers[send_id if send_id else task] = task
         else:
-            await self.send(event)
+            await self.send(cast(EventInput[EventDataT], event))
 
     async def _execute_cancel(self, action: Action) -> None:
         send_id = action.data.get("sendid")
@@ -258,8 +280,8 @@ class AsyncInterpreter:
     # -- delayed transitions ------------------------------------------------
 
     def _schedule(
-        self, coro_fn: Callable[[Any], Any], arg: Any, delay_ms: float
-    ) -> asyncio.Task:
+        self, coro_fn: Callable[[Any], Awaitable[Any]], arg: Any, delay_ms: float
+    ) -> asyncio.Task[None]:
         """Create a task that waits ``delay_ms`` then calls ``coro_fn(arg)``."""
 
         async def _fire() -> None:
@@ -301,7 +323,9 @@ class AsyncInterpreter:
             )
 
 
-def interpret_async(machine: Machine) -> AsyncInterpreter:
+def interpret_async[ContextT, EventDataT, OutputT](
+    machine: Machine[ContextT, EventDataT, OutputT],
+) -> AsyncInterpreter[ContextT, EventDataT, OutputT]:
     """Create an :class:`AsyncInterpreter` for ``machine``.
 
     The asyncio counterpart of :func:`~xstate.interpreter.interpret`. The service

--- a/src/xstate/context.py
+++ b/src/xstate/context.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 import dataclasses
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 
 from xstate.exceptions import InvalidConfigError
 
@@ -14,27 +14,27 @@ __all__ = [
 ]
 
 
-class ContextAdapter(Protocol):
-    def snapshot(self, context: Any) -> Any:
+class ContextAdapter[ContextT = Any](Protocol):
+    def snapshot(self, context: ContextT) -> ContextT:
         """Return the context object used as the base for a new snapshot."""
 
-    def apply(self, context: Any, updates: dict[str, Any]) -> Any:
+    def apply(self, context: ContextT, updates: dict[str, Any]) -> ContextT:
         """Return context after applying assign updates."""
 
 
-class DeepCopyContextAdapter:
+class DeepCopyContextAdapter[ContextT = Any]:
     """Default context policy: isolate snapshots with deepcopy, update by copy."""
 
-    def snapshot(self, context: Any) -> Any:
+    def snapshot(self, context: ContextT) -> ContextT:
         if context is None:
-            return {}
+            return cast(ContextT, {})
         return copy.deepcopy(context)
 
-    def apply(self, context: Any, updates: dict[str, Any]) -> Any:
+    def apply(self, context: ContextT, updates: dict[str, Any]) -> ContextT:
         if isinstance(context, dict):
             next_context = dict(context)
             next_context.update(updates)
-            return next_context
+            return cast(ContextT, next_context)
         if dataclasses.is_dataclass(context) and not isinstance(context, type):
             return dataclasses.replace(context, **updates)
         raise InvalidConfigError(
@@ -43,13 +43,13 @@ class DeepCopyContextAdapter:
         )
 
 
-class DataclassContextAdapter:
+class DataclassContextAdapter[ContextT = Any]:
     """Context policy for immutable dataclass context values."""
 
-    def snapshot(self, context: Any) -> Any:
+    def snapshot(self, context: ContextT) -> ContextT:
         return context
 
-    def apply(self, context: Any, updates: dict[str, Any]) -> Any:
+    def apply(self, context: ContextT, updates: dict[str, Any]) -> ContextT:
         if not dataclasses.is_dataclass(context) or isinstance(context, type):
             raise InvalidConfigError(
                 "DataclassContextAdapter requires a dataclass instance context."
@@ -57,5 +57,5 @@ class DataclassContextAdapter:
         return dataclasses.replace(context, **updates)
 
 
-def dataclass_context() -> DataclassContextAdapter:
+def dataclass_context[ContextT]() -> DataclassContextAdapter[ContextT]:
     return DataclassContextAdapter()

--- a/src/xstate/event.py
+++ b/src/xstate/event.py
@@ -3,18 +3,23 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-__all__ = ["Event", "to_event"]
+__all__ = ["Event", "EventInput", "RuntimeEventPayload", "to_event"]
+
+type EventInput[EventDataT = Any] = str | Event[EventDataT] | EventDataT
+type RuntimeEventPayload[EventDataT = Any, OutputT = Any] = (
+    EventDataT | OutputT | BaseException
+)
 
 
 @dataclass(slots=True, frozen=True)
-class Event:
+class Event[PayloadT = Any]:
     name: str
     # Excluded from __hash__ so events with dict payloads remain hashable.
     # __eq__ still compares data, preserving the Python hash/eq contract.
-    data: dict[str, Any] | None = field(default=None, hash=False)
+    data: PayloadT | None = field(default=None, hash=False)
 
 
-def to_event(event: Any) -> Event:
+def to_event[EventDataT](event: EventInput[EventDataT]) -> Event[EventDataT]:
     """Normalize any event representation to an :class:`Event`."""
     if isinstance(event, Event):
         return event

--- a/src/xstate/handlers.py
+++ b/src/xstate/handlers.py
@@ -3,14 +3,20 @@ from __future__ import annotations
 import functools
 import inspect
 import warnings
+from collections.abc import Awaitable, Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Protocol
 
-from xstate.event import Event
+from xstate.event import Event, RuntimeEventPayload
 from xstate.exceptions import InvalidConfigError
 
 __all__ = [
     "HandlerArgs",
+    "ActionHandler",
+    "AssignmentHandler",
+    "DelayHandler",
+    "GuardHandler",
+    "OutputHandler",
     "GuardReference",
     "HandlerAdapter",
     "adapt_handler",
@@ -21,11 +27,39 @@ _UNSET = object()
 
 
 @dataclass(frozen=True, slots=True)
-class HandlerArgs:
-    context: Any
-    event: Event | None
+class HandlerArgs[ContextT = Any, EventDataT = Any, OutputT = Any]:
+    context: ContextT
+    event: Event[RuntimeEventPayload[EventDataT, OutputT]] | None
     params: Any | None = None
     state: Any | None = None
+
+
+class ActionHandler[ContextT = Any, EventDataT = Any, OutputT = Any](Protocol):
+    def __call__(
+        self, args: HandlerArgs[ContextT, EventDataT, OutputT], /
+    ) -> None | Awaitable[None]: ...
+
+
+class AssignmentHandler[ContextT = Any, EventDataT = Any, OutputT = Any](Protocol):
+    def __call__(
+        self, args: HandlerArgs[ContextT, EventDataT, OutputT], /
+    ) -> Mapping[str, Any]: ...
+
+
+class DelayHandler[ContextT = Any, EventDataT = Any, OutputT = Any](Protocol):
+    def __call__(
+        self, args: HandlerArgs[ContextT, EventDataT, OutputT], /
+    ) -> int | float: ...
+
+
+class GuardHandler[ContextT = Any, EventDataT = Any, OutputT = Any](Protocol):
+    def __call__(self, args: HandlerArgs[ContextT, EventDataT, OutputT], /) -> bool: ...
+
+
+class OutputHandler[ContextT = Any, EventDataT = Any, OutputT = Any](Protocol):
+    def __call__(
+        self, args: HandlerArgs[ContextT, EventDataT, OutputT], /
+    ) -> OutputT: ...
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/xstate/interpreter.py
+++ b/src/xstate/interpreter.py
@@ -29,10 +29,10 @@ import functools
 import threading
 from collections import deque
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 from xstate.action import CANCEL_TYPE, SEND_PARENT_TYPE, SEND_TO_TYPE, SEND_TYPE, Action
-from xstate.event import Event as _Event
+from xstate.event import Event, EventInput, RuntimeEventPayload
 from xstate.exceptions import UnregisteredImplementationError
 from xstate.machine import Machine
 from xstate.scheduler import Clock, ThreadClock
@@ -54,7 +54,7 @@ STOPPED = "stopped"
 
 
 def resolve_delay_ms(
-    machine: Machine, delay_spec: Any, context: Any, event: Any
+    machine: Machine[Any, Any, Any], delay_spec: Any, context: Any, event: Any
 ) -> float:
     """Resolve a delay key to milliseconds.
 
@@ -78,12 +78,18 @@ def resolve_delay_ms(
     return float(delay)
 
 
-class Subscription:
+class Subscription[ContextT = Any, EventDataT = Any, OutputT = Any]:
     """Handle returned by :meth:`Interpreter.subscribe`; call ``unsubscribe``."""
 
-    def __init__(self, interpreter: Interpreter, listener: Callable[[State], None]):
+    def __init__(
+        self,
+        interpreter: Interpreter[ContextT, EventDataT, OutputT],
+        listener: Callable[[State[ContextT, EventDataT, OutputT]], None],
+    ):
         self._interpreter = interpreter
-        self._listener: Callable[[State], None] | None = listener
+        self._listener: (
+            Callable[[State[ContextT, EventDataT, OutputT]], None] | None
+        ) = listener
 
     def unsubscribe(self) -> None:
         with self._interpreter._lock:
@@ -92,19 +98,25 @@ class Subscription:
                 self._listener = None
 
 
-class Interpreter:
-    machine: Machine
-    state: State
+class Interpreter[ContextT = Any, EventDataT = Any, OutputT = Any]:
+    machine: Machine[ContextT, EventDataT, OutputT]
+    state: State[ContextT, EventDataT, OutputT]
     clock: Clock
 
-    def __init__(self, machine: Machine, clock: Clock | None = None):
+    def __init__(
+        self,
+        machine: Machine[ContextT, EventDataT, OutputT],
+        clock: Clock | None = None,
+    ):
         self.machine = machine
         self.clock = clock if clock is not None else ThreadClock()
         self.state = machine.initial_state
         self._status = NOT_STARTED
         self._lock = threading.RLock()
-        self._listeners: set[Callable[[State], None]] = set()
-        self._event_queue: deque[Any] = deque()
+        self._listeners: set[Callable[[State[ContextT, EventDataT, OutputT]], None]] = (
+            set()
+        )
+        self._event_queue: deque[EventInput[EventDataT]] = deque()
         self._processing = False
         # `after`-event name → clock timeout id
         self._scheduled: dict[str, int] = {}
@@ -124,14 +136,16 @@ class Interpreter:
     def initialized(self) -> bool:
         return self._status == RUNNING
 
-    def start(self, initial_state: State | None = None) -> Interpreter:
+    def start(
+        self, initial_state: State[ContextT, EventDataT, OutputT] | None = None
+    ) -> Interpreter[ContextT, EventDataT, OutputT]:
         """Start the service.  Idempotent while already running."""
         with self._lock:
             if self._status == RUNNING:
                 return self
             if initial_state is not None:
                 self.state = initial_state
-            self.state.event = _Event("xstate.init")
+            self.state.event = Event("xstate.init")
             self._status = RUNNING
             self._sync_delays()
             state = self.state
@@ -139,7 +153,7 @@ class Interpreter:
         self._notify(state)
         return self
 
-    def stop(self) -> Interpreter:
+    def stop(self) -> Interpreter[ContextT, EventDataT, OutputT]:
         """Stop the service: cancel pending timers and drop all listeners."""
         with self._lock:
             for timeout_id in self._scheduled.values():
@@ -155,7 +169,9 @@ class Interpreter:
 
     # -- events -------------------------------------------------------------
 
-    def send(self, event: Any) -> State:
+    def send(
+        self, event: EventInput[EventDataT]
+    ) -> State[ContextT, EventDataT, OutputT]:
         """Send an event.  Events sent during processing are queued (RTC)."""
         with self._lock:
             if self._status != RUNNING:
@@ -186,14 +202,17 @@ class Interpreter:
                     self._processing = False
                 raise
 
-    def _process(self, event: Any) -> None:
+    def _process(self, event: EventInput[EventDataT]) -> None:
         with self._lock:
             if self._status != RUNNING:
                 return
             state = self.state
 
         next_state = self.machine.transition(state, event)
-        next_state.event = self.machine._to_event(event)
+        next_state.event = cast(
+            Event[RuntimeEventPayload[EventDataT, OutputT]],
+            self.machine._to_event(event),
+        )
 
         with self._lock:
             if self._status != RUNNING:
@@ -206,7 +225,9 @@ class Interpreter:
 
     # -- subscriptions ------------------------------------------------------
 
-    def subscribe(self, listener: Callable[[State], None]) -> Subscription:
+    def subscribe(
+        self, listener: Callable[[State[ContextT, EventDataT, OutputT]], None]
+    ) -> Subscription[ContextT, EventDataT, OutputT]:
         """Register a listener called with the current state and on each change."""
         with self._lock:
             self._listeners.add(listener)
@@ -215,7 +236,7 @@ class Interpreter:
             listener(state)
         return Subscription(self, listener)
 
-    def _notify(self, state: State) -> None:
+    def _notify(self, state: State[ContextT, EventDataT, OutputT]) -> None:
         with self._lock:
             listeners = tuple(self._listeners)
         for listener in listeners:
@@ -230,7 +251,7 @@ class Interpreter:
         SEND_TO_TYPE: "_execute_send_to",
     }
 
-    def _execute(self, state: State) -> None:
+    def _execute(self, state: State[ContextT, EventDataT, OutputT]) -> None:
         """Run resolved action callables and handle interpreter-owned actions."""
         for action in state.actions:
             if isinstance(action, Action):
@@ -251,12 +272,15 @@ class Interpreter:
         send_id = action.data.get("id")
         if delay is not None:
             delay_ms = self._resolve_delay(delay)
-            tid = self.clock.set_timeout(functools.partial(self.send, event), delay_ms)
+            tid = self.clock.set_timeout(
+                functools.partial(self.send, cast(EventInput[EventDataT], event)),
+                delay_ms,
+            )
             # Use the explicit id if given; fall back to tid so stop() can
             # cancel anonymous delayed sends too.
             self._send_timers[send_id if send_id else tid] = tid
         else:
-            self.send(event)
+            self.send(cast(EventInput[EventDataT], event))
 
     def _execute_cancel(self, action: Action) -> None:
         send_id = action.data.get("sendid")
@@ -331,6 +355,8 @@ class Interpreter:
             )
 
 
-def interpret(machine: Machine, clock: Clock | None = None) -> Interpreter:
+def interpret[ContextT, EventDataT, OutputT](
+    machine: Machine[ContextT, EventDataT, OutputT], clock: Clock | None = None
+) -> Interpreter[ContextT, EventDataT, OutputT]:
     """Create an :class:`Interpreter` for ``machine`` (XState ``interpret``)."""
     return Interpreter(machine, clock=clock)

--- a/src/xstate/machine.py
+++ b/src/xstate/machine.py
@@ -4,7 +4,7 @@ import functools
 import warnings
 from collections import deque
 from collections.abc import Callable
-from typing import Any
+from typing import Any, cast
 
 from xstate.action import INTERPRETER_TYPES, Action
 from xstate.algorithm import (
@@ -15,9 +15,10 @@ from xstate.algorithm import (
 )
 from xstate.config_parser import StateNodeConfigParser
 from xstate.context import ContextAdapter, DeepCopyContextAdapter
-from xstate.event import Event, to_event
+from xstate.event import Event, EventInput, to_event
 from xstate.exceptions import InvalidConfigError, UnregisteredImplementationError
 from xstate.handlers import HandlerAdapter, adapt_handler
+from xstate.schema import MachineConfig
 from xstate.state import State
 from xstate.state_node import StateNode
 
@@ -27,7 +28,7 @@ ActionCallable = Callable[[], Any]
 ResolvedAction = Action | ActionCallable
 
 
-class Machine:
+class Machine[ContextT = Any, EventDataT = Any, OutputT = Any]:
     id: str
     root: StateNode
     _id_map: dict[str, StateNode]
@@ -39,16 +40,17 @@ class Machine:
     actors: dict[str, Any]
     _order: int
     strict: bool
-    context_adapter: ContextAdapter
+    context: ContextT
+    context_adapter: ContextAdapter[ContextT]
 
     def __init__(
         self,
-        config: dict[str, Any],
+        config: MachineConfig[ContextT, EventDataT, OutputT] | dict[str, Any],
         actions: dict[str, Any] | None = None,
         guards: dict[str, Any] | None = None,
         delays: dict[str, Any] | None = None,
         actors: dict[str, Any] | None = None,
-        context_adapter: ContextAdapter | None = None,
+        context_adapter: ContextAdapter[ContextT] | None = None,
         strict: bool = False,
     ):
         if "id" not in config:
@@ -71,11 +73,13 @@ class Machine:
         # Named actor logic referenced by `invoke: {"src": "<name>"}`; resolved
         # by the actor layer when an invoking state is entered.
         self.actors = actors if actors is not None else {}
-        self.root = StateNodeConfigParser(self).parse(config)
+        raw_config = cast(dict[str, Any], config)
+        self.root = StateNodeConfigParser(self).parse(raw_config)
         self.states = self.root.states
-        self.config = config
-        self.context = (
-            config.get("context") if config.get("context") is not None else {}
+        self.config = raw_config
+        self.context = cast(
+            ContextT,
+            config.get("context") if config.get("context") is not None else {},
         )
 
     def _adapt_registry(self, registry: dict[str, Any], *, kind: str) -> dict[str, Any]:
@@ -94,10 +98,14 @@ class Machine:
         self._order += 1
         return order
 
-    def _to_event(self, event: Any) -> Event:
+    def _to_event(self, event: EventInput[EventDataT]) -> Event[EventDataT]:
         return to_event(event)
 
-    def transition(self, state: State, event: Any) -> State:
+    def transition(
+        self,
+        state: State[ContextT, EventDataT, OutputT],
+        event: EventInput[EventDataT],
+    ) -> State[ContextT, EventDataT, OutputT]:
         event = self._to_event(event)
         configuration = get_configuration_from_state(
             from_node=self.root, state_value=state.value, partial_configuration=set()
@@ -113,12 +121,12 @@ class Machine:
         actions, unknown = self._get_actions(_actions, context, event)
         self._warn_unknown_actions(unknown)
 
-        return State(
+        return State[ContextT, EventDataT, OutputT](
             configuration=configuration,
             context=context,
             actions=actions,
             history_value=history_value,
-            output=output,
+            output=cast(OutputT | None, output),
         )
 
     def _get_actions(
@@ -181,9 +189,12 @@ class Machine:
                 stacklevel=3,
             )
 
-    def state_from(self, state_value: Any) -> State:
+    def state_from(self, state_value: Any) -> State[ContextT, EventDataT, OutputT]:
         configuration = set(self._get_configuration(state_value=state_value))
-        return State(configuration=configuration, context={})
+        return State[ContextT, EventDataT, OutputT](
+            configuration=configuration,
+            context=cast(ContextT, {}),
+        )
 
     def _register(self, state_node: StateNode) -> None:
         state_node.machine = self
@@ -220,7 +231,7 @@ class Machine:
         return configuration
 
     @property
-    def initial_state(self) -> State:
+    def initial_state(self) -> State[ContextT, EventDataT, OutputT]:
         context = self.context_adapter.snapshot(self.context)
         history_value: dict[str, Any] = {}
         init_event = Event("xstate.init")
@@ -248,10 +259,10 @@ class Machine:
         actions, unknown = self._get_actions(_actions, context, init_event)
         self._warn_unknown_actions(unknown)
 
-        return State(
+        return State[ContextT, EventDataT, OutputT](
             configuration=configuration,
             context=context,
             actions=actions,
             history_value=history_value,
-            output=output,
+            output=cast(OutputT | None, output),
         )

--- a/src/xstate/schema.py
+++ b/src/xstate/schema.py
@@ -1,19 +1,28 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, Literal, TypedDict, Union
+from typing import Any, Literal, TypedDict
+
+from xstate.handlers import ActionHandler, GuardHandler, OutputHandler
 
 StateNodeType = Literal["atomic", "compound", "parallel", "final", "history"]
 
-HandlerSpec = Union[str, "dict[str, Any]", "Callable[..., Any]"]
-ActionSpec = Union[str, "dict[str, Any]", "Callable[..., Any]"]
-TransitionTarget = Union[str, "list[str]"]
+type LegacyHandler = Callable[..., Any]
+type HandlerSpec[ContextT = Any, EventDataT = Any, OutputT = Any] = (
+    str | dict[str, Any] | GuardHandler[ContextT, EventDataT, OutputT] | LegacyHandler
+)
+type ActionSpec[ContextT = Any, EventDataT = Any, OutputT = Any] = (
+    str | dict[str, Any] | ActionHandler[ContextT, EventDataT, OutputT] | LegacyHandler
+)
+type TransitionTarget = str | list[str]
+type StateValue = str | dict[str, StateValue]
 
 __all__ = [
     "StateNodeType",
     "HandlerSpec",
     "ActionSpec",
     "TransitionTarget",
+    "StateValue",
     "TransitionConfig",
     "InvokeConfig",
     "StateNodeConfig",
@@ -21,49 +30,100 @@ __all__ = [
 ]
 
 
-TransitionConfig = TypedDict(
-    "TransitionConfig",
-    {
-        "target": TransitionTarget,
-        "actions": ActionSpec | list[ActionSpec],
-        "guard": HandlerSpec,
-        "cond": HandlerSpec,
-        "in": Any,
-        "type": Literal["internal", "external"],
-    },
+_TransitionInConfig = TypedDict(
+    "_TransitionInConfig",
+    {"in": Any},
     total=False,
 )
 
 
-class InvokeConfig(TypedDict, total=False):
+class TransitionConfig[ContextT = Any, EventDataT = Any, OutputT = Any](
+    _TransitionInConfig, total=False
+):
+    target: TransitionTarget
+    actions: (
+        ActionSpec[ContextT, EventDataT, OutputT]
+        | list[ActionSpec[ContextT, EventDataT, OutputT]]
+    )
+    guard: HandlerSpec[ContextT, EventDataT, OutputT]
+    cond: HandlerSpec[ContextT, EventDataT, OutputT]
+    type: Literal["internal", "external"]
+
+
+class InvokeConfig[ContextT = Any, EventDataT = Any, OutputT = Any](
+    TypedDict, total=False
+):
     id: str
     src: Any
     input: Any
-    onDone: TransitionConfig | str | list[TransitionConfig | str]
-    onError: TransitionConfig | str | list[TransitionConfig | str]
-    onSnapshot: TransitionConfig | str | list[TransitionConfig | str]
+    onDone: (
+        TransitionConfig[ContextT, EventDataT, OutputT]
+        | str
+        | list[TransitionConfig[ContextT, EventDataT, OutputT] | str]
+    )
+    onError: (
+        TransitionConfig[ContextT, EventDataT, OutputT]
+        | str
+        | list[TransitionConfig[ContextT, EventDataT, OutputT] | str]
+    )
+    onSnapshot: (
+        TransitionConfig[ContextT, EventDataT, OutputT]
+        | str
+        | list[TransitionConfig[ContextT, EventDataT, OutputT] | str]
+    )
     systemId: str
 
 
-class StateNodeConfig(TypedDict, total=False):
+class StateNodeConfig[ContextT = Any, EventDataT = Any, OutputT = Any](
+    TypedDict, total=False
+):
     id: str
     type: StateNodeType
     tags: str | list[str]
     meta: Any
     initial: str
-    states: dict[str, StateNodeConfig]
-    on: dict[str | None, TransitionConfig | str | list[TransitionConfig | str]]
-    always: TransitionConfig | str | list[TransitionConfig | str]
-    entry: ActionSpec | list[ActionSpec]
-    exit: ActionSpec | list[ActionSpec]
-    after: dict[Any, TransitionConfig | str | list[TransitionConfig | str]]
-    invoke: InvokeConfig | list[InvokeConfig]
-    onDone: TransitionConfig | str | list[TransitionConfig | str]
+    states: dict[str, StateNodeConfig[ContextT, EventDataT, OutputT]]
+    on: dict[
+        str | None,
+        TransitionConfig[ContextT, EventDataT, OutputT]
+        | str
+        | list[TransitionConfig[ContextT, EventDataT, OutputT] | str],
+    ]
+    always: (
+        TransitionConfig[ContextT, EventDataT, OutputT]
+        | str
+        | list[TransitionConfig[ContextT, EventDataT, OutputT] | str]
+    )
+    entry: (
+        ActionSpec[ContextT, EventDataT, OutputT]
+        | list[ActionSpec[ContextT, EventDataT, OutputT]]
+    )
+    exit: (
+        ActionSpec[ContextT, EventDataT, OutputT]
+        | list[ActionSpec[ContextT, EventDataT, OutputT]]
+    )
+    after: dict[
+        Any,
+        TransitionConfig[ContextT, EventDataT, OutputT]
+        | str
+        | list[TransitionConfig[ContextT, EventDataT, OutputT] | str],
+    ]
+    invoke: (
+        InvokeConfig[ContextT, EventDataT, OutputT]
+        | list[InvokeConfig[ContextT, EventDataT, OutputT]]
+    )
+    onDone: (
+        TransitionConfig[ContextT, EventDataT, OutputT]
+        | str
+        | list[TransitionConfig[ContextT, EventDataT, OutputT] | str]
+    )
     history: Literal["shallow", "deep"]
     target: TransitionTarget
-    output: Any
+    output: OutputT | OutputHandler[ContextT, EventDataT, OutputT] | LegacyHandler
     data: Any
 
 
-class MachineConfig(StateNodeConfig, total=False):
-    context: Any
+class MachineConfig[ContextT = Any, EventDataT = Any, OutputT = Any](
+    StateNodeConfig[ContextT, EventDataT, OutputT], total=False
+):
+    context: ContextT

--- a/src/xstate/setup_api.py
+++ b/src/xstate/setup_api.py
@@ -5,29 +5,30 @@ from typing import Any
 
 from xstate.context import ContextAdapter
 from xstate.machine import Machine
+from xstate.schema import MachineConfig
 
 __all__ = ["MachineSetup", "setup"]
 
 
 @dataclass(frozen=True, slots=True)
-class MachineSetup:
+class MachineSetup[ContextT = Any, EventDataT = Any, OutputT = Any]:
     actions: dict[str, Any] = field(default_factory=dict)
     guards: dict[str, Any] = field(default_factory=dict)
     delays: dict[str, Any] = field(default_factory=dict)
     actors: dict[str, Any] = field(default_factory=dict)
-    context_adapter: ContextAdapter | None = None
+    context_adapter: ContextAdapter[ContextT] | None = None
 
     def create_machine(
         self,
-        config: dict[str, Any],
+        config: MachineConfig[ContextT, EventDataT, OutputT] | dict[str, Any],
         *,
         actions: dict[str, Any] | None = None,
         guards: dict[str, Any] | None = None,
         delays: dict[str, Any] | None = None,
         actors: dict[str, Any] | None = None,
-        context_adapter: ContextAdapter | None = None,
-    ) -> Machine:
-        return Machine(
+        context_adapter: ContextAdapter[ContextT] | None = None,
+    ) -> Machine[ContextT, EventDataT, OutputT]:
+        return Machine[ContextT, EventDataT, OutputT](
             config,
             actions={**self.actions, **(actions or {})},
             guards={**self.guards, **(guards or {})},
@@ -38,15 +39,15 @@ class MachineSetup:
         )
 
 
-def setup(
+def setup[ContextT = Any, EventDataT = Any, OutputT = Any](
     *,
     actions: dict[str, Any] | None = None,
     guards: dict[str, Any] | None = None,
     delays: dict[str, Any] | None = None,
     actors: dict[str, Any] | None = None,
-    context_adapter: ContextAdapter | None = None,
-) -> MachineSetup:
-    return MachineSetup(
+    context_adapter: ContextAdapter[ContextT] | None = None,
+) -> MachineSetup[ContextT, EventDataT, OutputT]:
+    return MachineSetup[ContextT, EventDataT, OutputT](
         actions=actions or {},
         guards=guards or {},
         delays=delays or {},

--- a/src/xstate/snapshot.py
+++ b/src/xstate/snapshot.py
@@ -29,14 +29,16 @@ Usage::
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from xstate.machine import Machine
     from xstate.state import State
 
 
-def serialize_snapshot(snapshot: State) -> dict[str, Any]:
+def serialize_snapshot[ContextT, EventDataT, OutputT](
+    snapshot: State[ContextT, EventDataT, OutputT],
+) -> dict[str, Any]:
     """Serialize *snapshot* to a JSON-compatible dict."""
     history_value: dict[str, list[str]] = {}
     for hist_node_id, state_nodes in (snapshot.history_value or {}).items():
@@ -53,7 +55,9 @@ def serialize_snapshot(snapshot: State) -> dict[str, Any]:
     }
 
 
-def deserialize_snapshot(machine: Machine, data: dict[str, Any]) -> State:
+def deserialize_snapshot[ContextT, EventDataT, OutputT](
+    machine: Machine[ContextT, EventDataT, OutputT], data: dict[str, Any]
+) -> State[ContextT, EventDataT, OutputT]:
     """Reconstruct a :class:`~xstate.state.State` from a serialized dict.
 
     Pass the returned state to ``create_actor(machine, snapshot=...)`` or
@@ -69,9 +73,9 @@ def deserialize_snapshot(machine: Machine, data: dict[str, Any]) -> State:
         if nodes:
             history_value[hist_node_id] = nodes
 
-    state = State(
+    state = State[ContextT, EventDataT, OutputT](
         configuration=configuration,
-        context=dict(data.get("context") or {}),
+        context=cast(ContextT, dict(data.get("context") or {})),
         history_value=history_value,
     )
     if data.get("status") == "error":

--- a/src/xstate/state.py
+++ b/src/xstate/state.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from xstate.action import Action
 from xstate.algorithm import get_state_value, is_in_final_state
-from xstate.event import to_event
+from xstate.event import Event, EventInput, RuntimeEventPayload, to_event
 from xstate.exceptions import InvalidConfigError
 
 if TYPE_CHECKING:
@@ -17,28 +17,27 @@ __all__ = ["State", "MachineSnapshot"]
 _OUTPUT_UNSET = object()
 
 
-class State:
+class State[ContextT = Any, EventDataT = Any, OutputT = Any]:
     configuration: frozenset[StateNode]
     value: Any
-    context: Any
+    context: ContextT
     actions: tuple[Callable[..., Any] | Action, ...]
     history_value: Mapping[str, frozenset[StateNode]]
     _tags: frozenset[str]
     _meta: Mapping[str, Any]
     status: Literal["active", "done", "error"]
-    output: Any | None
+    output: OutputT | None
     error: Any | None
-    event: (
-        Any | None
-    )  # stamped by Interpreter; None when produced by machine.transition
+    # Stamped by Interpreter; None when produced by machine.transition.
+    event: Event[RuntimeEventPayload[EventDataT, OutputT]] | None
 
     def __init__(
         self,
         configuration: set[StateNode] | frozenset[StateNode],
-        context: Any,
+        context: ContextT,
         actions: Iterable[Callable[..., Any] | Action] | None = None,
         history_value: Mapping[str, Iterable[StateNode]] | None = None,
-        output: Any = _OUTPUT_UNSET,
+        output: OutputT | object = _OUTPUT_UNSET,
     ):
         if not configuration:
             raise InvalidConfigError("State requires a non-empty configuration.")
@@ -86,7 +85,7 @@ class State:
                 None,
             )
             if output is not _OUTPUT_UNSET:
-                self.output = output
+                self.output = cast(OutputT | None, output)
             elif final_child is None or callable(final_child.donedata):
                 # Callable output is resolved by the algorithm at entry time.
                 # State construction outside a macrostep must never expose the
@@ -120,7 +119,7 @@ class State:
     # XState v5 spells this ``hasTag``; expose both for JS-parity ergonomics.
     hasTag = has_tag
 
-    def can(self, event: Any) -> bool:
+    def can(self, event: EventInput[EventDataT]) -> bool:
         """Return True if any enabled transition exists for *event* right now.
 
         Respects guards and the current context, so the result reflects whether

--- a/tests/test_typing_contract.py
+++ b/tests/test_typing_contract.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+TYPING = ROOT / "tests" / "typing"
+
+
+def run_mypy(fixture: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "mypy",
+            "--strict",
+            "--show-error-codes",
+            str(TYPING / fixture),
+        ],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize("fixture", ["positive.py", "compatibility.py"])
+def test_valid_typing_contracts(fixture: str) -> None:
+    result = run_mypy(fixture)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_invalid_typing_contracts_are_rejected() -> None:
+    result = run_mypy("negative.py")
+    output = result.stdout + result.stderr
+
+    assert result.returncode != 0
+    for expected in (
+        'Argument 2 to "transition" of "Machine"',
+        'Argument 1 to "send" of "Interpreter"',
+        'expression has type "Context", variable has type "str"',
+        'expression has type "Output | None", variable has type "str"',
+        'variable has type "GuardHandler[Context, IncrementEvent, Output]"',
+        'variable has type "OutputHandler[Context, IncrementEvent, Output]"',
+        'Argument 2 to "Event"',
+    ):
+        assert expected in output

--- a/tests/typing/compatibility.py
+++ b/tests/typing/compatibility.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Any, assert_type
+
+from xstate import Event, Machine, State, interpret
+
+
+def legacy_action(context: dict[str, Any], event: Event) -> None:
+    context["seen"] = event.name
+
+
+def legacy_guard(context: dict[str, Any], event: Event) -> bool:
+    return bool(context) and event.name == "GO"
+
+
+machine: Machine = Machine(
+    {
+        "id": "legacy",
+        "context": {"seen": None},
+        "initial": "idle",
+        "states": {
+            "idle": {
+                "on": {
+                    "GO": {
+                        "target": "done",
+                        "guard": "allowed",
+                        "actions": "record",
+                    }
+                }
+            },
+            "done": {},
+        },
+    },
+    actions={"record": legacy_action},
+    guards={"allowed": legacy_guard},
+)
+assert_type(machine, Machine[Any, Any, Any])
+assert_type(machine.transition(machine.initial_state, "GO"), State[Any, Any, Any])
+assert_type(interpret(machine).send({"type": "GO"}), State[Any, Any, Any])

--- a/tests/typing/negative.py
+++ b/tests/typing/negative.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Literal, TypedDict
+
+from xstate import (
+    Event,
+    GuardHandler,
+    HandlerArgs,
+    Machine,
+    OutputHandler,
+    interpret,
+)
+
+
+class Context(TypedDict):
+    count: int
+
+
+class IncrementEvent(TypedDict):
+    type: Literal["INCREMENT"]
+    by: int
+
+
+class Output(TypedDict):
+    total: int
+
+
+machine: Machine[Context, IncrementEvent, Output] = Machine(
+    {
+        "id": "counter",
+        "context": {"count": 0},
+        "initial": "active",
+        "states": {"active": {}},
+    }
+)
+state = machine.initial_state
+
+machine.transition(state, {"type": "INCREMENT"})  # invalid-event-payload
+interpret(machine).send({"type": "OTHER", "by": 1})  # invalid-send
+
+bad_context: str = state.context  # invalid-snapshot-context
+bad_output: str = state.output  # invalid-snapshot-output
+
+
+def wrong_guard(_args: HandlerArgs[Context, IncrementEvent, Output]) -> str:
+    return "yes"
+
+
+def wrong_output(_args: HandlerArgs[Context, IncrementEvent, Output]) -> str:
+    return "wrong"
+
+
+guard: GuardHandler[Context, IncrementEvent, Output] = wrong_guard  # invalid-guard
+output: OutputHandler[Context, IncrementEvent, Output] = (  # invalid-output-handler
+    wrong_output
+)
+event = Event[IncrementEvent]("INCREMENT", {"type": "INCREMENT"})  # invalid-event

--- a/tests/typing/positive.py
+++ b/tests/typing/positive.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterable, Callable
+from typing import Any, Literal, TypedDict, assert_type
+
+from xstate import (
+    ActionHandler,
+    Actor,
+    ActorSnapshot,
+    AssignmentHandler,
+    AsyncInterpreter,
+    ContextAdapter,
+    DeepCopyContextAdapter,
+    DelayHandler,
+    Event,
+    EventInput,
+    GuardHandler,
+    HandlerArgs,
+    Interpreter,
+    Machine,
+    MachineConfig,
+    MachineSetup,
+    MachineSnapshot,
+    OutputHandler,
+    State,
+    create_actor,
+    from_callback,
+    from_observable,
+    from_promise,
+    interpret,
+    interpret_async,
+    setup,
+    to_promise,
+)
+
+
+class Context(TypedDict):
+    count: int
+
+
+class IncrementEvent(TypedDict):
+    type: Literal["INCREMENT"]
+    by: int
+
+
+class FinishEvent(TypedDict):
+    type: Literal["FINISH"]
+
+
+type AppEvent = IncrementEvent | FinishEvent
+
+
+class Output(TypedDict):
+    total: int
+
+
+def can_increment(args: HandlerArgs[Context, AppEvent, Output]) -> bool:
+    return args.context["count"] < 10
+
+
+def final_output(args: HandlerArgs[Context, AppEvent, Output]) -> Output:
+    return {"total": args.context["count"]}
+
+
+def record(args: HandlerArgs[Context, AppEvent, Output]) -> None:
+    _ = args
+    return None
+
+
+def update(args: HandlerArgs[Context, AppEvent, Output]) -> dict[str, object]:
+    _ = args
+    return {"count": 1}
+
+
+def short_delay(args: HandlerArgs[Context, AppEvent, Output]) -> float:
+    _ = args
+    return 10.0
+
+
+guard: GuardHandler[Context, AppEvent, Output] = can_increment
+output_handler: OutputHandler[Context, AppEvent, Output] = final_output
+action: ActionHandler[Context, AppEvent, Output] = record
+assignment: AssignmentHandler[Context, AppEvent, Output] = update
+delay: DelayHandler[Context, AppEvent, Output] = short_delay
+context_adapter: ContextAdapter[Context] = DeepCopyContextAdapter()
+assert_type(context_adapter.snapshot({"count": 0}), Context)
+
+config: MachineConfig[Context, AppEvent, Output] = {
+    "id": "counter",
+    "context": {"count": 0},
+    "initial": "active",
+    "states": {
+        "active": {
+            "on": {
+                "INCREMENT": {"target": "active", "guard": guard},
+                "FINISH": "done",
+            }
+        },
+        "done": {"type": "final", "output": output_handler},
+    },
+}
+
+machine: Machine[Context, AppEvent, Output] = Machine(config)
+state = machine.initial_state
+assert_type(state, State[Context, AppEvent, Output])
+assert_type(state, MachineSnapshot[Context, AppEvent, Output])
+state = machine.transition(state, {"type": "INCREMENT", "by": 2})
+assert_type(state.context, Context)
+assert_type(state.output, Output | None)
+assert_type(state.event, Event[AppEvent | Output | BaseException] | None)
+
+service = interpret(machine)
+assert_type(service, Interpreter[Context, AppEvent, Output])
+assert_type(
+    service.send({"type": "INCREMENT", "by": 1}),
+    State[Context, AppEvent, Output],
+)
+
+
+def observe(snapshot: State[Context, AppEvent, Output]) -> None:
+    assert_type(snapshot.context, Context)
+
+
+service.subscribe(observe)
+
+async_service = interpret_async(machine)
+assert_type(async_service, AsyncInterpreter[Context, AppEvent, Output])
+
+
+async def use_async() -> None:
+    assert_type(
+        await async_service.send({"type": "FINISH"}),
+        State[Context, AppEvent, Output],
+    )
+
+
+machine_actor = create_actor(machine)
+assert_type(
+    machine_actor,
+    Actor[EventInput[AppEvent], State[Context, AppEvent, Output], Output],
+)
+assert_type(machine_actor.get_snapshot(), State[Context, AppEvent, Output])
+machine_actor.subscribe(observe)
+assert_type(machine_actor.system.get("child"), Actor[Any, Any, Any] | None)
+
+
+def promise(input: int) -> Output:
+    return {"total": input}
+
+
+promise_actor = create_actor(from_promise(promise), input=2)
+assert_type(promise_actor, Actor[object, ActorSnapshot[Output], Output])
+assert_type(to_promise(promise_actor), asyncio.Future[Output])
+spawned_promise = machine_actor.spawn(from_promise(promise), input=3)
+assert_type(spawned_promise, Actor[object, ActorSnapshot[Output], Output])
+
+
+async def values(input: int) -> AsyncIterable[int]:
+    yield input
+
+
+observable_actor = create_actor(from_observable(values), input=1)
+assert_type(observable_actor, Actor[object, ActorSnapshot[int], int])
+
+
+class CallbackEvent(TypedDict):
+    type: Literal["PING"]
+
+
+def callback(
+    *,
+    send_back: Callable[[object], None],
+    receive: Callable[[Callable[[CallbackEvent], None]], None],
+    input: int,
+) -> None:
+    receive(lambda event: send_back((input, event)))
+
+
+callback_actor = create_actor(from_callback(callback), input=1)
+assert_type(
+    callback_actor,
+    Actor[CallbackEvent, ActorSnapshot[None], None],
+)
+callback_actor.send({"type": "PING"})
+
+machine_setup: MachineSetup[Context, AppEvent, Output] = setup(guards={"ok": guard})
+assert_type(machine_setup.create_machine(config), Machine[Context, AppEvent, Output])


### PR DESCRIPTION
## Summary

Adds backward-compatible, defaulted generics across the public machine, snapshot, handler, interpreter, setup, and actor APIs.

This is layer 2 of 2. PR #39 merged first as `50d200f2f296c68c6b639a1f08112219a12bf960`. This branch is rebased onto that exact `master` result, and the rebased tree matches the previously reviewed tree.

## Type model

- `Event[PayloadT = Any]`
- `HandlerArgs[ContextT = Any, EventDataT = Any, OutputT = Any]`
- `State[ContextT = Any, EventDataT = Any, OutputT = Any]`
- `Machine[ContextT = Any, EventDataT = Any, OutputT = Any]`
- `MachineSetup[ContextT = Any, EventDataT = Any, OutputT = Any]`
- `Interpreter[ContextT = Any, EventDataT = Any, OutputT = Any]`
- `AsyncInterpreter[ContextT = Any, EventDataT = Any, OutputT = Any]`
- `Actor[SendEventT = Any, SnapshotT = Any, OutputT = Any]`

`EventDataT` represents the complete external event mapping, including its `type` discriminator, in line with [XState event objects](https://stately.ai/docs/transitions). `HandlerArgs.event` can also carry machine or actor output and runtime exceptions for done and error events.

## Scope

- Carry context, external event, and output types through pure transitions and `MachineSnapshot`.
- Type sync and async interpreter sends, state fields, and subscription callbacks.
- Make `ContextAdapter` context-preserving.
- Add canonical protocols for action, guard, delay, assignment, and output handlers.
- Make the config `TypedDict` hierarchy generic, including recursive state-node and state-value types.
- Export config, handler, event-input, runtime-event-payload, and state-value types from `xstate`.
- Add typed machine, promise, callback, and observable actor overloads for `create_actor` and `spawn`.
- Preserve exact machine-backed actor snapshots and `to_promise` output.
- Keep heterogeneous `ActorSystem.get()` safely widened.
- Document typed `Machine`, `setup`, sync and async interpreters, subscriptions, actors, and `to_promise` with `TypedDict`, `Literal`, and `assert_type`.

## Compatibility

- Every public generic has an `Any` default.
- `Machine(config, ...)`, raw JSON dictionaries, string events, and event dictionaries remain valid.
- Legacy zero-, one-, two-, and keyword-argument handlers remain runtime-compatible.
- No `types=` runtime object, validation framework, generated code, runtime dependency, version bump, or release action is introduced.
- The existing `py.typed` marker remains included and the isolated wheel smoke verifies it.

## Static contract coverage

The primary test suite runs three strict-mypy fixtures:

- positive: context, full event objects, output, `MachineSnapshot`, canonical handlers, context adapters, setup, sync and async sends, subscriptions, machine and non-machine actors, spawn, heterogeneous lookup, and `to_promise`;
- negative: invalid event payload, invalid interpreter send, invalid snapshot assignments, invalid guard and output returns, and invalid `Event` payload;
- compatibility: unparameterized `Machine`, raw dictionaries, string and dictionary sends, and legacy `(context, event)` handlers.

## Validation

Local validation on Python 3.14.4 at exact rebased head `9fb3b633e805a2ae7d427b2850a1f6f0d8629ea9`:

- `poetry run python -m pytest tests/ --ignore=tests/test_scxml.py` - 435 passed
- `poetry run python -m pytest tests/test_scxml.py` - 57 passed
- `poetry run mypy src/xstate/` - passed
- `poetry run mypy --strict src/xstate/algorithm.py` - passed
- strict positive, negative, and compatibility consumer fixtures - passed through the primary suite
- `poetry run ruff check src/ tests/ scripts/ docs/examples/` - passed
- `poetry run ruff format --check src/ tests/ scripts/ docs/examples/` - passed
- `poetry check --lock` - passed
- `poetry build` - passed
- `poetry run python scripts/validate_distribution.py` - installed-wheel smoke and `py.typed` check passed

Hosted validation at exact head `9fb3b633e805a2ae7d427b2850a1f6f0d8629ea9`:

- `test (3.13, ubuntu-latest)` - passed
- `test (3.14, ubuntu-latest)` - passed
- `SCXML smoke` - passed
- `code-quality (3.14, ubuntu-latest)` - passed

## Risk and rollback

The primary risk is an annotation becoming narrower than an accepted legacy runtime form. Defaulted type parameters, explicit compatibility fallbacks, and the legacy strict-mypy fixture limit that risk. Dynamic actor backends are widened internally and cast only where overload-selected public types establish the relationship.

Rollback is the single commit unique to this branch after PR #39. There are no storage, dependency, deployment, or migration effects.

## Review focus

1. Confirm `EventDataT` is the whole event mapping and every send boundary consumes `EventInput[EventDataT]`.
2. Confirm `State`, interpreter subscriptions, machine actors, and `to_promise` preserve context, snapshot, and output types.
3. Confirm actor overloads stay precise for known logic while system lookup remains heterogeneous.
4. Confirm generic `TypedDict` configs and handler protocols improve opt-in checking without rejecting raw JSON or legacy callables.
5. Review the negative fixture for meaningful defect sensitivity rather than error-count-only assertions.

## Merge order

1. PR #39 merged first.
2. This branch was rebased onto the resulting `master` and retargeted to `master`.
3. Merge this PR only after all checks pass at the exact rebased head.

Merge was authorized after exact-head verification. No version bump, release publication, or new conformance claim is included.

