### PR TITLE
Complete the 0.7.1 changelog audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,36 @@
 
 All notable changes to this project will be documented here.
 
-## 0.7.1 - 2026-08-21
+## 0.7.1 - Unreleased
 
 ### Added
 
-- Vendored the configured 56-case SCXML Test Framework fixture subset under
-  `tests/fixtures/scxml/`, including upstream provenance, license custody, and
-  an exact-inventory test.
+- Added generic typing across machine configuration, handlers, events,
+  snapshots, sync and async interpreters, actor logic, setup, and persistence
+  APIs while retaining unparameterized `Machine(config, ...)`, raw JSON data,
+  string events, and legacy handler compatibility.
+- Added XState v5 event descriptor selection for exact event names, partial
+  wildcards ending in `.*`, and the `*` catch-all, with exact and
+  longest-prefix candidates taking precedence while preserving guarded
+  fallthrough.
+- Added XState v5 transition target paths for sibling descendants and
+  dot-prefixed children, including multi-target arrays, while retaining
+  `#id` targets.
+- Added optional macrostep bounds through `max_iterations` and portable
+  `options.maxIterations` configuration. Exceeding the bound raises
+  `InfiniteLoopError` before another microstep runs, and interpreters retain
+  their last committed snapshot.
+- Added immutable `TransitionTrace`, `MicrostepTrace`, and `MacrostepTrace`
+  records, `get_initial_microsteps(...)` and `get_microsteps(...)` helpers, and
+  local inspection callbacks for sync and async interpreters and
+  machine-backed actors. This inspection surface does not implement the
+  `@statelyai/inspect` wire protocol.
+- Added the runtime-checkable structural `ActorRef` boundary, plus
+  `CompletionSnapshot` and `SubscriptionProtocol` typing contracts;
+  `to_promise(...)` now accepts compatible structural actor references.
+- Vendored the SCXML Test Framework fixtures exercised by the configured suite
+  under `tests/fixtures/scxml/`, including upstream provenance, license
+  custody, and an exact-inventory test.
 - Added the fixture-proven SCXML integer-data subset: non-negative integer
   initialization, same-variable `+ 1` assignment, and strict integer equality
   guards.
@@ -18,10 +41,16 @@ All notable changes to this project will be documented here.
 - Removed the SCXML fixture submodule so local, CI, and release validation use
   the same repository-owned test inputs without a separate checkout step.
 - Expanded the enabled `more-parallel` conformance subset from 13 to 15 cases;
-  the configured suite now covers 56 cases.
+  the configured suite now reports 57 passing cases.
+- Changed public actor-system lookup, parent, and child references to widened
+  `ActorRef` values while keeping `create_actor(...)` and `spawn(...)` return
+  types precise when actor logic is known.
 
 ### Fixed
 
+- Corrected macrostep ordering so state exits, transition actions, and state
+  entries execute in SCXML order while one FIFO internal queue carries raised
+  events across eventless and internal-event microsteps.
 - Corrected atomic self-transition handling inside parallel states so the
   source branch exits and re-enters without cycling active sibling regions.
 

--- a/tests/test_actor_ref.py
+++ b/tests/test_actor_ref.py
@@ -1,10 +1,12 @@
 """Structural actor reference boundary tests."""
 
+from collections.abc import Callable
+
 from xstate import ActorRef, ActorSnapshot, SubscriptionProtocol, to_promise
 
 
 class _Subscription:
-    def __init__(self):
+    def __init__(self) -> None:
         self.unsubscribed = False
 
     def unsubscribe(self) -> None:
@@ -14,8 +16,8 @@ class _Subscription:
 class _ActorRefDouble:
     id = "double"
 
-    def __init__(self):
-        self.snapshot = ActorSnapshot("done", output=42)
+    def __init__(self) -> None:
+        self.snapshot: ActorSnapshot[int] = ActorSnapshot("done", output=42)
 
     def send(self, event: str) -> ActorSnapshot[int]:
         _ = event
@@ -24,16 +26,18 @@ class _ActorRefDouble:
     def get_snapshot(self) -> ActorSnapshot[int]:
         return self.snapshot
 
-    def subscribe(self, listener) -> SubscriptionProtocol:
+    def subscribe(
+        self, listener: Callable[[ActorSnapshot[int]], None]
+    ) -> SubscriptionProtocol:
         listener(self.snapshot)
         return _Subscription()
 
 
-def test_structural_double_satisfies_actor_ref_at_runtime():
+def test_structural_double_satisfies_actor_ref_at_runtime() -> None:
     assert isinstance(_ActorRefDouble(), ActorRef)
 
 
-async def test_to_promise_accepts_structural_actor_ref():
+async def test_to_promise_accepts_structural_actor_ref() -> None:
     actor_ref: ActorRef[str, ActorSnapshot[int]] = _ActorRefDouble()
 
     assert await to_promise(actor_ref) == 42


### PR DESCRIPTION
## Rationale

The 0.7.1 changelog was dated before the latest merged work even though the
repository has no published 0.7.1 release. It also reported 56 configured SCXML
cases instead of the current 57 and omitted the merged SCXML macrostep ordering
and public generic typing work.

The ActorRef structural boundary test exercised runtime behavior but did not
pass strict MyPy because its test double, listener, constructors, and test
functions lacked annotations.

## Scope

- Mark 0.7.1 as unreleased.
- Document the merged public generic typing, XState v5 event descriptor and
  target path behavior, bounded macrostep execution, immutable microstep
  traces, local inspection callbacks, ActorRef boundary, and SCXML macrostep
  ordering.
- Reconcile the configured SCXML result to 57 passing cases.
- Preserve the limits around broader W3C conformance, the local inspection
  callback, package ownership, and publication authorization.
- Add strict annotations to the ActorRef structural test double and tests.

## Non-scope

- No runtime statechart or actor behavior changes.
- No claim of full W3C SCXML conformance.
- No claim of compatibility with the Stately inspection wire protocol.
- No tag, GitHub Release, PyPI publication, package ownership change, or
  publication authorization.

## Validation

- Focused behavior and typing-contract suite: 68 passed.
- Strict MyPy for tests/test_actor_ref.py: no issues found.
- Strict MyPy for src/xstate/algorithm.py and src/xstate/trace.py: no issues
  found.
- Canonical release preflight:
  - Package metadata and lock validation passed.
  - Primary suite: 482 passed.
  - Configured SCXML suite: 57 passed.
  - Ruff format and lint passed.
  - MyPy passed for 23 source files.
  - Source distribution and wheel built successfully.
  - Isolated installed-wheel smoke passed.
- Staged diff and whitespace checks passed.
- Changed files contain ASCII US English only.

## Risks and rollback

Risk is limited to release-note accuracy and stricter test annotations. The
runtime package implementation is unchanged. Rollback is a revert of commit
7e71b69257592e57e8b287b276228d0dd409a1c1.

## Release boundary

This PR validates a 0.7.1 source and wheel candidate. It does not establish
PyPI project ownership, authorize publication, create a tag, or publish a
release.

## Review focus

- Confirm the changelog claims match merged PRs 39 through 43 without claiming
  broader parity.
- Confirm 57 is limited to the configured SCXML suite.
- Confirm local inspection is distinguished from the Stately wire protocol.
- Confirm ActorRef remains a consumer boundary while concrete actor creation
  and spawn return precise Actor types.

## Diff size and merge plan

The change is intentionally limited to one changelog and one focused test file.
It should merge as one squash commit after hosted checks pass for the exact
reviewed head.
