### PR TITLE
Add structural ActorRef boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,11 @@ Actor helpers exported from `xstate` include:
 - `to_promise(actor)`
 - `send_parent(event)` and `send_to(actor_id, event)`
 
+Use `ActorRef[SendEventT, SnapshotT]` for consumer-only send, snapshot, and
+subscription boundaries. Concrete `Actor` values retain lifecycle and spawn
+methods, while `to_promise` also accepts references with a compatible
+`CompletionSnapshot[OutputT]`.
+
 ## `setup()` And Handler Signatures
 
 `setup(...)` mirrors XState v5's named implementation style and creates machines

--- a/docs/concepts/actors.md
+++ b/docs/concepts/actors.md
@@ -34,6 +34,24 @@ subscription.unsubscribe()
 The actor owns its interpreter and timers. Call `stop()` when its lifecycle is
 not already owned by a parent actor.
 
+Consumers that only send, read, and subscribe can depend on the structural
+`ActorRef[SendEventT, SnapshotT]` protocol. Concrete `Actor` values still own
+`start()`, `stop()`, and `spawn()`:
+
+```python
+from xstate import ActorRef, State
+
+
+def observe(ref: ActorRef[str, State]) -> None:
+    ref.subscribe(lambda snapshot: print(snapshot.value))
+    ref.send("START")
+```
+
+`ActorSystem.get()`, public parent references, and public child mappings return
+widened `ActorRef[Any, Any]` values because an actor system can contain
+heterogeneous logic. `create_actor()` and `spawn()` still return precise
+concrete `Actor` types when their logic is known.
+
 ## Invoked Actors
 
 An `invoke` declaration starts child logic while its state is active:
@@ -80,6 +98,10 @@ logic can produce `snapshot.invoke.<id>`.
 Promise input is resolved from `invoke.input` before the child starts. A
 resolved value completes the actor; an exception moves its snapshot to error
 and drives the parent's `onError` transition.
+
+`to_promise()` accepts concrete actors and structural actor references whose
+snapshots satisfy `CompletionSnapshot[OutputT]`. Output inference remains
+precise for both forms.
 
 See [fetch with retry](../examples/fetch_with_retry.py) for invoked promise
 logic, context assignment, guarded retry, and deterministic backoff.

--- a/docs/concepts/typing.md
+++ b/docs/concepts/typing.md
@@ -74,7 +74,7 @@ at runtime.
 ## Setup and interpreters
 
 ```python
-from typing import assert_type
+from typing import Any, assert_type
 
 from xstate import AsyncInterpreter, Interpreter, MachineSetup, interpret, interpret_async, setup
 
@@ -104,9 +104,17 @@ Subscriptions receive the same typed `State`, so a listener can be declared as
 
 ```python
 import asyncio
-from typing import assert_type
+from typing import Any, assert_type
 
