### PR TITLE
Add bounded microstep traces and inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,13 @@ await service.stop()
 The pure transition and guard layer remains synchronous; only action execution,
 timers, and actor settlement are async-aware.
 
+Macrosteps can be bounded with `Machine(..., max_iterations=N)` or portable
+`options.maxIterations` configuration. `get_microsteps(...)` and
+`get_initial_microsteps(...)` return immutable intermediate trace records, and
+sync, async, and machine-backed actor runtimes accept an optional `inspect`
+callback for settled `MacrostepTrace` values. See
+[Runtime Choices](./docs/concepts/runtimes.md#bounded-execution-and-microstep-traces).
+
 ## Actors And `invoke`
 
 XState v5 treats running logic as actors. This library supports machine actors,

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -57,6 +57,8 @@ structure with a JavaScript/XState frontend or a Stately-authored design.
 - Synchronous `Interpreter` with a run-to-completion queue and thread-safe timer
   callback serialization.
 - `AsyncInterpreter` for asyncio runtimes and awaitable action side effects.
+- Bounded macrostep execution, typed microstep traces, and local sync/async
+  inspection callbacks.
 - Actor model with `create_actor`, `ActorSystem`, `spawn`, `from_promise`,
   `from_callback`, `from_observable`, `to_promise`, `send_parent`, `send_to`,
   and `invoke` reconciliation.
@@ -75,7 +77,7 @@ structure with a JavaScript/XState frontend or a Stately-authored design.
 | SCXML conformance | Configured SCXML suite is `57 passed`, `0 failed`; broader W3C coverage is not yet claimed. |
 | Full ECMAScript cond support | Intentionally not implemented; unsupported SCXML expressions raise `InvalidConfigError`. |
 | Graph/test utilities | Mermaid export exists; no graph traversal/test-path helpers yet. |
-| Inspector protocol | No `@statelyai/inspect` compatibility yet. |
+| Inspector protocol | Local `MacrostepTrace` callbacks exist; no `@statelyai/inspect` wire-protocol compatibility yet. |
 
 ## Strategic Position
 

--- a/docs/concepts/runtimes.md
+++ b/docs/concepts/runtimes.md
@@ -67,6 +67,56 @@ guard layer remains synchronous.
 
 See [async workflow](../examples/async_workflow.py) for a complete program.
 
+## Bounded Execution And Microstep Traces
+
+Use `max_iterations` to fail before a macrostep executes more enabled
+microsteps than the application permits. The same limit can be stored in
+portable machine JSON as `options.maxIterations`; a non-`None` constructor
+keyword takes precedence.
+
+```python
+from xstate import Machine
+
+machine = Machine(config, max_iterations=100)
+```
+
+The default is unlimited. Boolean, negative, and non-integer limits raise
+`InvalidConfigError`. If a limit is exceeded, `InfiniteLoopError` is raised
+before the next microstep runs, and a running interpreter keeps its last
+committed snapshot.
+
+Pure trace helpers expose settled intermediate snapshots without exposing the
+internal transition queue:
+
+```python
+from xstate import get_initial_microsteps, get_microsteps
+
+initial_steps = get_initial_microsteps(machine)
+steps = get_microsteps(machine, machine.initial_state, {"type": "SUBMIT"})
+
+for step in steps:
+    print(step.event.name, step.snapshot.value, step.transitions)
+```
+
+Each intermediate snapshot contains only that microstep's actions. The normal
+`Machine.transition` result still contains every macrostep action in execution
+order. Ignored events appear with an empty `transitions` tuple.
+
+Sync and async interpreters accept an `inspect` callback. It receives one
+`MacrostepTrace` for initialization and one for each external event after the
+settled snapshot is installed but before actions and subscribers run:
+
+```python
+from xstate import interpret
+
+service = interpret(machine, inspect=lambda trace: print(trace.snapshot.value))
+service.start()
+```
+
+Inspector failures emit `RuntimeWarning` and do not interrupt machine behavior.
+Machine-backed `create_actor` accepts the same callback. This local callback is
+not the remote `@statelyai/inspect` protocol.
+
 ## Actors
 
 `create_actor(machine)` wraps a machine with an XState v5-style actor API. It is

--- a/src/xstate/__init__.py
+++ b/src/xstate/__init__.py
@@ -31,6 +31,7 @@ from xstate.context import (  # noqa
 )
 from xstate.event import Event, EventInput, RuntimeEventPayload, to_event  # noqa
 from xstate.exceptions import (  # noqa
+    InfiniteLoopError,
     InvalidConfigError,
     UnregisteredImplementationError,
     XStateError,
@@ -45,7 +46,7 @@ from xstate.handlers import (  # noqa
     OutputHandler,
 )
 from xstate.interpreter import Interpreter, interpret  # noqa
-from xstate.machine import Machine  # noqa
+from xstate.machine import Machine, get_initial_microsteps, get_microsteps  # noqa
 from xstate.mermaid import to_mermaid  # noqa
 from xstate.scheduler import Clock, SimulatedClock, ThreadClock  # noqa
 from xstate.schema import (  # noqa
@@ -53,6 +54,7 @@ from xstate.schema import (  # noqa
     HandlerSpec,
     InvokeConfig,
     MachineConfig,
+    MachineOptionsConfig,
     StateNodeConfig,
     StateValue,
     TransitionConfig,
@@ -61,6 +63,7 @@ from xstate.schema import (  # noqa
 from xstate.setup_api import MachineSetup, setup  # noqa
 from xstate.snapshot import deserialize_snapshot, serialize_snapshot  # noqa
 from xstate.state import MachineSnapshot, State  # noqa
+from xstate.trace import MacrostepTrace, MicrostepTrace, TransitionTrace  # noqa
 
 __all__ = [
     # Core
@@ -75,6 +78,11 @@ __all__ = [
     "DelayHandler",
     "GuardHandler",
     "OutputHandler",
+    "TransitionTrace",
+    "MicrostepTrace",
+    "MacrostepTrace",
+    "get_microsteps",
+    "get_initial_microsteps",
     # Interpreter
     "interpret",
     "Interpreter",
@@ -123,9 +131,11 @@ __all__ = [
     "InvokeConfig",
     "StateNodeConfig",
     "MachineConfig",
+    "MachineOptionsConfig",
     # Exceptions
     "XStateError",
     "InvalidConfigError",
+    "InfiniteLoopError",
     "UnregisteredImplementationError",
     # Clocks
     "Clock",

--- a/src/xstate/actor.py
+++ b/src/xstate/actor.py
@@ -49,6 +49,7 @@ from xstate.interpreter import NOT_STARTED, RUNNING, STOPPED, Interpreter, Subsc
 from xstate.machine import Machine
 from xstate.scheduler import Clock
 from xstate.state import State
+from xstate.trace import MacrostepTrace
 
 __all__ = [
     "PromiseLogic",
@@ -337,8 +338,14 @@ class _MachineBackend:
 
     is_machine = True
 
-    def __init__(self, actor: Actor, machine: Machine, clock: Clock | None):
-        self.interpreter = Interpreter(machine, clock=clock)
+    def __init__(
+        self,
+        actor: Actor,
+        machine: Machine,
+        clock: Clock | None,
+        inspect: Callable[[MacrostepTrace], None] | None,
+    ):
+        self.interpreter = Interpreter(machine, clock=clock, inspect=inspect)
         # Back-reference so interpreter-owned actions (send_parent / send_to)
         # can reach the actor and its system.
         self.interpreter._actor = actor
@@ -527,10 +534,16 @@ type ActorSnapshotValue[ContextT = Any, EventDataT = Any, OutputT = Any] = (
 
 
 def _build_backend(
-    actor: Actor, logic: ActorLogic, clock: Clock | None, input: Any
+    actor: Actor,
+    logic: ActorLogic,
+    clock: Clock | None,
+    input: Any,
+    inspect: Callable[[MacrostepTrace], None] | None,
 ) -> ActorBackend:
     if isinstance(logic, Machine):
-        return _MachineBackend(actor, logic, clock)
+        return _MachineBackend(actor, logic, clock, inspect)
+    if inspect is not None:
+        raise TypeError("inspect is only supported for machine actor logic.")
     if isinstance(logic, PromiseLogic):
         return _PromiseBackend(actor, logic, input)
     if isinstance(logic, CallbackLogic):
@@ -621,6 +634,7 @@ class Actor[SendEventT = Any, SnapshotT = Any, OutputT = Any]:
         parent: Actor[Any, Any, Any] | None = None,
         input: Any = None,
         snapshot: Any = None,
+        inspect: Callable[[MacrostepTrace], None] | None = None,
     ) -> None:
         self._system = system if system is not None else ActorSystem()
         with self._system._lock:
@@ -634,7 +648,9 @@ class Actor[SendEventT = Any, SnapshotT = Any, OutputT = Any]:
             self._invoked: dict[str, Actor[Any, Any, Any]] = {}
             self._invocation_sub: SubscriptionProtocol | None = None
             self._syncing = False
-            self._backend: ActorBackend = _build_backend(self, logic, clock, input)
+            self._backend: ActorBackend = _build_backend(
+                self, logic, clock, input, inspect
+            )
             self._system._register_unlocked(self)
 
     # -- identity -----------------------------------------------------------
@@ -934,6 +950,9 @@ def create_actor[ContextT, EventDataT, OutputT](
     system: ActorSystem | None = None,
     input: Any = None,
     snapshot: State[ContextT, EventDataT, OutputT] | None = None,
+    inspect: (
+        Callable[[MacrostepTrace[ContextT, EventDataT, OutputT]], None] | None
+    ) = None,
 ) -> Actor[EventInput[EventDataT], State[ContextT, EventDataT, OutputT], OutputT]: ...
 
 
@@ -993,6 +1012,7 @@ def create_actor(
     system: ActorSystem | None = None,
     input: Any = None,
     snapshot: Any = None,
+    inspect: Callable[[MacrostepTrace], None] | None = None,
 ) -> Actor[Any, Any, Any]:
     """Create an :class:`Actor` from actor *logic* (XState v5 ``createActor``).
 
@@ -1003,7 +1023,13 @@ def create_actor(
     :func:`~xstate.snapshot.deserialize_snapshot`) to resume from a checkpoint.
     """
     return Actor(
-        logic, id=id, clock=clock, system=system, input=input, snapshot=snapshot
+        logic,
+        id=id,
+        clock=clock,
+        system=system,
+        input=input,
+        snapshot=snapshot,
+        inspect=inspect,
     )
 
 

--- a/src/xstate/algorithm.py
+++ b/src/xstate/algorithm.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections import deque
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from collections.abc import Set as AbstractSet
 from typing import Any, NamedTuple, cast
 
@@ -14,7 +14,7 @@ from xstate.action import (
     build_action,
 )
 from xstate.event import Event
-from xstate.exceptions import UnregisteredImplementationError
+from xstate.exceptions import InfiniteLoopError, UnregisteredImplementationError
 from xstate.handlers import GuardReference, invoke_handler
 from xstate.state_node import StateNode
 from xstate.transition import Transition
@@ -37,11 +37,22 @@ class MicrostepResult[ContextT, OutputT](NamedTuple):
     output: OutputT | None
 
 
+class AlgorithmMicrostep[ContextT, OutputT](NamedTuple):
+    event: Event[Any]
+    transitions: tuple[Transition, ...]
+    configuration: frozenset[StateNode]
+    actions: tuple[Action, ...]
+    context: ContextT
+    history_value: dict[str, frozenset[StateNode]]
+    output: OutputT | None
+
+
 class MacrostepResult[ContextT, OutputT](NamedTuple):
     configuration: Configuration
     actions: list[Action]
     context: ContextT
     output: OutputT | None
+    microsteps: tuple[AlgorithmMicrostep[ContextT, OutputT], ...]
 
 
 class ExitResult[ContextT](NamedTuple):
@@ -769,20 +780,120 @@ def remove_conflicting_transitions(
     return sorted(filtered_transitions, key=lambda transition: transition.order)
 
 
+def _capture_algorithm_microstep[ContextT, OutputT](
+    *,
+    event: Event[Any],
+    transitions: TransitionSequence,
+    configuration: ReadOnlyConfiguration,
+    actions: Iterable[Action],
+    context: ContextT,
+    history_value: ReadOnlyHistoryValue,
+    output: OutputT | None,
+    context_snapshot: Callable[[ContextT], ContextT],
+) -> AlgorithmMicrostep[ContextT, OutputT]:
+    return AlgorithmMicrostep(
+        event=event,
+        transitions=tuple(transitions),
+        configuration=frozenset(configuration),
+        actions=tuple(actions),
+        context=context_snapshot(context),
+        history_value={
+            state_id: frozenset(states) for state_id, states in history_value.items()
+        },
+        output=output,
+    )
+
+
+def _consume_iteration(
+    *,
+    iterations: int,
+    max_iterations: int | None,
+    machine_id: str,
+    event: Event[Any],
+) -> int:
+    if max_iterations is not None and iterations >= max_iterations:
+        raise InfiniteLoopError(machine_id, max_iterations, event.name)
+    return iterations + 1
+
+
+def initial_event_loop[ContextT, OutputT](
+    initial_transition: Transition,
+    context: ContextT,
+    *,
+    history_value: HistoryValue,
+    context_snapshot: Callable[[ContextT], ContextT],
+    machine_id: str,
+    max_iterations: int | None,
+) -> MacrostepResult[ContextT, OutputT]:
+    init_event: Event[Any] = Event("xstate.init")
+    iterations = _consume_iteration(
+        iterations=0,
+        max_iterations=max_iterations,
+        machine_id=machine_id,
+        event=init_event,
+    )
+    configuration, actions, internal_queue, context, output = enter_states(
+        [initial_transition],
+        configuration=set(),
+        history_value=history_value,
+        actions=[],
+        internal_queue=deque(),
+        context=context,
+        event=init_event,
+        output=None,
+    )
+    microsteps: list[AlgorithmMicrostep[ContextT, OutputT]] = [
+        _capture_algorithm_microstep(
+            event=init_event,
+            transitions=[initial_transition],
+            configuration=configuration,
+            actions=actions,
+            context=context,
+            history_value=history_value,
+            output=output,
+            context_snapshot=context_snapshot,
+        )
+    ]
+    return main_event_loop2(
+        configuration=configuration,
+        actions=actions,
+        internal_queue=internal_queue,
+        context=context,
+        event=init_event,
+        history_value=history_value,
+        output=output,
+        context_snapshot=context_snapshot,
+        machine_id=machine_id,
+        max_iterations=max_iterations,
+        iterations=iterations,
+        microsteps=microsteps,
+    )
+
+
 def main_event_loop[ContextT](
     configuration: Configuration,
     event: Event,
     context: ContextT,
-    history_value: HistoryValue | None = None,
+    *,
+    history_value: HistoryValue,
+    context_snapshot: Callable[[ContextT], ContextT],
+    machine_id: str,
+    max_iterations: int | None,
 ) -> MacrostepResult[ContextT, Any]:
-    if history_value is None:
-        history_value = {}
     enabled_transitions = select_transitions(
         event=event,
         configuration=configuration,
         context=context,
         history_value=history_value,
     )
+    iterations = 0
+    if enabled_transitions:
+        iterations = _consume_iteration(
+            iterations=iterations,
+            max_iterations=max_iterations,
+            machine_id=machine_id,
+            event=event,
+        )
     configuration, actions, internal_queue, context, output = microstep(
         enabled_transitions,
         configuration=configuration,
@@ -792,6 +903,18 @@ def main_event_loop[ContextT](
         event=event,
         output=None,
     )
+    microsteps: list[AlgorithmMicrostep[ContextT, Any]] = [
+        _capture_algorithm_microstep(
+            event=event,
+            transitions=enabled_transitions,
+            configuration=configuration,
+            actions=actions,
+            context=context,
+            history_value=history_value,
+            output=output,
+            context_snapshot=context_snapshot,
+        )
+    ]
     return main_event_loop2(
         configuration=configuration,
         actions=actions,
@@ -800,6 +923,11 @@ def main_event_loop[ContextT](
         event=event,
         history_value=history_value,
         output=output,
+        context_snapshot=context_snapshot,
+        machine_id=machine_id,
+        max_iterations=max_iterations,
+        iterations=iterations,
+        microsteps=microsteps,
     )
 
 
@@ -808,15 +936,18 @@ def main_event_loop2[ContextT, OutputT](
     actions: list[Action],
     internal_queue: InternalQueue,
     context: ContextT,
+    *,
     event: Event | None = None,
-    history_value: HistoryValue | None = None,
+    history_value: HistoryValue,
     output: OutputT | None = None,
+    context_snapshot: Callable[[ContextT], ContextT],
+    machine_id: str,
+    max_iterations: int | None,
+    iterations: int,
+    microsteps: list[AlgorithmMicrostep[ContextT, OutputT]],
 ) -> MacrostepResult[ContextT, OutputT]:
     enabled_transitions: TransitionSequence = []
     macrostep_done = False
-    if history_value is None:
-        history_value = {}
-
     while not macrostep_done:
         enabled_transitions = select_eventless_transitions(
             configuration=configuration,
@@ -837,7 +968,27 @@ def main_event_loop2[ContextT, OutputT](
                     context=context,
                     history_value=history_value,
                 )
+                if not enabled_transitions:
+                    microsteps.append(
+                        _capture_algorithm_microstep(
+                            event=internal_event,
+                            transitions=[],
+                            configuration=configuration,
+                            actions=[],
+                            context=context,
+                            history_value=history_value,
+                            output=output,
+                            context_snapshot=context_snapshot,
+                        )
+                    )
         if enabled_transitions:
+            effective_event = event if event is not None else Event("")
+            iterations = _consume_iteration(
+                iterations=iterations,
+                max_iterations=max_iterations,
+                machine_id=machine_id,
+                event=effective_event,
+            )
             # Accumulate — microstep produces a fresh actions list each call, so
             # extend rather than rebind to avoid dropping actions from prior steps.
             configuration, new_actions, internal_queue, context, output = microstep(
@@ -850,8 +1001,20 @@ def main_event_loop2[ContextT, OutputT](
                 output=output,
             )
             actions.extend(new_actions)
+            microsteps.append(
+                _capture_algorithm_microstep(
+                    event=effective_event,
+                    transitions=enabled_transitions,
+                    configuration=configuration,
+                    actions=new_actions,
+                    context=context,
+                    history_value=history_value,
+                    output=output,
+                    context_snapshot=context_snapshot,
+                )
+            )
 
-    return MacrostepResult(configuration, actions, context, output)
+    return MacrostepResult(configuration, actions, context, output, tuple(microsteps))
 
 
 def execute_transition_content[ContextT](

--- a/src/xstate/async_interpreter.py
+++ b/src/xstate/async_interpreter.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import warnings
 from collections import deque
 from collections.abc import Awaitable, Callable
 from typing import Any, cast
@@ -51,6 +52,7 @@ from xstate.event import Event, EventInput, RuntimeEventPayload
 from xstate.interpreter import NOT_STARTED, RUNNING, STOPPED, resolve_delay_ms
 from xstate.machine import Machine
 from xstate.state import State
+from xstate.trace import MacrostepTrace
 
 __all__ = ["AsyncSubscription", "AsyncInterpreter", "interpret_async"]
 
@@ -91,9 +93,17 @@ class AsyncInterpreter[ContextT = Any, EventDataT = Any, OutputT = Any]:
     machine: Machine[ContextT, EventDataT, OutputT]
     state: State[ContextT, EventDataT, OutputT]
 
-    def __init__(self, machine: Machine[ContextT, EventDataT, OutputT]):
+    def __init__(
+        self,
+        machine: Machine[ContextT, EventDataT, OutputT],
+        *,
+        inspect: (
+            Callable[[MacrostepTrace[ContextT, EventDataT, OutputT]], None] | None
+        ) = None,
+    ):
         self.machine = machine
-        self.state = machine.initial_state
+        self.state, self._initial_trace = machine._initial_transition()
+        self._inspector = inspect
         self._status = NOT_STARTED
         self._listeners: set[Callable[[State[ContextT, EventDataT, OutputT]], None]] = (
             set()
@@ -124,9 +134,16 @@ class AsyncInterpreter[ContextT = Any, EventDataT = Any, OutputT = Any]:
             return self
         if initial_state is not None:
             self.state = initial_state
+            self._initial_trace = MacrostepTrace(
+                event=cast(Event[EventDataT], Event("xstate.init")),
+                previous_snapshot=None,
+                snapshot=initial_state,
+                microsteps=(),
+            )
         self.state.event = Event("xstate.init")
         self._status = RUNNING
         self._sync_delays()
+        self._inspect_trace(self._initial_trace)
         await self._execute(self.state)
         self._notify(self.state)
         return self
@@ -202,13 +219,14 @@ class AsyncInterpreter[ContextT = Any, EventDataT = Any, OutputT = Any]:
                 future.exception()
 
     async def _process(self, event: EventInput[EventDataT]) -> None:
-        next_state = self.machine.transition(self.state, event)
+        next_state, trace = self.machine._transition_with_trace(self.state, event)
         next_state.event = cast(
             Event[RuntimeEventPayload[EventDataT, OutputT]],
             self.machine._to_event(event),
         )
         self.state = next_state
         self._sync_delays()
+        self._inspect_trace(trace)
         await self._execute(next_state)
         self._notify(next_state)
 
@@ -230,6 +248,20 @@ class AsyncInterpreter[ContextT = Any, EventDataT = Any, OutputT = Any]:
     def _notify(self, state: State[ContextT, EventDataT, OutputT]) -> None:
         for listener in list(self._listeners):
             listener(state)
+
+    def _inspect_trace(
+        self, trace: MacrostepTrace[ContextT, EventDataT, OutputT]
+    ) -> None:
+        if self._inspector is None:
+            return
+        try:
+            self._inspector(trace)
+        except Exception as exc:  # noqa: BLE001 - inspection must be fail-open
+            warnings.warn(
+                f"Inspector callback failed: {exc}",
+                RuntimeWarning,
+                stacklevel=3,
+            )
 
     # -- side effects -------------------------------------------------------
 
@@ -325,10 +357,13 @@ class AsyncInterpreter[ContextT = Any, EventDataT = Any, OutputT = Any]:
 
 def interpret_async[ContextT, EventDataT, OutputT](
     machine: Machine[ContextT, EventDataT, OutputT],
+    *,
+    inspect: Callable[[MacrostepTrace[ContextT, EventDataT, OutputT]], None]
+    | None = None,
 ) -> AsyncInterpreter[ContextT, EventDataT, OutputT]:
     """Create an :class:`AsyncInterpreter` for ``machine``.
 
     The asyncio counterpart of :func:`~xstate.interpreter.interpret`. The service
     is not started; ``await`` its :meth:`AsyncInterpreter.start`.
     """
-    return AsyncInterpreter(machine)
+    return AsyncInterpreter(machine, inspect=inspect)

--- a/src/xstate/exceptions.py
+++ b/src/xstate/exceptions.py
@@ -1,4 +1,9 @@
-__all__ = ["XStateError", "InvalidConfigError", "UnregisteredImplementationError"]
+__all__ = [
+    "XStateError",
+    "InvalidConfigError",
+    "InfiniteLoopError",
+    "UnregisteredImplementationError",
+]
 
 
 class XStateError(Exception):
@@ -11,6 +16,16 @@ class InvalidConfigError(XStateError, ValueError):
     Subclasses :class:`ValueError` for backwards compatibility with callers that
     already catch ``ValueError`` on bad machine configurations.
     """
+
+
+class InfiniteLoopError(XStateError):
+    """Raised before a macrostep exceeds its configured iteration limit."""
+
+    def __init__(self, machine_id: str, limit: int, event_type: str):
+        super().__init__(
+            f"Machine '{machine_id}' exceeded max iterations {limit} for event "
+            f"'{event_type}'."
+        )
 
 
 class UnregisteredImplementationError(XStateError, UserWarning, ValueError):

--- a/src/xstate/interpreter.py
+++ b/src/xstate/interpreter.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import functools
 import threading
+import warnings
 from collections import deque
 from collections.abc import Callable
 from typing import Any, cast
@@ -37,6 +38,7 @@ from xstate.exceptions import UnregisteredImplementationError
 from xstate.machine import Machine
 from xstate.scheduler import Clock, ThreadClock
 from xstate.state import State
+from xstate.trace import MacrostepTrace
 
 __all__ = [
     "NOT_STARTED",
@@ -107,10 +109,15 @@ class Interpreter[ContextT = Any, EventDataT = Any, OutputT = Any]:
         self,
         machine: Machine[ContextT, EventDataT, OutputT],
         clock: Clock | None = None,
+        *,
+        inspect: (
+            Callable[[MacrostepTrace[ContextT, EventDataT, OutputT]], None] | None
+        ) = None,
     ):
         self.machine = machine
         self.clock = clock if clock is not None else ThreadClock()
-        self.state = machine.initial_state
+        self.state, self._initial_trace = machine._initial_transition()
+        self._inspector = inspect
         self._status = NOT_STARTED
         self._lock = threading.RLock()
         self._listeners: set[Callable[[State[ContextT, EventDataT, OutputT]], None]] = (
@@ -145,10 +152,18 @@ class Interpreter[ContextT = Any, EventDataT = Any, OutputT = Any]:
                 return self
             if initial_state is not None:
                 self.state = initial_state
+                self._initial_trace = MacrostepTrace(
+                    event=cast(Event[EventDataT], Event("xstate.init")),
+                    previous_snapshot=None,
+                    snapshot=initial_state,
+                    microsteps=(),
+                )
             self.state.event = Event("xstate.init")
             self._status = RUNNING
             self._sync_delays()
             state = self.state
+            initial_trace = self._initial_trace
+        self._inspect_trace(initial_trace)
         self._execute(state)
         self._notify(state)
         return self
@@ -208,7 +223,7 @@ class Interpreter[ContextT = Any, EventDataT = Any, OutputT = Any]:
                 return
             state = self.state
 
-        next_state = self.machine.transition(state, event)
+        next_state, trace = self.machine._transition_with_trace(state, event)
         next_state.event = cast(
             Event[RuntimeEventPayload[EventDataT, OutputT]],
             self.machine._to_event(event),
@@ -220,6 +235,7 @@ class Interpreter[ContextT = Any, EventDataT = Any, OutputT = Any]:
             self.state = next_state
             self._sync_delays()
 
+        self._inspect_trace(trace)
         self._execute(next_state)
         self._notify(next_state)
 
@@ -241,6 +257,20 @@ class Interpreter[ContextT = Any, EventDataT = Any, OutputT = Any]:
             listeners = tuple(self._listeners)
         for listener in listeners:
             listener(state)
+
+    def _inspect_trace(
+        self, trace: MacrostepTrace[ContextT, EventDataT, OutputT]
+    ) -> None:
+        if self._inspector is None:
+            return
+        try:
+            self._inspector(trace)
+        except Exception as exc:  # noqa: BLE001 - inspection must be fail-open
+            warnings.warn(
+                f"Inspector callback failed: {exc}",
+                RuntimeWarning,
+                stacklevel=3,
+            )
 
     # -- side effects -------------------------------------------------------
 
@@ -356,7 +386,11 @@ class Interpreter[ContextT = Any, EventDataT = Any, OutputT = Any]:
 
 
 def interpret[ContextT, EventDataT, OutputT](
-    machine: Machine[ContextT, EventDataT, OutputT], clock: Clock | None = None
+    machine: Machine[ContextT, EventDataT, OutputT],
+    clock: Clock | None = None,
+    *,
+    inspect: Callable[[MacrostepTrace[ContextT, EventDataT, OutputT]], None]
+    | None = None,
 ) -> Interpreter[ContextT, EventDataT, OutputT]:
     """Create an :class:`Interpreter` for ``machine`` (XState ``interpret``)."""
-    return Interpreter(machine, clock=clock)
+    return Interpreter(machine, clock=clock, inspect=inspect)

--- a/src/xstate/machine.py
+++ b/src/xstate/machine.py
@@ -2,27 +2,28 @@ from __future__ import annotations
 
 import functools
 import warnings
-from collections import deque
 from collections.abc import Callable
 from typing import Any, cast
 
 from xstate.action import INTERPRETER_TYPES, Action
 from xstate.algorithm import (
-    enter_states,
+    AlgorithmMicrostep,
+    MacrostepResult,
     get_configuration_from_state,
+    initial_event_loop,
     main_event_loop,
-    main_event_loop2,
 )
 from xstate.config_parser import StateNodeConfigParser
 from xstate.context import ContextAdapter, DeepCopyContextAdapter
-from xstate.event import Event, EventInput, to_event
+from xstate.event import Event, EventInput, RuntimeEventPayload, to_event
 from xstate.exceptions import InvalidConfigError, UnregisteredImplementationError
 from xstate.handlers import HandlerAdapter, adapt_handler
 from xstate.schema import MachineConfig
 from xstate.state import State
 from xstate.state_node import StateNode
+from xstate.trace import MacrostepTrace, MicrostepTrace, TransitionTrace
 
-__all__ = ["Machine"]
+__all__ = ["Machine", "get_microsteps", "get_initial_microsteps"]
 
 ActionCallable = Callable[[], Any]
 ResolvedAction = Action | ActionCallable
@@ -42,6 +43,7 @@ class Machine[ContextT = Any, EventDataT = Any, OutputT = Any]:
     strict: bool
     context: ContextT
     context_adapter: ContextAdapter[ContextT]
+    max_iterations: int | None
 
     def __init__(
         self,
@@ -52,6 +54,7 @@ class Machine[ContextT = Any, EventDataT = Any, OutputT = Any]:
         actors: dict[str, Any] | None = None,
         context_adapter: ContextAdapter[ContextT] | None = None,
         strict: bool = False,
+        max_iterations: int | None = None,
     ):
         if "id" not in config:
             raise InvalidConfigError(
@@ -63,6 +66,16 @@ class Machine[ContextT = Any, EventDataT = Any, OutputT = Any]:
         self._order = 0
         self.strict = strict
         self.context_adapter = context_adapter or DeepCopyContextAdapter()
+        options = config.get("options")
+        if options is not None and not isinstance(options, dict):
+            raise InvalidConfigError("Machine options must be a dict.")
+        configured_limit = (
+            options.get("maxIterations") if isinstance(options, dict) else None
+        )
+        effective_limit = (
+            max_iterations if max_iterations is not None else configured_limit
+        )
+        self.max_iterations = self._validate_max_iterations(effective_limit)
         # Registries must be populated *before* the state tree is built: node and
         # transition construction resolves named actions against `self.actions`
         # (see action.build_action), so a named assign/raise/send is expanded to
@@ -81,6 +94,17 @@ class Machine[ContextT = Any, EventDataT = Any, OutputT = Any]:
             ContextT,
             config.get("context") if config.get("context") is not None else {},
         )
+
+    @staticmethod
+    def _validate_max_iterations(value: Any) -> int | None:
+        if value is None:
+            return None
+        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+            raise InvalidConfigError(
+                "options.maxIterations and max_iterations must be a non-negative "
+                "integer or None."
+            )
+        return cast(int, value)
 
     def _adapt_registry(self, registry: dict[str, Any], *, kind: str) -> dict[str, Any]:
         return {
@@ -106,7 +130,18 @@ class Machine[ContextT = Any, EventDataT = Any, OutputT = Any]:
         state: State[ContextT, EventDataT, OutputT],
         event: EventInput[EventDataT],
     ) -> State[ContextT, EventDataT, OutputT]:
-        event = self._to_event(event)
+        next_state, _trace = self._transition_with_trace(state, event)
+        return next_state
+
+    def _transition_with_trace(
+        self,
+        state: State[ContextT, EventDataT, OutputT],
+        event: EventInput[EventDataT],
+    ) -> tuple[
+        State[ContextT, EventDataT, OutputT],
+        MacrostepTrace[ContextT, EventDataT, OutputT],
+    ]:
+        event_object = self._to_event(event)
         configuration = get_configuration_from_state(
             from_node=self.root, state_value=state.value, partial_configuration=set()
         )
@@ -114,20 +149,70 @@ class Machine[ContextT = Any, EventDataT = Any, OutputT = Any]:
         history_value = {
             state_id: set(states) for state_id, states in state.history_value.items()
         }
-        configuration, _actions, context, output = main_event_loop(
-            configuration, event, context, history_value
+        result = main_event_loop(
+            configuration,
+            event_object,
+            context,
+            history_value=history_value,
+            context_snapshot=self.context_adapter.snapshot,
+            machine_id=self.id,
+            max_iterations=self.max_iterations,
         )
 
-        actions, unknown = self._get_actions(_actions, context, event)
+        actions, unknown = self._get_actions(
+            result.actions, result.context, event_object
+        )
         self._warn_unknown_actions(unknown)
 
-        return State[ContextT, EventDataT, OutputT](
-            configuration=configuration,
-            context=context,
+        next_state = State[ContextT, EventDataT, OutputT](
+            configuration=result.configuration,
+            context=result.context,
             actions=actions,
             history_value=history_value,
-            output=cast(OutputT | None, output),
+            output=result.output,
         )
+        trace = MacrostepTrace[ContextT, EventDataT, OutputT](
+            event=event_object,
+            previous_snapshot=state,
+            snapshot=next_state,
+            microsteps=self._build_microstep_traces(result.microsteps),
+        )
+        return next_state, trace
+
+    def _build_microstep_traces(
+        self,
+        microsteps: tuple[AlgorithmMicrostep[ContextT, Any], ...],
+    ) -> tuple[MicrostepTrace[ContextT, EventDataT, OutputT], ...]:
+        result: list[MicrostepTrace[ContextT, EventDataT, OutputT]] = []
+        for microstep in microsteps:
+            actions, _unknown = self._get_actions(
+                list(microstep.actions), microstep.context, microstep.event
+            )
+            snapshot = State[ContextT, EventDataT, OutputT](
+                configuration=microstep.configuration,
+                context=microstep.context,
+                actions=actions,
+                history_value=microstep.history_value,
+                output=cast(OutputT | None, microstep.output),
+            )
+            result.append(
+                MicrostepTrace[ContextT, EventDataT, OutputT](
+                    event=cast(
+                        Event[RuntimeEventPayload[EventDataT, OutputT]],
+                        microstep.event,
+                    ),
+                    snapshot=snapshot,
+                    transitions=tuple(
+                        TransitionTrace(
+                            event_type=transition.event or "",
+                            source_id=transition.source.id,
+                            target_ids=tuple(target.id for target in transition.target),
+                        )
+                        for transition in microstep.transitions
+                    ),
+                )
+            )
+        return tuple(result)
 
     def _get_actions(
         self, actions: list[Action], context: Any, event: Event | None
@@ -232,37 +317,59 @@ class Machine[ContextT = Any, EventDataT = Any, OutputT = Any]:
 
     @property
     def initial_state(self) -> State[ContextT, EventDataT, OutputT]:
+        state, _trace = self._initial_transition()
+        return state
+
+    def _initial_transition(
+        self,
+    ) -> tuple[
+        State[ContextT, EventDataT, OutputT],
+        MacrostepTrace[ContextT, EventDataT, OutputT],
+    ]:
         context = self.context_adapter.snapshot(self.context)
         history_value: dict[str, Any] = {}
-        init_event = Event("xstate.init")
-        configuration, _actions, internal_queue, context, output = enter_states(
-            [self.root.initial],
-            configuration=set(),
+        result: MacrostepResult[ContextT, OutputT] = initial_event_loop(
+            self.root.initial,
+            context,
             history_value=history_value,
-            actions=[],
-            internal_queue=deque(),
-            context=context,
-            event=init_event,
-            output=None,
+            context_snapshot=self.context_adapter.snapshot,
+            machine_id=self.id,
+            max_iterations=self.max_iterations,
         )
+        init_event: Event[EventDataT] = Event("xstate.init")
 
-        configuration, _actions, context, output = main_event_loop2(
-            configuration=configuration,
-            actions=_actions,
-            internal_queue=internal_queue,
-            context=context,
-            event=init_event,
-            history_value=history_value,
-            output=output,
-        )
-
-        actions, unknown = self._get_actions(_actions, context, init_event)
+        actions, unknown = self._get_actions(result.actions, result.context, init_event)
         self._warn_unknown_actions(unknown)
 
-        return State[ContextT, EventDataT, OutputT](
-            configuration=configuration,
-            context=context,
+        state = State[ContextT, EventDataT, OutputT](
+            configuration=result.configuration,
+            context=result.context,
             actions=actions,
             history_value=history_value,
-            output=cast(OutputT | None, output),
+            output=result.output,
         )
+        trace = MacrostepTrace[ContextT, EventDataT, OutputT](
+            event=init_event,
+            previous_snapshot=None,
+            snapshot=state,
+            microsteps=self._build_microstep_traces(result.microsteps),
+        )
+        return state, trace
+
+
+def get_microsteps[ContextT, EventDataT, OutputT](
+    machine: Machine[ContextT, EventDataT, OutputT],
+    snapshot: State[ContextT, EventDataT, OutputT],
+    event: EventInput[EventDataT],
+) -> tuple[MicrostepTrace[ContextT, EventDataT, OutputT], ...]:
+    """Return immutable microstep traces for one pure machine transition."""
+    _state, trace = machine._transition_with_trace(snapshot, event)
+    return trace.microsteps
+
+
+def get_initial_microsteps[ContextT, EventDataT, OutputT](
+    machine: Machine[ContextT, EventDataT, OutputT],
+) -> tuple[MicrostepTrace[ContextT, EventDataT, OutputT], ...]:
+    """Return immutable microstep traces for machine initialization."""
+    _state, trace = machine._initial_transition()
+    return trace.microsteps

--- a/src/xstate/schema.py
+++ b/src/xstate/schema.py
@@ -23,11 +23,16 @@ __all__ = [
     "ActionSpec",
     "TransitionTarget",
     "StateValue",
+    "MachineOptionsConfig",
     "TransitionConfig",
     "InvokeConfig",
     "StateNodeConfig",
     "MachineConfig",
 ]
+
+
+class MachineOptionsConfig(TypedDict, total=False):
+    maxIterations: int
 
 
 _TransitionInConfig = TypedDict(
@@ -127,3 +132,4 @@ class MachineConfig[ContextT = Any, EventDataT = Any, OutputT = Any](
     StateNodeConfig[ContextT, EventDataT, OutputT], total=False
 ):
     context: ContextT
+    options: MachineOptionsConfig

--- a/src/xstate/trace.py
+++ b/src/xstate/trace.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from xstate.event import Event, RuntimeEventPayload
+
+if TYPE_CHECKING:
+    from xstate.state import State
+
+__all__ = ["TransitionTrace", "MicrostepTrace", "MacrostepTrace"]
+
+
+@dataclass(frozen=True, slots=True)
+class TransitionTrace:
+    """Portable summary of one selected transition."""
+
+    event_type: str
+    source_id: str
+    target_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class MicrostepTrace[ContextT = Any, EventDataT = Any, OutputT = Any]:
+    """One immutable intermediate result inside a macrostep."""
+
+    event: Event[RuntimeEventPayload[EventDataT, OutputT]]
+    snapshot: State[ContextT, EventDataT, OutputT]
+    transitions: tuple[TransitionTrace, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class MacrostepTrace[ContextT = Any, EventDataT = Any, OutputT = Any]:
+    """Settled result and ordered microsteps for one external event."""
+
+    event: Event[EventDataT]
+    previous_snapshot: State[ContextT, EventDataT, OutputT] | None
+    snapshot: State[ContextT, EventDataT, OutputT]
+    microsteps: tuple[MicrostepTrace[ContextT, EventDataT, OutputT], ...]

--- a/tests/test_microstep_traces.py
+++ b/tests/test_microstep_traces.py
@@ -1,0 +1,398 @@
+"""Public microstep traces, bounded execution, and interpreter inspection."""
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from xstate import (
+    InfiniteLoopError,
+    Machine,
+    MacrostepTrace,
+    TransitionTrace,
+    assign,
+    create_actor,
+    from_promise,
+    get_initial_microsteps,
+    get_microsteps,
+    interpret,
+    interpret_async,
+    raise_,
+)
+from xstate.exceptions import InvalidConfigError
+
+
+def _trace_machine(effects=None):
+    effects = effects if effects is not None else []
+    return Machine(
+        {
+            "id": "trace-machine",
+            "initial": "idle",
+            "states": {
+                "idle": {
+                    "on": {
+                        "START": {
+                            "target": "working",
+                            "actions": [
+                                "external",
+                                raise_("IGNORED"),
+                                raise_("NEXT"),
+                            ],
+                        }
+                    }
+                },
+                "working": {"always": {"target": "ready", "actions": "eventless"}},
+                "ready": {"on": {"NEXT": {"target": "done", "actions": "raised"}}},
+                "done": {},
+            },
+        },
+        actions={
+            "external": lambda: effects.append("external"),
+            "eventless": lambda: effects.append("eventless"),
+            "raised": lambda: effects.append("raised"),
+        },
+    )
+
+
+def test_get_microsteps_records_external_eventless_and_internal_fifo_order():
+    effects = []
+    machine = _trace_machine(effects)
+
+    microsteps = get_microsteps(machine, machine.initial_state, "START")
+
+    assert effects == []
+    assert tuple(step.event.name for step in microsteps) == (
+        "START",
+        "START",
+        "IGNORED",
+        "NEXT",
+    )
+    assert tuple(len(step.transitions) for step in microsteps) == (1, 1, 0, 1)
+    assert tuple(len(step.snapshot.actions) for step in microsteps) == (1, 1, 0, 1)
+    assert tuple(step.snapshot.value for step in microsteps) == (
+        "working",
+        "ready",
+        "ready",
+        "done",
+    )
+    assert microsteps[0].transitions == (
+        TransitionTrace(
+            event_type="START",
+            source_id="trace-machine.idle",
+            target_ids=("trace-machine.working",),
+        ),
+    )
+    assert microsteps[1].transitions[0].event_type == ""
+    assert microsteps[3].transitions[0].event_type == "NEXT"
+
+
+def test_intermediate_snapshots_and_trace_records_are_immutable():
+    machine = _trace_machine()
+    step = get_microsteps(machine, machine.initial_state, "START")[0]
+
+    assert isinstance(step.snapshot.configuration, frozenset)
+    assert isinstance(step.snapshot.actions, tuple)
+    with pytest.raises(FrozenInstanceError):
+        step.transitions = ()
+
+
+def test_machine_transition_keeps_all_macrostep_actions():
+    machine = _trace_machine()
+
+    state = machine.transition(machine.initial_state, "START")
+
+    assert state.value == "done"
+    assert len(state.actions) == 3
+
+
+def test_get_initial_microsteps_includes_initial_and_eventless_steps():
+    machine = Machine(
+        {
+            "id": "initial-trace",
+            "initial": "a",
+            "states": {
+                "a": {"entry": "enter-a", "always": "b"},
+                "b": {"entry": "enter-b"},
+            },
+        },
+        actions={"enter-a": lambda: None, "enter-b": lambda: None},
+    )
+
+    microsteps = get_initial_microsteps(machine)
+
+    assert tuple(step.event.name for step in microsteps) == (
+        "xstate.init",
+        "xstate.init",
+    )
+    assert tuple(step.snapshot.value for step in microsteps) == ("a", "b")
+    assert tuple(len(step.snapshot.actions) for step in microsteps) == (1, 1)
+
+
+def test_eventless_cycle_stops_before_first_microstep_over_limit():
+    executed = []
+
+    def record(context, event):
+        executed.append(event.name)
+        return {}
+
+    machine = Machine(
+        {
+            "id": "eventless-cycle",
+            "initial": "a",
+            "states": {
+                "a": {"always": {"target": "b", "actions": assign(record)}},
+                "b": {"always": {"target": "a", "actions": assign(record)}},
+            },
+        },
+        max_iterations=3,
+    )
+
+    with pytest.raises(InfiniteLoopError) as exc_info:
+        _ = machine.initial_state
+
+    assert executed == ["xstate.init", "xstate.init"]
+    assert str(exc_info.value) == (
+        "Machine 'eventless-cycle' exceeded max iterations 3 for event 'xstate.init'."
+    )
+
+
+def test_raised_event_cycle_stops_at_exact_limit():
+    executed = []
+
+    def record(context, event):
+        executed.append(event.name)
+        return {}
+
+    machine = Machine(
+        {
+            "id": "raised-cycle",
+            "initial": "a",
+            "states": {
+                "a": {
+                    "on": {
+                        "START": {
+                            "target": "b",
+                            "actions": [assign(record), raise_("LOOP")],
+                        }
+                    }
+                },
+                "b": {
+                    "on": {
+                        "LOOP": {
+                            "target": "b",
+                            "actions": [assign(record), raise_("LOOP")],
+                        }
+                    }
+                },
+            },
+        },
+        max_iterations=3,
+    )
+
+    with pytest.raises(InfiniteLoopError, match="raised-cycle"):
+        machine.transition(machine.initial_state, "START")
+
+    assert executed == ["START", "LOOP", "LOOP"]
+
+
+def test_unlimited_finite_eventless_execution_preserves_behavior():
+    machine = Machine(
+        {
+            "id": "unlimited",
+            "initial": "a",
+            "states": {
+                "a": {"always": "b"},
+                "b": {"always": "c"},
+                "c": {"always": "d"},
+                "d": {},
+            },
+        }
+    )
+
+    assert machine.initial_state.value == "d"
+
+
+def test_ignored_events_do_not_consume_iteration_limit():
+    machine = Machine(
+        {
+            "id": "ignored-limit",
+            "initial": "a",
+            "states": {"a": {"on": {"GO": "b"}}, "b": {}},
+        },
+        max_iterations=1,
+    )
+    initial = machine.initial_state
+
+    ignored = get_microsteps(machine, initial, "IGNORED")
+    settled = machine.transition(initial, "GO")
+
+    assert len(ignored) == 1
+    assert ignored[0].transitions == ()
+    assert settled.value == "b"
+
+
+@pytest.mark.parametrize("value", [True, False, -1, 1.5, "2"])
+def test_invalid_max_iterations_values_are_rejected(value):
+    with pytest.raises(InvalidConfigError, match="maxIterations"):
+        Machine(
+            {
+                "id": "invalid-limit",
+                "initial": "a",
+                "states": {"a": {}},
+                "options": {"maxIterations": value},
+            }
+        )
+
+
+def test_constructor_limit_overrides_json_option_only_when_non_none():
+    config = {
+        "id": "limit-precedence",
+        "initial": "a",
+        "states": {"a": {}},
+        "options": {"maxIterations": 1},
+    }
+
+    assert Machine(config).max_iterations == 1
+    assert Machine(config, max_iterations=None).max_iterations == 1
+    assert Machine(config, max_iterations=4).max_iterations == 4
+
+
+def _failing_transition_machine():
+    return Machine(
+        {
+            "id": "transactional-limit",
+            "initial": "a",
+            "states": {
+                "a": {"on": {"GO": "b"}},
+                "b": {"always": "c"},
+                "c": {},
+            },
+        },
+        max_iterations=1,
+    )
+
+
+def test_sync_interpreter_keeps_committed_snapshot_when_limit_fails():
+    service = interpret(_failing_transition_machine()).start()
+    previous = service.state
+
+    with pytest.raises(InfiniteLoopError):
+        service.send("GO")
+
+    assert service.state is previous
+    assert service.state.value == "a"
+
+
+async def test_async_interpreter_keeps_committed_snapshot_when_limit_fails():
+    service = await interpret_async(_failing_transition_machine()).start()
+    previous = service.state
+
+    with pytest.raises(InfiniteLoopError):
+        await service.send("GO")
+
+    assert service.state is previous
+    assert service.state.value == "a"
+
+
+def _inspection_machine(log):
+    return Machine(
+        {
+            "id": "inspection",
+            "initial": "idle",
+            "states": {
+                "idle": {
+                    "entry": "initial-action",
+                    "on": {"GO": {"target": "done", "actions": "go-action"}},
+                },
+                "done": {},
+            },
+        },
+        actions={
+            "initial-action": lambda: log.append("initial-action"),
+            "go-action": lambda: log.append("go-action"),
+        },
+    )
+
+
+def test_sync_inspector_runs_after_install_before_actions_and_subscribers():
+    log = []
+    traces = []
+
+    def inspect_trace(trace):
+        assert isinstance(trace, MacrostepTrace)
+        traces.append(trace)
+        log.append(f"inspect:{trace.snapshot.value}")
+
+    service = interpret(_inspection_machine(log), inspect=inspect_trace)
+    service.subscribe(lambda state: log.append(f"subscribe:{state.value}"))
+    service.start()
+    service.send("GO")
+
+    assert log == [
+        "inspect:idle",
+        "initial-action",
+        "subscribe:idle",
+        "inspect:done",
+        "go-action",
+        "subscribe:done",
+    ]
+    assert traces[0].previous_snapshot is None
+    assert traces[0].event.name == "xstate.init"
+    assert traces[1].previous_snapshot.value == "idle"
+    assert traces[1].event.name == "GO"
+
+
+def test_inspector_failure_warns_without_interrupting_behavior():
+    effects = []
+
+    def fail(_trace):
+        raise RuntimeError("observer failed")
+
+    service = interpret(_inspection_machine(effects), inspect=fail)
+
+    with pytest.warns(RuntimeWarning, match="Inspector callback failed"):
+        service.start()
+    with pytest.warns(RuntimeWarning, match="Inspector callback failed"):
+        state = service.send("GO")
+
+    assert state.value == "done"
+    assert effects == ["initial-action", "go-action"]
+
+
+def _trace_signature(trace):
+    return (
+        trace.event.name,
+        None if trace.previous_snapshot is None else trace.previous_snapshot.value,
+        trace.snapshot.value,
+        tuple(
+            (step.event.name, step.snapshot.value, len(step.transitions))
+            for step in trace.microsteps
+        ),
+    )
+
+
+async def test_sync_and_async_inspectors_receive_equivalent_traces():
+    sync_traces = []
+    async_traces = []
+    sync_service = interpret(_trace_machine(), inspect=sync_traces.append).start()
+    sync_service.send("START")
+
+    async_service = interpret_async(_trace_machine(), inspect=async_traces.append)
+    await async_service.start()
+    await async_service.send("START")
+
+    assert tuple(map(_trace_signature, sync_traces)) == tuple(
+        map(_trace_signature, async_traces)
+    )
+
+
+def test_machine_actor_accepts_inspector():
+    traces = []
+    actor = create_actor(_trace_machine(), inspect=traces.append).start()
+    actor.send("START")
+
+    assert tuple(trace.event.name for trace in traces) == ("xstate.init", "START")
+
+
+def test_non_machine_actor_rejects_inspector():
+    with pytest.raises(TypeError, match="inspect"):
+        create_actor(from_promise(lambda: 1), inspect=lambda trace: None)

--- a/tests/test_typing_contract.py
+++ b/tests/test_typing_contract.py
@@ -46,5 +46,9 @@ def test_invalid_typing_contracts_are_rejected() -> None:
         'variable has type "GuardHandler[Context, IncrementEvent, Output]"',
         'variable has type "OutputHandler[Context, IncrementEvent, Output]"',
         'Argument 2 to "Event"',
+        'TypedDict item "maxIterations" has type "int"',
+        'Argument "max_iterations" to "Machine"',
+        'Argument "inspect" to "interpret"',
+        'variable has type "State[str, IncrementEvent, Output]"',
     ):
         assert expected in output

--- a/tests/typing/negative.py
+++ b/tests/typing/negative.py
@@ -7,7 +7,10 @@ from xstate import (
     GuardHandler,
     HandlerArgs,
     Machine,
+    MachineOptionsConfig,
+    MacrostepTrace,
     OutputHandler,
+    State,
     interpret,
 )
 
@@ -55,3 +58,19 @@ output: OutputHandler[Context, IncrementEvent, Output] = (  # invalid-output-han
     wrong_output
 )
 event = Event[IncrementEvent]("INCREMENT", {"type": "INCREMENT"})  # invalid-event
+options: MachineOptionsConfig = {"maxIterations": "2"}  # invalid-options
+Machine({"id": "bad", "states": {}}, max_iterations="2")  # invalid-limit
+
+
+def wrong_inspector(_trace: State[Context, IncrementEvent, Output]) -> None:
+    return None
+
+
+interpret(machine, inspect=wrong_inspector)  # invalid-inspector
+
+
+def valid_inspector(
+    trace: MacrostepTrace[Context, IncrementEvent, Output],
+) -> None:
+    bad_snapshot: State[str, IncrementEvent, Output] = trace.snapshot  # invalid-trace
+    _ = bad_snapshot

--- a/tests/typing/positive.py
+++ b/tests/typing/positive.py
@@ -20,14 +20,20 @@ from xstate import (
     Interpreter,
     Machine,
     MachineConfig,
+    MachineOptionsConfig,
     MachineSetup,
     MachineSnapshot,
+    MacrostepTrace,
+    MicrostepTrace,
     OutputHandler,
     State,
+    TransitionTrace,
     create_actor,
     from_callback,
     from_observable,
     from_promise,
+    get_initial_microsteps,
+    get_microsteps,
     interpret,
     interpret_async,
     setup,
@@ -100,8 +106,10 @@ config: MachineConfig[Context, AppEvent, Output] = {
         "done": {"type": "final", "output": output_handler},
     },
 }
+options: MachineOptionsConfig = {"maxIterations": 10}
+config["options"] = options
 
-machine: Machine[Context, AppEvent, Output] = Machine(config)
+machine: Machine[Context, AppEvent, Output] = Machine(config, max_iterations=20)
 state = machine.initial_state
 assert_type(state, State[Context, AppEvent, Output])
 assert_type(state, MachineSnapshot[Context, AppEvent, Output])
@@ -109,8 +117,25 @@ state = machine.transition(state, {"type": "INCREMENT", "by": 2})
 assert_type(state.context, Context)
 assert_type(state.output, Output | None)
 assert_type(state.event, Event[AppEvent | Output | BaseException] | None)
+finish_event: FinishEvent = {"type": "FINISH"}
+assert_type(
+    get_microsteps(machine, state, finish_event),
+    tuple[MicrostepTrace[Context, AppEvent, Output], ...],
+)
+assert_type(
+    get_initial_microsteps(machine),
+    tuple[MicrostepTrace[Context, AppEvent, Output], ...],
+)
+transition_trace = TransitionTrace("FINISH", "counter.active", ("counter.done",))
+assert_type(transition_trace.target_ids, tuple[str, ...])
 
-service = interpret(machine)
+
+def inspect_trace(trace: MacrostepTrace[Context, AppEvent, Output]) -> None:
+    assert_type(trace.snapshot, State[Context, AppEvent, Output])
+    assert_type(trace.microsteps, tuple[MicrostepTrace[Context, AppEvent, Output], ...])
+
+
+service = interpret(machine, inspect=inspect_trace)
 assert_type(service, Interpreter[Context, AppEvent, Output])
 assert_type(
     service.send({"type": "INCREMENT", "by": 1}),
@@ -124,7 +149,7 @@ def observe(snapshot: State[Context, AppEvent, Output]) -> None:
 
 service.subscribe(observe)
 
-async_service = interpret_async(machine)
+async_service = interpret_async(machine, inspect=inspect_trace)
 assert_type(async_service, AsyncInterpreter[Context, AppEvent, Output])
 
 
@@ -135,7 +160,7 @@ async def use_async() -> None:
     )
 
 
-machine_actor = create_actor(machine)
+machine_actor = create_actor(machine, inspect=inspect_trace)
 assert_type(
     machine_actor,
     Actor[EventInput[AppEvent], State[Context, AppEvent, Output], Output],


### PR DESCRIPTION
## Summary

Add bounded run-to-completion execution, immutable typed microstep traces, and fail-open inspection callbacks for machine runtimes.

## Rationale

Stable XState v5 exposes public microstep utilities and a `maxIterations` guard for non-settling machines. Python already had a W3C-style macrostep loop, but callers could only observe the final snapshot and an eventless or raised-event cycle could run without a configured bound.

This PR keeps transition calculation pure. It records portable summaries at each settled microstep, resolves public snapshots at the machine boundary, and leaves action execution with interpreters and actors.

## Scope

- Add frozen `TransitionTrace`, `MicrostepTrace`, and `MacrostepTrace` records with defaulted generics.
- Add `get_microsteps(machine, snapshot, event)` and `get_initial_microsteps(machine)`.
- Record external, eventless, raised, and ignored internal events in execution order.
- Keep only each microstep's actions on its intermediate snapshot while preserving all ordered macrostep actions on `Machine.transition` results.
- Add `MachineOptionsConfig` and support JSON `options.maxIterations`.
- Add `Machine(..., max_iterations=N)` with non-`None` keyword precedence.
- Reject Boolean, negative, and non-integer limits with `InvalidConfigError`.
- Raise `InfiniteLoopError` before the first enabled microstep over the limit.
- Keep interpreter snapshots transactional when pure execution fails.
- Add typed `inspect` callbacks to sync and async interpreters and machine-backed actors.
- Invoke inspectors after snapshot installation and before actions and ordinary subscribers.
- Warn and continue when an inspector raises.
- Document the bounded execution and local inspection APIs.

## Trace boundary

Transition summaries expose only event type, source ID, and ordered target IDs. Public trace records do not expose internal `Transition` objects, a mutable configuration set, or the internal queue. Intermediate state containers retain the existing immutable public configuration and action boundaries.

## Non-scope

- Promise, callback, observable, actor-system topology, or remote inspection.
- The `@statelyai/inspect` wire protocol.
- Explicit runtime effect descriptors or durable execution.
- Snapshot schema versioning or migrations.
- Runtime schema validation.
- Version changes, publication, or new conformance claims.

## Validation

Local Python 3.14:

- `poetry run python -m pytest tests/ --ignore=tests/test_scxml.py`: 480 passed.
- `poetry run python -m pytest tests/test_scxml.py`: 57 passed.
- `poetry run mypy src/xstate/`: passed.
- `poetry run mypy --strict src/xstate/algorithm.py`: passed.
- Positive and negative strict-mypy consumer fixtures: passed.
- Ruff format and lint checks: passed.
- `poetry check --lock`: passed.
- `poetry build`: passed.
- `poetry run python scripts/validate_distribution.py`: installed-wheel smoke passed.

Hosted exact head `1b1106d9385d99af61d7bdbecb6fa84b069b3e73`:

- Python 3.13 test job: passed.
- Python 3.14 test job: passed.
- SCXML smoke job: passed.
- Python 3.14 code-quality job: passed.

## Risks and rollback

The highest-risk area is the macrostep loop because tracing and the iteration counter observe every enabled microstep. Regression coverage locks FIFO internal events, ignored-event records, action accumulation, limit timing, final output, and existing SCXML behavior. Inspectors are fail-open and do not participate in transition calculation.

There is additional allocation when a macrostep captures intermediate immutable records. No persisted format or external dependency changes. Rollback is a revert of this PR after reverting or retargeting PR 3.

## Review focus

- Limit accounting immediately before enabled microstep execution.
- Empty trace records for ignored external and internal events.
- Per-microstep context, history, output, and action capture.
- Inspector ordering relative to state installation, effects, and subscribers.
- Generic inference for trace helpers and callbacks.

## Stack and merge order

This is PR 2 of 3. PR 1 has merged, so this PR now targets `master`. Merge it before `actor-ref-boundary`.