-from xstate import Actor, ActorSnapshot, EventInput, create_actor, from_promise, to_promise
+from xstate import (
+    Actor,
+    ActorRef,
+    ActorSnapshot,
+    EventInput,
+    create_actor,
+    from_promise,
+    to_promise,
+)
 
 machine_actor = create_actor(machine)
 assert_type(
@@ -126,11 +134,13 @@ def calculate(input: int) -> Output:
 promise_actor = create_actor(from_promise(calculate), input=3)
 assert_type(promise_actor, Actor[object, ActorSnapshot[Output], Output])
 assert_type(to_promise(promise_actor), asyncio.Future[Output])
+assert_type(machine_actor.system.get("child"), ActorRef[Any, Any] | None)
 ```
 
 Known machine, promise, callback, and observable logic preserves precise actor
-types. `ActorSystem.get()` is intentionally widened because one system may hold
-heterogeneous actors.
+types. Consumer-only boundaries can accept `ActorRef[SendEventT, SnapshotT]`
+without acquiring lifecycle control. `ActorSystem.get()` is intentionally
+widened because one system may hold heterogeneous actors.
 
 Raw JSON dictionaries, string events, and unparameterized machines remain valid.
 These annotations guide static consumers only; they do not generate code or add

--- a/src/xstate/__init__.py
+++ b/src/xstate/__init__.py
@@ -10,12 +10,15 @@ from xstate.action import (  # noqa
 )
 from xstate.actor import (  # noqa
     Actor,
+    ActorRef,
     ActorSnapshot,
     ActorSystem,
     CallbackHandler,
     CallbackLogic,
+    CompletionSnapshot,
     ObservableLogic,
     PromiseLogic,
+    SubscriptionProtocol,
     create_actor,
     from_callback,
     from_observable,
@@ -92,7 +95,10 @@ __all__ = [
     # Actor model (v5)
     "create_actor",
     "Actor",
+    "ActorRef",
     "ActorSnapshot",
+    "CompletionSnapshot",
+    "SubscriptionProtocol",
     "ActorSystem",
     "PromiseLogic",
     "CallbackLogic",

--- a/src/xstate/actor.py
+++ b/src/xstate/actor.py
@@ -42,7 +42,7 @@ import asyncio
 import inspect
 import threading
 from collections.abc import AsyncIterable, Awaitable, Callable
-from typing import Any, Literal, Protocol, cast, overload
+from typing import Any, Literal, Protocol, cast, overload, runtime_checkable
 
 from xstate.event import Event, EventInput
 from xstate.interpreter import NOT_STARTED, RUNNING, STOPPED, Interpreter, Subscription
@@ -56,8 +56,10 @@ __all__ = [
     "CallbackLogic",
     "ObservableLogic",
     "ActorSnapshot",
+    "CompletionSnapshot",
     "ActorSystem",
     "Actor",
+    "ActorRef",
     "ActorLogic",
     "ActorSnapshotValue",
     "SubscriptionProtocol",
@@ -72,6 +74,35 @@ __all__ = [
 
 class SubscriptionProtocol(Protocol):
     def unsubscribe(self) -> None: ...
+
+
+@runtime_checkable
+class ActorRef[SendEventT = Any, SnapshotT = Any](Protocol):
+    """Consumer-facing structural reference to actor capabilities."""
+
+    @property
+    def id(self) -> str: ...
+
+    def send(self, event: SendEventT) -> SnapshotT: ...
+
+    def get_snapshot(self) -> SnapshotT: ...
+
+    def subscribe(
+        self, listener: Callable[[SnapshotT], None]
+    ) -> SubscriptionProtocol: ...
+
+
+class CompletionSnapshot[OutputT = Any](Protocol):
+    """Structural snapshot contract consumed by :func:`to_promise`."""
+
+    @property
+    def status(self) -> Literal["active", "done", "error"]: ...
+
+    @property
+    def output(self) -> OutputT | None: ...
+
+    @property
+    def error(self) -> Any | None: ...
 
 
 # ---------------------------------------------------------------------------
@@ -609,7 +640,7 @@ class ActorSystem:
             if self._actors.get(actor_id) is actor:
                 del self._actors[actor_id]
 
-    def get(self, actor_id: str) -> Actor[Any, Any, Any] | None:
+    def get(self, actor_id: str) -> ActorRef[Any, Any] | None:
         """Return the actor registered under *actor_id*, or ``None``."""
         with self._lock:
             return self._actors.get(actor_id)
@@ -664,12 +695,15 @@ class Actor[SendEventT = Any, SnapshotT = Any, OutputT = Any]:
         return self._system
 
     @property
-    def parent(self) -> Actor[Any, Any, Any] | None:
+    def parent(self) -> ActorRef[Any, Any] | None:
         return self._parent
 
     @property
-    def children(self) -> dict[str, Actor[Any, Any, Any]]:
-        return dict(self._children)
+    def children(self) -> dict[str, ActorRef[Any, Any]]:
+        return {
+            actor_id: cast(ActorRef[Any, Any], actor)
+            for actor_id, actor in self._children.items()
+        }
 
     # -- lifecycle ----------------------------------------------------------
 
@@ -1033,9 +1067,21 @@ def create_actor(
     )
 
 
+@overload
 def to_promise[OutputT](
     actor: Actor[Any, Any, OutputT],
-) -> asyncio.Future[OutputT]:
+) -> asyncio.Future[OutputT]: ...
+
+
+@overload
+def to_promise[OutputT](
+    actor: ActorRef[Any, CompletionSnapshot[OutputT]],
+) -> asyncio.Future[OutputT]: ...
+
+
+def to_promise(
+    actor: ActorRef[Any, Any],
+) -> asyncio.Future[Any]:
     """Adapt *actor* to an :class:`asyncio.Future` (XState v5 ``toPromise``).
 
     The future resolves with the actor's ``output`` when its snapshot reaches
@@ -1052,14 +1098,14 @@ def to_promise[OutputT](
             "async context, e.g. within asyncio.run(...)."
         ) from None
 
-    future: asyncio.Future[OutputT] = loop.create_future()
+    future: asyncio.Future[Any] = loop.create_future()
 
     def _settle(snapshot: Any) -> None:
         if future.done():
             return
         status = getattr(snapshot, "status", None)
         if status == "done":
-            future.set_result(cast(OutputT, getattr(snapshot, "output", None)))
+            future.set_result(getattr(snapshot, "output", None))
         elif status == "error":
             error = getattr(snapshot, "error", None)
             future.set_exception(

--- a/src/xstate/interpreter.py
+++ b/src/xstate/interpreter.py
@@ -30,7 +30,7 @@ import threading
 import warnings
 from collections import deque
 from collections.abc import Callable
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from xstate.action import CANCEL_TYPE, SEND_PARENT_TYPE, SEND_TO_TYPE, SEND_TYPE, Action
 from xstate.event import Event, EventInput, RuntimeEventPayload
@@ -39,6 +39,9 @@ from xstate.machine import Machine
 from xstate.scheduler import Clock, ThreadClock
 from xstate.state import State
 from xstate.trace import MacrostepTrace
+
+if TYPE_CHECKING:
+    from xstate.actor import ActorRef
 
 __all__ = [
     "NOT_STARTED",
@@ -334,7 +337,7 @@ class Interpreter[ContextT = Any, EventDataT = Any, OutputT = Any]:
             return
         self._deliver_external(target, action)
 
-    def _deliver_external(self, target: Any, action: Action) -> None:
+    def _deliver_external(self, target: ActorRef[Any, Any], action: Action) -> None:
         """Deliver an event to another actor, immediately or after a delay."""
         event = action.data.get("event")
         delay = action.data.get("delay")

--- a/tests/test_actor_ref.py
+++ b/tests/test_actor_ref.py
@@ -1,0 +1,39 @@
+"""Structural actor reference boundary tests."""
+
+from xstate import ActorRef, ActorSnapshot, SubscriptionProtocol, to_promise
+
+
+class _Subscription:
+    def __init__(self):
+        self.unsubscribed = False
+
+    def unsubscribe(self) -> None:
+        self.unsubscribed = True
+
+
+class _ActorRefDouble:
+    id = "double"
+
+    def __init__(self):
+        self.snapshot = ActorSnapshot("done", output=42)
+
+    def send(self, event: str) -> ActorSnapshot[int]:
+        _ = event
+        return self.snapshot
+
+    def get_snapshot(self) -> ActorSnapshot[int]:
+        return self.snapshot
+
+    def subscribe(self, listener) -> SubscriptionProtocol:
+        listener(self.snapshot)
+        return _Subscription()
+
+
+def test_structural_double_satisfies_actor_ref_at_runtime():
+    assert isinstance(_ActorRefDouble(), ActorRef)
+
+
+async def test_to_promise_accepts_structural_actor_ref():
+    actor_ref: ActorRef[str, ActorSnapshot[int]] = _ActorRefDouble()
+
+    assert await to_promise(actor_ref) == 42

--- a/tests/test_typing_contract.py
+++ b/tests/test_typing_contract.py
@@ -50,5 +50,7 @@ def test_invalid_typing_contracts_are_rejected() -> None:
         'Argument "max_iterations" to "Machine"',
         'Argument "inspect" to "interpret"',
         'variable has type "State[str, IncrementEvent, Output]"',
+        'TypedDict item "type" has type "Literal[\'INCREMENT\']"',
+        'variable has type "ActorSnapshot[Output',
     ):
         assert expected in output

--- a/tests/typing/negative.py
+++ b/tests/typing/negative.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import Literal, TypedDict
 
 from xstate import (
+    ActorRef,
+    ActorSnapshot,
     Event,
     GuardHandler,
     HandlerArgs,
@@ -11,6 +13,7 @@ from xstate import (
     MacrostepTrace,
     OutputHandler,
     State,
+    create_actor,
     interpret,
 )
 
@@ -74,3 +77,12 @@ def valid_inspector(
 ) -> None:
     bad_snapshot: State[str, IncrementEvent, Output] = trace.snapshot  # invalid-trace
     _ = bad_snapshot
+
+
+actor_ref: ActorRef[IncrementEvent, State[Context, IncrementEvent, Output]] = (
+    create_actor(machine)
+)
+actor_ref.send({"type": "OTHER", "by": 1})  # invalid-actor-ref-send
+wrong_ref_snapshot: ActorSnapshot[Output] = (  # invalid-actor-ref-snapshot
+    actor_ref.get_snapshot()
+)

--- a/tests/typing/positive.py
+++ b/tests/typing/positive.py
@@ -7,9 +7,11 @@ from typing import Any, Literal, TypedDict, assert_type
 from xstate import (
     ActionHandler,
     Actor,
+    ActorRef,
     ActorSnapshot,
     AssignmentHandler,
     AsyncInterpreter,
+    CompletionSnapshot,
     ContextAdapter,
     DeepCopyContextAdapter,
     DelayHandler,
@@ -27,6 +29,7 @@ from xstate import (
     MicrostepTrace,
     OutputHandler,
     State,
+    SubscriptionProtocol,
     TransitionTrace,
     create_actor,
     from_callback,
@@ -167,7 +170,12 @@ assert_type(
 )
 assert_type(machine_actor.get_snapshot(), State[Context, AppEvent, Output])
 machine_actor.subscribe(observe)
-assert_type(machine_actor.system.get("child"), Actor[Any, Any, Any] | None)
+assert_type(machine_actor.parent, ActorRef[Any, Any] | None)
+assert_type(machine_actor.children, dict[str, ActorRef[Any, Any]])
+assert_type(machine_actor.system.get("child"), ActorRef[Any, Any] | None)
+machine_ref: ActorRef[EventInput[AppEvent], State[Context, AppEvent, Output]] = (
+    machine_actor
+)
 
 
 def promise(input: int) -> Output:
@@ -177,8 +185,42 @@ def promise(input: int) -> Output:
 promise_actor = create_actor(from_promise(promise), input=2)
 assert_type(promise_actor, Actor[object, ActorSnapshot[Output], Output])
 assert_type(to_promise(promise_actor), asyncio.Future[Output])
+promise_ref: ActorRef[object, ActorSnapshot[Output]] = promise_actor
+assert_type(to_promise(promise_ref), asyncio.Future[Output])
 spawned_promise = machine_actor.spawn(from_promise(promise), input=3)
 assert_type(spawned_promise, Actor[object, ActorSnapshot[Output], Output])
+
+
+class RefSubscription:
+    def unsubscribe(self) -> None:
+        return None
+
+
+class StructuralRef:
+    id = "structural"
+
+    def __init__(self) -> None:
+        self.snapshot: CompletionSnapshot[Output] = ActorSnapshot[Output](
+            "done", output={"total": 2}
+        )
+
+    def send(self, event: object) -> CompletionSnapshot[Output]:
+        _ = event
+        return self.snapshot
+
+    def get_snapshot(self) -> CompletionSnapshot[Output]:
+        return self.snapshot
+
+    def subscribe(
+        self,
+        listener: Callable[[CompletionSnapshot[Output]], None],
+    ) -> SubscriptionProtocol:
+        listener(self.snapshot)
+        return RefSubscription()
+
+
+structural_ref: ActorRef[object, CompletionSnapshot[Output]] = StructuralRef()
+assert_type(to_promise(structural_ref), asyncio.Future[Output])
 
 
 async def values(input: int) -> AsyncIterable[int]:


### PR DESCRIPTION
## Summary

Separate the consumer-facing actor reference contract from the concrete actor lifecycle while preserving precise types for actors created from known logic.

## Rationale

XState v5 and the v6 architecture research distinguish what an actor consumer may do from what the concrete runtime owns. Python benefits from the same boundary through structural protocols: application code can depend on send, snapshot, and subscription capabilities without receiving start, stop, spawn, or backend details.

This is a typing and interface boundary. Runtime actors, mailboxes, invocation reconciliation, and lifecycle behavior remain unchanged.

## Scope

- Add defaulted `ActorRef[SendEventT, SnapshotT]` as a runtime-checkable structural protocol.
- Keep `Actor.send()` returning the current snapshot for backward compatibility.
- Keep concrete `Actor[SendEventT, SnapshotT, OutputT]` lifecycle and spawn methods.
- Widen `ActorSystem.get()` to `ActorRef[Any, Any] | None` for heterogeneous lookup.
- Widen public parent references and child mappings to `ActorRef`.
- Type interpreter messaging targets as actor references.
- Keep `create_actor()` and `spawn()` return types as precise concrete actors for known machine, promise, callback, and observable logic.
- Add structural `CompletionSnapshot[OutputT]` for completion-capable snapshots.
- Overload `to_promise()` for concrete actors and compatible actor references while preserving output inference.
- Export `ActorRef`, `CompletionSnapshot`, and `SubscriptionProtocol` from `xstate`.
- Document lifecycle ownership and consumer-only actor boundaries.

## Compatibility

Existing actor construction, start, stop, send, subscribe, get_snapshot, state, spawn, invoke, parent-child ownership, and system registration behavior is unchanged. Raw and unparameterized consumers remain `Any` compatible. Known logic still returns concrete `Actor` values, so this PR does not remove lifecycle methods from existing call sites.

## Non-scope

- Remote transports, actor proxies, or location transparency.
- Durable addresses, incarnation identifiers, or persistence changes.
- Runtime message or snapshot validation.
- Actor-system topology inspection.
- Changes to invocation or mailbox semantics.
- Version changes or publication.

## Validation

Local Python 3.14 on exact head `9072aed`:

- `poetry run python -m pytest tests/ --ignore=tests/test_scxml.py`: 482 passed.
- `poetry run python -m pytest tests/test_scxml.py`: 57 passed.
- `poetry run mypy src/xstate/`: passed.
- `poetry run mypy --strict src/xstate/algorithm.py`: passed.
- Positive and negative strict-mypy consumer fixtures: passed.
- Ruff format and lint checks: passed.
- `poetry check --lock`: passed.
- `poetry build`: passed.
- `poetry run python scripts/validate_distribution.py`: installed-wheel smoke passed.

Hosted exact head `9072aedfe6c9a4003fe6ff4cebfcf13c4d4357bd`:

- Python 3.13 test job: passed.
- Python 3.14 test job: passed.
- SCXML smoke job: passed.
- Python 3.14 code-quality job: passed.

## Risks and rollback

The main risk is variance or overload behavior widening too much or rejecting valid structural implementations. Strict-mypy fixtures cover invalid sends and snapshots, concrete actor precision, widened system lookup, and `to_promise` inference through both concrete actors and actor references. Runtime tests cover structural protocol recognition and completion.

Rollback is a revert of this PR. It changes no persisted data, dependency, runtime effect order, or public lifecycle behavior.

## Review focus

- The minimal capability set on `ActorRef`.
- The intentional difference between precise creation and widened heterogeneous lookup.
- Public versus internal parent and child ownership types.
- `CompletionSnapshot` structural compatibility and `to_promise` inference.
- Backward compatibility of concrete `Actor.send()` and lifecycle methods.

## Stack and merge order

This is PR 3 of 3. PR 1 and PR 2 have merged, so this PR now targets `master` and is the final layer in the stack.
