### PR TITLE
Harden runtime correctness and performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ All notable changes to this project will be documented here.
 - Changed public actor-system lookup, parent, and child references to widened
   `ActorRef` values while keeping `create_actor(...)` and `spawn(...)` return
   types precise when actor logic is known.
+- Avoided trace-only context snapshots unless a trace helper or interpreter
+  inspector requests them, and cached transition exit sets during parallel
+  conflict resolution.
+- Changed `ThreadClock` from one thread per timer to one on-demand scheduler
+  thread per clock.
 
 ### Fixed
 
@@ -53,6 +58,15 @@ All notable changes to this project will be documented here.
   events across eventless and internal-event microsteps.
 - Corrected atomic self-transition handling inside parallel states so the
   source branch exits and re-enters without cycling active sibling regions.
+- Prevented actor stop and invocation reconciliation from leaving a running
+  child, and prevented late spawns from remaining registered after parent stop.
+- Made sync and async interpreter stop terminal, made async stop wait for owned
+  timer task cancellation to settle, and skipped later runtime actions after a
+  concurrent stop.
+- Made serialized snapshot value, context, and output data independent from the
+  live snapshot, added explicit custom context codecs, and kept the immutable
+  configuration authoritative if a caller mutates the derived state value.
+- Completed strict generic annotations across all 23 source files.
 
 ## 0.7.0 - 2026-07-02
 

--- a/docs/concepts/actors.md
+++ b/docs/concepts/actors.md
@@ -116,6 +116,8 @@ the next snapshot.
 
 Actor IDs must be unique within a system. A parent owns the lifetime of its
 spawned and invoked children; stopping the parent stops those children as well.
+Calling `spawn()` after the parent has stopped returns a stopped child and does
+not leave that child registered in the actor system.
 
 ## Choosing An Actor Boundary
 

--- a/docs/concepts/persistence.md
+++ b/docs/concepts/persistence.md
@@ -39,6 +39,28 @@ The serialized dictionary contains:
 Context and output must already be JSON-compatible if the payload is sent
 through `json.dumps()`.
 
+The returned dictionary owns independent copies of the snapshot value, context,
+and output. Mutating the serialized payload does not mutate the live snapshot.
+
+Use the optional context codec callbacks when an application context is not
+directly JSON-compatible. For example, an immutable dataclass context can be
+encoded and restored explicitly:
+
+```python
+from dataclasses import asdict
+
+data = serialize_snapshot(snapshot, context_serializer=asdict)
+restored = deserialize_snapshot(
+    machine,
+    data,
+    context_deserializer=lambda value: AppContext(**value),
+)
+```
+
+Without a codec, the deserializer passes the stored context through the
+machine's configured `ContextAdapter`. A codec is the application boundary for
+validating and reconstructing custom context types.
+
 ## Compatibility Boundary
 
 Restore only into the same machine definition, or a definition whose active

--- a/docs/concepts/runtimes.md
+++ b/docs/concepts/runtimes.md
@@ -30,8 +30,10 @@ Calls to `send()` are serialized. An event sent while another event is being
 processed is queued until the active macrostep completes. This preserves
 run-to-completion even when an action sends another event.
 
-The default `ThreadClock` schedules real timers. Tests and deterministic tools
-should inject `SimulatedClock` and advance it explicitly:
+The default `ThreadClock` schedules all timers for one clock on a single
+on-demand daemon worker. The worker exits after the last timer fires or is
+canceled. Tests and deterministic tools should inject `SimulatedClock` and
+advance it explicitly:
 
 ```python
 from xstate import SimulatedClock, interpret
@@ -42,7 +44,8 @@ clock.increment(1_000)
 ```
 
 Stopping an interpreter cancels its active `after` timers and delayed sends,
-clears listeners, and drops later events.
+clears listeners, and drops later events. A stopped interpreter does not
+restart; create a new interpreter to run the machine again.
 
 ## Async Interpreter
 
@@ -64,6 +67,11 @@ async work from actions rather than subscription callbacks.
 
 Async `after` transitions use the running event loop. The pure transition and
 guard layer remains synchronous.
+
+`await service.stop()` cancels and waits for interpreter-owned timer tasks to
+settle before returning. An action that is already awaiting may finish in its
+caller's send task, but later runtime actions from that macrostep are skipped.
+The interpreter does not wait for application tasks created outside it.
 
 See [async workflow](../examples/async_workflow.py) for a complete program.
 
@@ -101,6 +109,9 @@ for step in steps:
 Each intermediate snapshot contains only that microstep's actions. The normal
 `Machine.transition` result still contains every macrostep action in execution
 order. Ignored events appear with an empty `transitions` tuple.
+
+Normal transitions do not build trace-only context snapshots. Those snapshots
+are collected only when a trace helper or interpreter inspector requests them.
 
 Sync and async interpreters accept an `inspect` callback. It receives one
 `MacrostepTrace` for initialization and one for each external event after the

--- a/src/xstate/actor.py
+++ b/src/xstate/actor.py
@@ -224,7 +224,7 @@ def from_observable(
     return ObservableLogic(fn)
 
 
-def _ensure_future(awaitable: Any) -> asyncio.Task:
+def _ensure_future(awaitable: Any) -> asyncio.Task[Any]:
     """Schedule *awaitable* on the running loop, with a clear error if none.
 
     Async actor logic (coroutine ``from_promise`` / ``from_observable``) can
@@ -417,7 +417,7 @@ class _PromiseBackend(_ListenerBackend):
     def __init__(self, actor: Actor, logic: PromiseLogic, input: Any):
         super().__init__(actor, input)
         self._fn = logic.fn
-        self._task: asyncio.Task | None = None
+        self._task: asyncio.Task[Any] | None = None
 
     def start(self, initial_state: State | None = None) -> None:
         if self._status != NOT_STARTED:
@@ -438,7 +438,7 @@ class _PromiseBackend(_ListenerBackend):
             self._snapshot = ActorSnapshot("done", output=result)
             self._notify()
 
-    def _on_resolved(self, task: asyncio.Task) -> None:
+    def _on_resolved(self, task: asyncio.Task[Any]) -> None:
         if self._status == STOPPED or task.cancelled():
             return
         exc = task.exception()
@@ -507,7 +507,7 @@ class _ObservableBackend(_ListenerBackend):
     def __init__(self, actor: Actor, logic: ObservableLogic, input: Any):
         super().__init__(actor, input)
         self._fn = logic.fn
-        self._task: asyncio.Task | None = None
+        self._task: asyncio.Task[Any] | None = None
 
     def start(self, initial_state: State | None = None) -> None:
         if self._status != NOT_STARTED:
@@ -536,7 +536,7 @@ class _ObservableBackend(_ListenerBackend):
             self._notify()
         return last
 
-    def _on_finished(self, task: asyncio.Task) -> None:
+    def _on_finished(self, task: asyncio.Task[Any]) -> None:
         if self._status == STOPPED or task.cancelled():
             return
         exc = task.exception()
@@ -668,6 +668,8 @@ class Actor[SendEventT = Any, SnapshotT = Any, OutputT = Any]:
         inspect: Callable[[MacrostepTrace], None] | None = None,
     ) -> None:
         self._system = system if system is not None else ActorSystem()
+        self._lifecycle_lock = threading.RLock()
+        self._stopping = False
         with self._system._lock:
             self._id = id if id is not None else self._system._next_id_unlocked()
             self._parent = parent
@@ -700,10 +702,11 @@ class Actor[SendEventT = Any, SnapshotT = Any, OutputT = Any]:
 
     @property
     def children(self) -> dict[str, ActorRef[Any, Any]]:
-        return {
-            actor_id: cast(ActorRef[Any, Any], actor)
-            for actor_id, actor in self._children.items()
-        }
+        with self._lifecycle_lock:
+            return {
+                actor_id: cast(ActorRef[Any, Any], actor)
+                for actor_id, actor in self._children.items()
+            }
 
     # -- lifecycle ----------------------------------------------------------
 
@@ -714,45 +717,59 @@ class Actor[SendEventT = Any, SnapshotT = Any, OutputT = Any]:
     def start(
         self, initial_state: SnapshotT | None = None
     ) -> Actor[SendEventT, SnapshotT, OutputT]:
-        if self._backend.status == STOPPED:
-            # Match XState: a stopped actor does not restart.
+        with self._lifecycle_lock:
+            if self._stopping or self._backend.status == STOPPED:
+                # Match XState: a stopped actor does not restart.
+                return self
+            effective = initial_state if initial_state is not None else self._snapshot
+            self._backend.start(cast(Any, effective))
+            # For machine actors that declare any `invoke:`, reconcile child actors
+            # on every state change (the immediate subscribe call handles the
+            # initial state). Invoke-free machines skip this entirely.
+            if (
+                self._backend.is_machine
+                and getattr(self._backend, "has_invoke", False)
+                and self._invocation_sub is None
+            ):
+                self._invocation_sub = self._backend.subscribe(
+                    lambda _snapshot: self._sync_invocations()
+                )
             return self
-        effective = initial_state if initial_state is not None else self._snapshot
-        self._backend.start(cast(Any, effective))
-        # For machine actors that declare any `invoke:`, reconcile child actors
-        # on every state change (the immediate subscribe call handles the
-        # initial state). Invoke-free machines skip this entirely.
-        if (
-            self._backend.is_machine
-            and getattr(self._backend, "has_invoke", False)
-            and self._invocation_sub is None
-        ):
-            self._invocation_sub = self._backend.subscribe(
-                lambda _snapshot: self._sync_invocations()
-            )
-        return self
 
     def stop(self) -> Actor[SendEventT, SnapshotT, OutputT]:
-        if self._backend.status == STOPPED:
-            return self
-        # Stop children (including invoked ones) before tearing down self.
-        for child in list(self._children.values()):
-            child.stop()
-        self._children.clear()
-        self._invoked.clear()
-        if self._invocation_sub is not None:
-            self._invocation_sub.unsubscribe()
-            self._invocation_sub = None
-        self._backend.stop()
-        if self._parent is not None:
-            self._parent._children.pop(self.id, None)
-        self._system._unregister(self)
+        parent: Actor[Any, Any, Any] | None = None
+        with self._lifecycle_lock:
+            if self._stopping or self._backend.status == STOPPED:
+                return self
+            self._stopping = True
+            try:
+                if self._invocation_sub is not None:
+                    self._invocation_sub.unsubscribe()
+                    self._invocation_sub = None
+                # Stop children (including invoked ones) before tearing down self.
+                for child in list(self._children.values()):
+                    child.stop()
+                self._children.clear()
+                self._invoked.clear()
+                self._backend.stop()
+                parent = self._parent
+                self._system._unregister(self)
+            finally:
+                self._stopping = False
+        # Do not hold this actor's lock while acquiring its parent's lock. A
+        # concurrent parent stop acquires those locks in the opposite order.
+        if parent is not None:
+            with parent._lifecycle_lock:
+                parent._children.pop(self.id, None)
         return self
 
     # -- messaging ----------------------------------------------------------
 
     def send(self, event: SendEventT) -> SnapshotT:
         """Deliver *event* to this actor (run-to-completion for machines)."""
+        with self._lifecycle_lock:
+            if self._stopping or self._backend.status == STOPPED:
+                return self.get_snapshot()
         self._backend.send(event)
         return self.get_snapshot()
 
@@ -838,18 +855,22 @@ class Actor[SendEventT = Any, SnapshotT = Any, OutputT = Any]:
         """Create a child actor from *logic* in this actor's system.
 
         The child is registered as a child of this actor and shares the system,
-        but is not started — call :meth:`Actor.start` on the returned actor.
+        but is not started - call :meth:`Actor.start` on the returned actor.
         """
-        child = Actor(
-            logic,
-            id=id,
-            clock=clock if clock is not None else self._clock,
-            system=self._system,
-            parent=self,
-            input=input,
-        )
-        self._children[child.id] = child
-        return child
+        with self._lifecycle_lock:
+            child = Actor(
+                logic,
+                id=id,
+                clock=clock if clock is not None else self._clock,
+                system=self._system,
+                parent=self,
+                input=input,
+            )
+            if self._stopping or self._backend.status == STOPPED:
+                child.stop()
+            else:
+                self._children[child.id] = child
+            return child
 
     # -- invoke reconciliation ----------------------------------------------
 
@@ -862,19 +883,29 @@ class Actor[SendEventT = Any, SnapshotT = Any, OutputT = Any]:
         Runs to a fixed point so that a child resolving synchronously (which can
         transition this actor again) is reconciled within one call.
         """
-        if not self._backend.is_machine or self._syncing:
-            return
-        self._syncing = True
-        try:
-            while self._reconcile_invocations_once():
-                pass
-        finally:
-            self._syncing = False
+        with self._lifecycle_lock:
+            if (
+                not self._backend.is_machine
+                or self._stopping
+                or self._backend.status != RUNNING
+                or self._syncing
+            ):
+                return
+            self._syncing = True
+            try:
+                while (
+                    not self._stopping
+                    and self._backend.status == RUNNING
+                    and self._reconcile_invocations_once()
+                ):
+                    pass
+            finally:
+                self._syncing = False
 
     def _reconcile_invocations_once(self) -> bool:
         backend = cast(_MachineBackend, self._backend)
         configuration = backend.snapshot.configuration
-        wanted: dict[str, dict] = {}
+        wanted: dict[str, dict[str, Any]] = {}
         for node in configuration:
             for invocation in getattr(node, "invoke", []):
                 wanted[invocation["id"]] = invocation

--- a/src/xstate/algorithm.py
+++ b/src/xstate/algorithm.py
@@ -748,25 +748,24 @@ def remove_conflicting_transitions(
     history_value: ReadOnlyHistoryValue,
 ) -> TransitionSequence:
     ordered = sorted(enabled_transitions, key=lambda t: t.order)
+    exit_sets = {
+        transition: frozenset(
+            compute_exit_set(
+                enabled_transitions=[transition],
+                configuration=configuration,
+                history_value=history_value,
+            )
+        )
+        for transition in ordered
+    }
 
     filtered_transitions: TransitionSequence = []
     for t1 in ordered:
         t1_preempted = False
         transitions_to_remove: set[Transition] = set()
-        t1_exit_set = compute_exit_set(
-            enabled_transitions=[t1],
-            configuration=configuration,
-            history_value=history_value,
-        )
+        t1_exit_set = exit_sets[t1]
         for t2 in filtered_transitions:
-            t2_exit_set = compute_exit_set(
-                enabled_transitions=[t2],
-                configuration=configuration,
-                history_value=history_value,
-            )
-            intersection = [value for value in t1_exit_set if value in t2_exit_set]
-
-            if intersection:
+            if not t1_exit_set.isdisjoint(exit_sets[t2]):
                 if is_descendent(t1.source, t2.source):
                     transitions_to_remove.add(t2)
                 else:
@@ -824,6 +823,7 @@ def initial_event_loop[ContextT, OutputT](
     context_snapshot: Callable[[ContextT], ContextT],
     machine_id: str,
     max_iterations: int | None,
+    capture_microsteps: bool = True,
 ) -> MacrostepResult[ContextT, OutputT]:
     init_event: Event[Any] = Event("xstate.init")
     iterations = _consume_iteration(
@@ -842,18 +842,20 @@ def initial_event_loop[ContextT, OutputT](
         event=init_event,
         output=None,
     )
-    microsteps: list[AlgorithmMicrostep[ContextT, OutputT]] = [
-        _capture_algorithm_microstep(
-            event=init_event,
-            transitions=[initial_transition],
-            configuration=configuration,
-            actions=actions,
-            context=context,
-            history_value=history_value,
-            output=output,
-            context_snapshot=context_snapshot,
+    microsteps: list[AlgorithmMicrostep[ContextT, OutputT]] = []
+    if capture_microsteps:
+        microsteps.append(
+            _capture_algorithm_microstep(
+                event=init_event,
+                transitions=[initial_transition],
+                configuration=configuration,
+                actions=actions,
+                context=context,
+                history_value=history_value,
+                output=output,
+                context_snapshot=context_snapshot,
+            )
         )
-    ]
     return main_event_loop2(
         configuration=configuration,
         actions=actions,
@@ -867,6 +869,7 @@ def initial_event_loop[ContextT, OutputT](
         max_iterations=max_iterations,
         iterations=iterations,
         microsteps=microsteps,
+        capture_microsteps=capture_microsteps,
     )
 
 
@@ -879,6 +882,7 @@ def main_event_loop[ContextT](
     context_snapshot: Callable[[ContextT], ContextT],
     machine_id: str,
     max_iterations: int | None,
+    capture_microsteps: bool = True,
 ) -> MacrostepResult[ContextT, Any]:
     enabled_transitions = select_transitions(
         event=event,
@@ -903,18 +907,20 @@ def main_event_loop[ContextT](
         event=event,
         output=None,
     )
-    microsteps: list[AlgorithmMicrostep[ContextT, Any]] = [
-        _capture_algorithm_microstep(
-            event=event,
-            transitions=enabled_transitions,
-            configuration=configuration,
-            actions=actions,
-            context=context,
-            history_value=history_value,
-            output=output,
-            context_snapshot=context_snapshot,
+    microsteps: list[AlgorithmMicrostep[ContextT, Any]] = []
+    if capture_microsteps:
+        microsteps.append(
+            _capture_algorithm_microstep(
+                event=event,
+                transitions=enabled_transitions,
+                configuration=configuration,
+                actions=actions,
+                context=context,
+                history_value=history_value,
+                output=output,
+                context_snapshot=context_snapshot,
+            )
         )
-    ]
     return main_event_loop2(
         configuration=configuration,
         actions=actions,
@@ -928,6 +934,7 @@ def main_event_loop[ContextT](
         max_iterations=max_iterations,
         iterations=iterations,
         microsteps=microsteps,
+        capture_microsteps=capture_microsteps,
     )
 
 
@@ -945,6 +952,7 @@ def main_event_loop2[ContextT, OutputT](
     max_iterations: int | None,
     iterations: int,
     microsteps: list[AlgorithmMicrostep[ContextT, OutputT]],
+    capture_microsteps: bool,
 ) -> MacrostepResult[ContextT, OutputT]:
     enabled_transitions: TransitionSequence = []
     macrostep_done = False
@@ -968,7 +976,7 @@ def main_event_loop2[ContextT, OutputT](
                     context=context,
                     history_value=history_value,
                 )
-                if not enabled_transitions:
+                if not enabled_transitions and capture_microsteps:
                     microsteps.append(
                         _capture_algorithm_microstep(
                             event=internal_event,
@@ -1001,18 +1009,19 @@ def main_event_loop2[ContextT, OutputT](
                 output=output,
             )
             actions.extend(new_actions)
-            microsteps.append(
-                _capture_algorithm_microstep(
-                    event=effective_event,
-                    transitions=enabled_transitions,
-                    configuration=configuration,
-                    actions=new_actions,
-                    context=context,
-                    history_value=history_value,
-                    output=output,
-                    context_snapshot=context_snapshot,
+            if capture_microsteps:
+                microsteps.append(
+                    _capture_algorithm_microstep(
+                        event=effective_event,
+                        transitions=enabled_transitions,
+                        configuration=configuration,
+                        actions=new_actions,
+                        context=context,
+                        history_value=history_value,
+                        output=output,
+                        context_snapshot=context_snapshot,
+                    )
                 )
-            )
 
     return MacrostepResult(configuration, actions, context, output, tuple(microsteps))
 

--- a/src/xstate/async_interpreter.py
+++ b/src/xstate/async_interpreter.py
@@ -102,8 +102,14 @@ class AsyncInterpreter[ContextT = Any, EventDataT = Any, OutputT = Any]:
         ) = None,
     ):
         self.machine = machine
-        self.state, self._initial_trace = machine._initial_transition()
         self._inspector = inspect
+        if inspect is None:
+            self.state = machine.initial_state
+            self._initial_trace: (
+                MacrostepTrace[ContextT, EventDataT, OutputT] | None
+            ) = None
+        else:
+            self.state, self._initial_trace = machine._initial_transition()
         self._status = NOT_STARTED
         self._listeners: set[Callable[[State[ContextT, EventDataT, OutputT]], None]] = (
             set()
@@ -112,9 +118,9 @@ class AsyncInterpreter[ContextT = Any, EventDataT = Any, OutputT = Any]:
         self._processing = False
         self._processing_task: asyncio.Task[Any] | None = None
         # `after`-event name -> asyncio.Task running the delay
-        self._scheduled: dict[str, asyncio.Task] = {}
+        self._scheduled: dict[str, asyncio.Task[Any]] = {}
         # named `send(..., id=...)` (or the Task itself) -> delayed-send Task
-        self._send_timers: dict[Any, asyncio.Task] = {}
+        self._send_timers: dict[Any, asyncio.Task[Any]] = {}
 
     # -- lifecycle ----------------------------------------------------------
 
@@ -130,35 +136,44 @@ class AsyncInterpreter[ContextT = Any, EventDataT = Any, OutputT = Any]:
         self, initial_state: State[ContextT, EventDataT, OutputT] | None = None
     ) -> AsyncInterpreter[ContextT, EventDataT, OutputT]:
         """Start the service. Idempotent while already running."""
-        if self._status == RUNNING:
+        if self._status != NOT_STARTED:
             return self
         if initial_state is not None:
             self.state = initial_state
-            self._initial_trace = MacrostepTrace(
-                event=cast(Event[EventDataT], Event("xstate.init")),
-                previous_snapshot=None,
-                snapshot=initial_state,
-                microsteps=(),
+            self._initial_trace = (
+                MacrostepTrace(
+                    event=cast(Event[EventDataT], Event("xstate.init")),
+                    previous_snapshot=None,
+                    snapshot=initial_state,
+                    microsteps=(),
+                )
+                if self._inspector is not None
+                else None
             )
         self.state.event = Event("xstate.init")
         self._status = RUNNING
         self._sync_delays()
-        self._inspect_trace(self._initial_trace)
+        if self._initial_trace is not None:
+            self._inspect_trace(self._initial_trace)
         await self._execute(self.state)
-        self._notify(self.state)
+        if self._status == RUNNING:
+            self._notify(self.state)
         return self
 
     async def stop(self) -> AsyncInterpreter[ContextT, EventDataT, OutputT]:
         """Stop the service: cancel pending timers and drop all listeners."""
-        for task in self._scheduled.values():
+        tasks = set(self._scheduled.values()) | set(self._send_timers.values())
+        for task in tasks:
             task.cancel()
         self._scheduled.clear()
-        for task in self._send_timers.values():
-            task.cancel()
         self._send_timers.clear()
         self._listeners.clear()
         self._resolve_queued_events(self.state)
         self._status = STOPPED
+        current_task = asyncio.current_task()
+        pending = [task for task in tasks if task is not current_task]
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
         return self
 
     # -- events -------------------------------------------------------------
@@ -219,16 +234,22 @@ class AsyncInterpreter[ContextT = Any, EventDataT = Any, OutputT = Any]:
                 future.exception()
 
     async def _process(self, event: EventInput[EventDataT]) -> None:
-        next_state, trace = self.machine._transition_with_trace(self.state, event)
+        trace: MacrostepTrace[ContextT, EventDataT, OutputT] | None = None
+        if self._inspector is None:
+            next_state = self.machine.transition(self.state, event)
+        else:
+            next_state, trace = self.machine._transition_with_trace(self.state, event)
         next_state.event = cast(
             Event[RuntimeEventPayload[EventDataT, OutputT]],
             self.machine._to_event(event),
         )
         self.state = next_state
         self._sync_delays()
-        self._inspect_trace(trace)
+        if trace is not None:
+            self._inspect_trace(trace)
         await self._execute(next_state)
-        self._notify(next_state)
+        if self._status == RUNNING:
+            self._notify(next_state)
 
     # -- subscriptions ------------------------------------------------------
 
@@ -273,6 +294,8 @@ class AsyncInterpreter[ContextT = Any, EventDataT = Any, OutputT = Any]:
     async def _execute(self, state: State[ContextT, EventDataT, OutputT]) -> None:
         """Run resolved action callables; await any that return a coroutine."""
         for action in state.actions:
+            if self._status != RUNNING:
+                return
             if isinstance(action, Action):
                 action_type = action.type
                 method_name = (

--- a/src/xstate/guards.py
+++ b/src/xstate/guards.py
@@ -65,7 +65,7 @@ class _ComposableGuard:
         guard: Any,
         context: Any,
         event: Any,
-        registry: dict,
+        registry: dict[str, Any],
         state: Any | None = None,
     ) -> bool:
         if isinstance(guard, str):
@@ -89,7 +89,7 @@ class _ComposableGuard:
         self,
         context: Any,
         event: Any,
-        registry: dict,
+        registry: dict[str, Any],
         state: Any | None = None,
     ) -> bool:
         raise NotImplementedError
@@ -118,7 +118,7 @@ class _AndGuard(_ComposableGuard):
         self,
         context: Any,
         event: Any,
-        registry: dict,
+        registry: dict[str, Any],
         state: Any | None = None,
     ) -> bool:
         return all(
@@ -136,7 +136,7 @@ class _OrGuard(_ComposableGuard):
         self,
         context: Any,
         event: Any,
-        registry: dict,
+        registry: dict[str, Any],
         state: Any | None = None,
     ) -> bool:
         return any(
@@ -154,7 +154,7 @@ class _NotGuard(_ComposableGuard):
         self,
         context: Any,
         event: Any,
-        registry: dict,
+        registry: dict[str, Any],
         state: Any | None = None,
     ) -> bool:
         return not self._eval(
@@ -185,7 +185,7 @@ class _StateInGuard(_ComposableGuard):
         self,
         context: Any,
         event: Any,
-        registry: dict,
+        registry: dict[str, Any],
         state: Any | None = None,
     ) -> bool:
         if state is None:

--- a/src/xstate/interpreter.py
+++ b/src/xstate/interpreter.py
@@ -119,8 +119,14 @@ class Interpreter[ContextT = Any, EventDataT = Any, OutputT = Any]:
     ):
         self.machine = machine
         self.clock = clock if clock is not None else ThreadClock()
-        self.state, self._initial_trace = machine._initial_transition()
         self._inspector = inspect
+        if inspect is None:
+            self.state = machine.initial_state
+            self._initial_trace: (
+                MacrostepTrace[ContextT, EventDataT, OutputT] | None
+            ) = None
+        else:
+            self.state, self._initial_trace = machine._initial_transition()
         self._status = NOT_STARTED
         self._lock = threading.RLock()
         self._listeners: set[Callable[[State[ContextT, EventDataT, OutputT]], None]] = (
@@ -151,22 +157,27 @@ class Interpreter[ContextT = Any, EventDataT = Any, OutputT = Any]:
     ) -> Interpreter[ContextT, EventDataT, OutputT]:
         """Start the service.  Idempotent while already running."""
         with self._lock:
-            if self._status == RUNNING:
+            if self._status != NOT_STARTED:
                 return self
             if initial_state is not None:
                 self.state = initial_state
-                self._initial_trace = MacrostepTrace(
-                    event=cast(Event[EventDataT], Event("xstate.init")),
-                    previous_snapshot=None,
-                    snapshot=initial_state,
-                    microsteps=(),
+                self._initial_trace = (
+                    MacrostepTrace(
+                        event=cast(Event[EventDataT], Event("xstate.init")),
+                        previous_snapshot=None,
+                        snapshot=initial_state,
+                        microsteps=(),
+                    )
+                    if self._inspector is not None
+                    else None
                 )
             self.state.event = Event("xstate.init")
             self._status = RUNNING
             self._sync_delays()
             state = self.state
             initial_trace = self._initial_trace
-        self._inspect_trace(initial_trace)
+        if initial_trace is not None:
+            self._inspect_trace(initial_trace)
         self._execute(state)
         self._notify(state)
         return self
@@ -226,7 +237,11 @@ class Interpreter[ContextT = Any, EventDataT = Any, OutputT = Any]:
                 return
             state = self.state
 
-        next_state, trace = self.machine._transition_with_trace(state, event)
+        trace: MacrostepTrace[ContextT, EventDataT, OutputT] | None = None
+        if self._inspector is None:
+            next_state = self.machine.transition(state, event)
+        else:
+            next_state, trace = self.machine._transition_with_trace(state, event)
         next_state.event = cast(
             Event[RuntimeEventPayload[EventDataT, OutputT]],
             self.machine._to_event(event),
@@ -238,7 +253,8 @@ class Interpreter[ContextT = Any, EventDataT = Any, OutputT = Any]:
             self.state = next_state
             self._sync_delays()
 
-        self._inspect_trace(trace)
+        if trace is not None:
+            self._inspect_trace(trace)
         self._execute(next_state)
         self._notify(next_state)
 

--- a/src/xstate/machine.py
+++ b/src/xstate/machine.py
@@ -9,7 +9,6 @@ from xstate.action import INTERPRETER_TYPES, Action
 from xstate.algorithm import (
     AlgorithmMicrostep,
     MacrostepResult,
-    get_configuration_from_state,
     initial_event_loop,
     main_event_loop,
 )
@@ -130,7 +129,9 @@ class Machine[ContextT = Any, EventDataT = Any, OutputT = Any]:
         state: State[ContextT, EventDataT, OutputT],
         event: EventInput[EventDataT],
     ) -> State[ContextT, EventDataT, OutputT]:
-        next_state, _trace = self._transition_with_trace(state, event)
+        next_state, _event, _result = self._transition_core(
+            state, event, capture_microsteps=False
+        )
         return next_state
 
     def _transition_with_trace(
@@ -141,10 +142,34 @@ class Machine[ContextT = Any, EventDataT = Any, OutputT = Any]:
         State[ContextT, EventDataT, OutputT],
         MacrostepTrace[ContextT, EventDataT, OutputT],
     ]:
-        event_object = self._to_event(event)
-        configuration = get_configuration_from_state(
-            from_node=self.root, state_value=state.value, partial_configuration=set()
+        next_state, event_object, result = self._transition_core(
+            state, event, capture_microsteps=True
         )
+        trace = MacrostepTrace[ContextT, EventDataT, OutputT](
+            event=event_object,
+            previous_snapshot=state,
+            snapshot=next_state,
+            microsteps=self._build_microstep_traces(result.microsteps),
+        )
+        return next_state, trace
+
+    def _transition_core(
+        self,
+        state: State[ContextT, EventDataT, OutputT],
+        event: EventInput[EventDataT],
+        *,
+        capture_microsteps: bool,
+    ) -> tuple[
+        State[ContextT, EventDataT, OutputT],
+        Event[EventDataT],
+        MacrostepResult[ContextT, Any],
+    ]:
+        event_object = self._to_event(event)
+        configuration = set(state.configuration)
+        if any(node.machine is not self for node in configuration):
+            raise InvalidConfigError(
+                f"State snapshot does not belong to machine '{self.id}'."
+            )
         context = self.context_adapter.snapshot(state.context)
         history_value = {
             state_id: set(states) for state_id, states in state.history_value.items()
@@ -157,6 +182,7 @@ class Machine[ContextT = Any, EventDataT = Any, OutputT = Any]:
             context_snapshot=self.context_adapter.snapshot,
             machine_id=self.id,
             max_iterations=self.max_iterations,
+            capture_microsteps=capture_microsteps,
         )
 
         actions, unknown = self._get_actions(
@@ -171,13 +197,7 @@ class Machine[ContextT = Any, EventDataT = Any, OutputT = Any]:
             history_value=history_value,
             output=result.output,
         )
-        trace = MacrostepTrace[ContextT, EventDataT, OutputT](
-            event=event_object,
-            previous_snapshot=state,
-            snapshot=next_state,
-            microsteps=self._build_microstep_traces(result.microsteps),
-        )
-        return next_state, trace
+        return next_state, event_object, result
 
     def _build_microstep_traces(
         self,
@@ -317,7 +337,7 @@ class Machine[ContextT = Any, EventDataT = Any, OutputT = Any]:
 
     @property
     def initial_state(self) -> State[ContextT, EventDataT, OutputT]:
-        state, _trace = self._initial_transition()
+        state, _event, _result = self._initial_transition_core(capture_microsteps=False)
         return state
 
     def _initial_transition(
@@ -325,6 +345,24 @@ class Machine[ContextT = Any, EventDataT = Any, OutputT = Any]:
     ) -> tuple[
         State[ContextT, EventDataT, OutputT],
         MacrostepTrace[ContextT, EventDataT, OutputT],
+    ]:
+        state, init_event, result = self._initial_transition_core(
+            capture_microsteps=True
+        )
+        trace = MacrostepTrace[ContextT, EventDataT, OutputT](
+            event=init_event,
+            previous_snapshot=None,
+            snapshot=state,
+            microsteps=self._build_microstep_traces(result.microsteps),
+        )
+        return state, trace
+
+    def _initial_transition_core(
+        self, *, capture_microsteps: bool
+    ) -> tuple[
+        State[ContextT, EventDataT, OutputT],
+        Event[EventDataT],
+        MacrostepResult[ContextT, OutputT],
     ]:
         context = self.context_adapter.snapshot(self.context)
         history_value: dict[str, Any] = {}
@@ -335,6 +373,7 @@ class Machine[ContextT = Any, EventDataT = Any, OutputT = Any]:
             context_snapshot=self.context_adapter.snapshot,
             machine_id=self.id,
             max_iterations=self.max_iterations,
+            capture_microsteps=capture_microsteps,
         )
         init_event: Event[EventDataT] = Event("xstate.init")
 
@@ -348,13 +387,7 @@ class Machine[ContextT = Any, EventDataT = Any, OutputT = Any]:
             history_value=history_value,
             output=result.output,
         )
-        trace = MacrostepTrace[ContextT, EventDataT, OutputT](
-            event=init_event,
-            previous_snapshot=None,
-            snapshot=state,
-            microsteps=self._build_microstep_traces(result.microsteps),
-        )
-        return state, trace
+        return state, init_event, result
 
 
 def get_microsteps[ContextT, EventDataT, OutputT](

--- a/src/xstate/scheduler.py
+++ b/src/xstate/scheduler.py
@@ -3,21 +3,29 @@
 The interpreter schedules delayed events through a :class:`Clock`.  Two
 implementations are provided:
 
-* :class:`SimulatedClock` — deterministic, time only advances when the test
+* :class:`SimulatedClock` - deterministic, time only advances when the test
   calls :meth:`SimulatedClock.increment`.  This is the recommended clock for
   tests and mirrors XState's ``SimulatedClock``.
-* :class:`ThreadClock` — real wall-clock time backed by ``threading.Timer``,
-  used by the interpreter by default for production use.
+* :class:`ThreadClock` - real wall-clock time backed by one on-demand scheduler
+  thread, used by the interpreter by default for production use.
 """
 
 from __future__ import annotations
 
 import abc
+import heapq
 import threading
+import time
+import traceback
 from collections.abc import Callable
-from typing import Any, override
+from typing import Any, TypedDict, override
 
 __all__ = ["Clock", "SimulatedClock", "ThreadClock"]
+
+
+class _SimulatedTimeout(TypedDict):
+    due: float
+    fn: Callable[[], Any]
 
 
 class Clock(abc.ABC):
@@ -39,7 +47,7 @@ class SimulatedClock(Clock):
         self._now: float = 0.0
         self._next_id: int = 0
         # timeout_id -> {"due": float, "fn": Callable}
-        self._timeouts: dict[int, dict] = {}
+        self._timeouts: dict[int, _SimulatedTimeout] = {}
 
     @override
     def set_timeout(self, fn: Callable[[], Any], delay_ms: float) -> int:
@@ -58,7 +66,7 @@ class SimulatedClock(Clock):
     def increment(self, ms: float) -> None:
         """Advance time by ``ms`` and fire every timeout that comes due, in order.
 
-        Timeouts scheduled by callbacks fired during this increment are honoured
+        Timeouts scheduled by callbacks fired during this increment are honored
         if they too come due before ``target``, matching real event-loop ordering.
         """
         target = self._now + ms
@@ -75,36 +83,60 @@ class SimulatedClock(Clock):
 
 
 class ThreadClock(Clock):
-    """Real-time clock backed by ``threading.Timer`` (interpreter default)."""
+    """Real-time clock backed by one on-demand scheduler thread."""
 
     def __init__(self) -> None:
-        self._timers: dict[int, threading.Timer] = {}
+        self._timers: dict[int, tuple[float, Callable[[], Any]]] = {}
+        self._heap: list[tuple[float, int]] = []
         self._next_id: int = 0
-        self._lock = threading.Lock()
+        self._condition = threading.Condition()
+        self._worker: threading.Thread | None = None
 
     @override
     def set_timeout(self, fn: Callable[[], Any], delay_ms: float) -> int:
-        with self._lock:
+        due = time.monotonic() + max(delay_ms, 0.0) / 1000.0
+        with self._condition:
             timeout_id = self._next_id
             self._next_id += 1
-
-        def _run() -> None:
-            try:
-                fn()
-            finally:
-                with self._lock:
-                    self._timers.pop(timeout_id, None)
-
-        timer = threading.Timer(delay_ms / 1000.0, _run)
-        timer.daemon = True
-        with self._lock:
-            self._timers[timeout_id] = timer
-        timer.start()
+            self._timers[timeout_id] = (due, fn)
+            heapq.heappush(self._heap, (due, timeout_id))
+            if self._worker is None:
+                self._worker = threading.Thread(
+                    target=self._run,
+                    name="xstate-thread-clock",
+                    daemon=True,
+                )
+                self._worker.start()
+            self._condition.notify()
         return timeout_id
 
     @override
     def clear_timeout(self, timeout_id: int) -> None:
-        with self._lock:
-            timer = self._timers.pop(timeout_id, None)
-        if timer is not None:
-            timer.cancel()
+        with self._condition:
+            self._timers.pop(timeout_id, None)
+            self._condition.notify()
+
+    def _run(self) -> None:
+        while True:
+            callback: Callable[[], Any] | None = None
+            with self._condition:
+                while self._heap:
+                    due, timeout_id = self._heap[0]
+                    timer = self._timers.get(timeout_id)
+                    if timer is None or timer[0] != due:
+                        heapq.heappop(self._heap)
+                        continue
+                    remaining = due - time.monotonic()
+                    if remaining > 0:
+                        self._condition.wait(timeout=remaining)
+                        continue
+                    heapq.heappop(self._heap)
+                    _due, callback = self._timers.pop(timeout_id)
+                    break
+                if callback is None:
+                    self._worker = None
+                    return
+            try:
+                callback()
+            except BaseException:  # noqa: BLE001 - match Timer traceback behavior
+                traceback.print_exc()

--- a/src/xstate/snapshot.py
+++ b/src/xstate/snapshot.py
@@ -29,6 +29,8 @@ Usage::
 
 from __future__ import annotations
 
+import copy
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
@@ -38,30 +40,46 @@ if TYPE_CHECKING:
 
 def serialize_snapshot[ContextT, EventDataT, OutputT](
     snapshot: State[ContextT, EventDataT, OutputT],
+    *,
+    context_serializer: Callable[[ContextT], Any] | None = None,
 ) -> dict[str, Any]:
-    """Serialize *snapshot* to a JSON-compatible dict."""
+    """Serialize *snapshot* to an independent JSON-compatible dictionary.
+
+    ``context_serializer`` converts custom context values, such as dataclasses,
+    before the result is copied into the returned payload.
+    """
     history_value: dict[str, list[str]] = {}
     for hist_node_id, state_nodes in (snapshot.history_value or {}).items():
         history_value[hist_node_id] = sorted(node.id for node in state_nodes)
 
     error = snapshot.error
+    serialized_context = (
+        context_serializer(snapshot.context)
+        if context_serializer is not None
+        else snapshot.context
+    )
     return {
-        "value": snapshot.value,
-        "context": snapshot.context,
+        "value": copy.deepcopy(snapshot.value),
+        "context": copy.deepcopy(serialized_context),
         "status": snapshot.status,
         "history_value": history_value,
-        "output": snapshot.output,
+        "output": copy.deepcopy(snapshot.output),
         "error": repr(error) if error is not None else None,
     }
 
 
 def deserialize_snapshot[ContextT, EventDataT, OutputT](
-    machine: Machine[ContextT, EventDataT, OutputT], data: dict[str, Any]
+    machine: Machine[ContextT, EventDataT, OutputT],
+    data: dict[str, Any],
+    *,
+    context_deserializer: Callable[[Any], ContextT] | None = None,
 ) -> State[ContextT, EventDataT, OutputT]:
     """Reconstruct a :class:`~xstate.state.State` from a serialized dict.
 
     Pass the returned state to ``create_actor(machine, snapshot=...)`` or
     ``actor.start(initial_state=...)`` to resume execution.
+    ``context_deserializer`` reconstructs a custom context value before the
+    machine's context adapter applies its snapshot policy.
     """
     from xstate.state import State
 
@@ -73,9 +91,14 @@ def deserialize_snapshot[ContextT, EventDataT, OutputT](
         if nodes:
             history_value[hist_node_id] = nodes
 
+    raw_context = data.get("context")
+    if context_deserializer is not None:
+        context = context_deserializer(raw_context)
+    else:
+        context = cast(ContextT, raw_context if raw_context is not None else {})
     state = State[ContextT, EventDataT, OutputT](
         configuration=configuration,
-        context=cast(ContextT, dict(data.get("context") or {})),
+        context=machine.context_adapter.snapshot(context),
         history_value=history_value,
     )
     if data.get("status") == "error":

--- a/tests/test_actor_logic.py
+++ b/tests/test_actor_logic.py
@@ -148,6 +148,17 @@ def test_stopping_parent_stops_children():
     assert parent.system.get("kid") is None
 
 
+def test_spawning_after_parent_stop_does_not_leak_child():
+    parent = create_actor(_toggle_machine(), id="parent").start()
+    parent.stop()
+
+    child = parent.spawn(_toggle_machine(), id="late-child")
+
+    assert child.status == "stopped"
+    assert parent.children == {}
+    assert parent.system.get("late-child") is None
+
+
 def test_spawn_into_explicit_shared_system():
     system = ActorSystem()
     parent = create_actor(_toggle_machine(), id="p", system=system).start()

--- a/tests/test_async_interpreter.py
+++ b/tests/test_async_interpreter.py
@@ -72,6 +72,17 @@ async def test_events_dropped_before_start_and_after_stop():
     assert service.state.value == "active"
 
 
+async def test_start_after_stop_does_not_restart_service():
+    service = await interpret_async(_toggle_machine()).start()
+    await service.stop()
+
+    await service.start()
+    await service.send("TOGGLE")
+
+    assert service.status == "stopped"
+    assert service.state.value == "inactive"
+
+
 # ---------------------------------------------------------------------------
 # Awaitable action callables
 # ---------------------------------------------------------------------------
@@ -278,6 +289,65 @@ async def test_stop_cancels_pending_after():
     # Stopped service ignores the fired timer.
     assert service.state.value == "waiting"
     assert service.status == "stopped"
+
+
+async def test_stop_waits_for_owned_timer_tasks_to_finish_cancelling():
+    machine = Machine(
+        {
+            "id": "settled-stop",
+            "initial": "waiting",
+            "states": {
+                "waiting": {"after": {60_000: "fired"}},
+                "fired": {},
+            },
+        }
+    )
+    service = await interpret_async(machine).start()
+    tasks = tuple(service._scheduled.values())
+
+    await service.stop()
+
+    assert tasks
+    assert all(task.done() for task in tasks)
+    assert all(task.cancelled() for task in tasks)
+
+
+async def test_stop_during_action_prevents_later_runtime_actions():
+    action_started = asyncio.Event()
+    release_action = asyncio.Event()
+
+    async def blocking_action():
+        action_started.set()
+        await release_action.wait()
+
+    machine = Machine(
+        {
+            "id": "stop-during-action",
+            "initial": "active",
+            "states": {
+                "active": {
+                    "on": {
+                        "GO": {
+                            "actions": [
+                                blocking_action,
+                                _send("LATE", delay=60_000),
+                            ]
+                        }
+                    }
+                }
+            },
+        }
+    )
+    service = await interpret_async(machine).start()
+    send_task = asyncio.create_task(service.send("GO"))
+    await action_started.wait()
+
+    await service.stop()
+    release_action.set()
+    await send_task
+
+    assert service.status == "stopped"
+    assert service._send_timers == {}
 
 
 async def test_named_delay_resolved_from_machine_delays():

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -366,6 +366,23 @@ def test_thread_clock_clear_nonexistent_is_noop():
     clock.clear_timeout(9999)  # must not raise
 
 
+def test_thread_clock_uses_at_most_one_worker_for_many_timers():
+    clock = ThreadClock()
+    existing_threads = set(threading.enumerate())
+    timeout_ids = [clock.set_timeout(lambda: None, 60_000) for _ in range(20)]
+    worker_threads = tuple(
+        thread for thread in threading.enumerate() if thread not in existing_threads
+    )
+
+    for timeout_id in timeout_ids:
+        clock.clear_timeout(timeout_id)
+    for thread in worker_threads:
+        thread.join(timeout=1.0)
+
+    assert len(worker_threads) <= 1
+    assert all(not thread.is_alive() for thread in worker_threads)
+
+
 # ---------------------------------------------------------------------------
 # state.py — _matches_dict return-False branch
 # ---------------------------------------------------------------------------

--- a/tests/test_interpreter.py
+++ b/tests/test_interpreter.py
@@ -86,6 +86,17 @@ def test_stop_sets_stopped_and_drops_events():
     assert service.state.value == "green"
 
 
+def test_start_after_stop_does_not_restart_service():
+    service = interpret(make_light(), clock=SimulatedClock()).start()
+    service.stop()
+
+    service.start()
+    service.send("TIMER")
+
+    assert service.status == "stopped"
+    assert service.state.value == "green"
+
+
 def test_send_before_start_is_dropped():
     service = interpret(make_light(), clock=SimulatedClock())
     service.send("TIMER")  # before start → no-op

--- a/tests/test_invoke.py
+++ b/tests/test_invoke.py
@@ -9,6 +9,8 @@ Covers:
   - the invoked actor is stopped when its state is exited before completing
 """
 
+import threading
+
 from xstate import (
     Machine,
     SimulatedClock,
@@ -286,3 +288,48 @@ def test_invoke_with_simulated_clock_timer():
     actor = create_actor(machine, clock=SimulatedClock()).start()
     assert actor.get_snapshot().value == "ready"
     assert actor.get_snapshot().context["value"] == 7
+
+
+def test_stop_blocks_late_invocation_reconciliation():
+    child_machine = Machine(
+        {"id": "late-child", "initial": "running", "states": {"running": {}}}
+    )
+    parent_machine = Machine(
+        {
+            "id": "late-parent",
+            "initial": "idle",
+            "states": {
+                "idle": {"on": {"GO": "active"}},
+                "active": {"invoke": {"id": "invoked-child", "src": "child"}},
+            },
+        },
+        actors={"child": child_machine},
+    )
+    parent = create_actor(parent_machine).start()
+    reconciliation_entered = threading.Event()
+    release_reconciliation = threading.Event()
+    original_sync = parent._sync_invocations
+
+    def delayed_sync() -> None:
+        reconciliation_entered.set()
+        assert release_reconciliation.wait(timeout=2.0)
+        original_sync()
+
+    parent._sync_invocations = delayed_sync
+    sender = threading.Thread(target=parent.send, args=("GO",))
+    sender.start()
+    assert reconciliation_entered.wait(timeout=2.0)
+
+    parent.stop()
+    release_reconciliation.set()
+    sender.join(timeout=2.0)
+
+    leaked_child = parent.system.get("invoked-child")
+    try:
+        assert not sender.is_alive()
+        assert parent.status == "stopped"
+        assert parent.children == {}
+        assert leaked_child is None
+    finally:
+        if leaked_child is not None:
+            leaked_child.stop()

--- a/tests/test_microstep_traces.py
+++ b/tests/test_microstep_traces.py
@@ -104,6 +104,50 @@ def test_machine_transition_keeps_all_macrostep_actions():
     assert len(state.actions) == 3
 
 
+def test_untraced_transitions_do_not_capture_trace_only_context_snapshots():
+    class CountingContextAdapter:
+        def __init__(self) -> None:
+            self.snapshot_calls = 0
+
+        def snapshot(self, context: dict[str, int]) -> dict[str, int]:
+            self.snapshot_calls += 1
+            return dict(context)
+
+        def apply(
+            self, context: dict[str, int], updates: dict[str, object]
+        ) -> dict[str, int]:
+            next_context = dict(context)
+            next_context.update(updates)
+            return next_context
+
+    adapter = CountingContextAdapter()
+    machine = Machine(
+        {
+            "id": "trace-capture-policy",
+            "context": {"count": 0},
+            "initial": "a",
+            "states": {
+                "a": {"on": {"GO": "b"}},
+                "b": {},
+            },
+        },
+        context_adapter=adapter,
+    )
+
+    state = machine.initial_state
+    assert adapter.snapshot_calls == 1
+
+    adapter.snapshot_calls = 0
+    next_state = machine.transition(state, "GO")
+    assert next_state.value == "b"
+    assert adapter.snapshot_calls == 1
+
+    adapter.snapshot_calls = 0
+    microsteps = get_microsteps(machine, state, "GO")
+    assert microsteps[-1].snapshot.value == "b"
+    assert adapter.snapshot_calls >= 2
+
+
 def test_get_initial_microsteps_includes_initial_and_eventless_steps():
     machine = Machine(
         {

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+import xstate.algorithm as algorithm
 from xstate import Machine, interpret
 
 
@@ -323,3 +324,43 @@ def test_parallel_conflict_with_nested_target_reenters_sibling_initial_state():
             "b": {"b1": "b11"},
         }
     }
+
+
+def test_parallel_conflict_computes_each_exit_set_once(monkeypatch):
+    region_count = 16
+    regions = {
+        f"region_{index}": {
+            "initial": "a",
+            "states": {
+                "a": {"on": {"GO": "b"}},
+                "b": {},
+            },
+        }
+        for index in range(region_count)
+    }
+    machine = Machine(
+        {
+            "id": "wide-parallel",
+            "initial": "running",
+            "states": {
+                "running": {"type": "parallel", "states": regions},
+            },
+        }
+    )
+    state = machine.initial_state
+    original_compute_exit_set = algorithm.compute_exit_set
+    calls = 0
+
+    def counted_compute_exit_set(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original_compute_exit_set(*args, **kwargs)
+
+    monkeypatch.setattr(algorithm, "compute_exit_set", counted_compute_exit_set)
+
+    state = machine.transition(state, "GO")
+
+    assert all(value == "b" for value in state.value["running"].values())
+    # Conflict filtering computes one exit set per enabled transition. The
+    # selected transition set is computed once more when the microstep exits.
+    assert calls == region_count + 1

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -8,7 +8,16 @@ Covers:
   - Error-status snapshots round-trip
 """
 
-from xstate import Machine, create_actor, deserialize_snapshot, serialize_snapshot
+import json
+from dataclasses import asdict, dataclass
+
+from xstate import (
+    Machine,
+    create_actor,
+    dataclass_context,
+    deserialize_snapshot,
+    serialize_snapshot,
+)
 
 
 def _toggle_machine():
@@ -91,13 +100,121 @@ def test_serialize_error_is_none_for_active():
 
 
 def test_serialize_produces_json_compatible_types():
-    import json
-
     actor = create_actor(_counter_machine()).start()
     actor.send("INC")
     data = serialize_snapshot(actor.get_snapshot())
     # Should not raise
     json.dumps(data)
+
+
+def test_serialized_payload_is_independent_from_live_snapshot():
+    machine = Machine(
+        {
+            "id": "independent",
+            "context": {"nested": {"count": 1}},
+            "initial": "outer",
+            "states": {
+                "outer": {
+                    "initial": "a",
+                    "states": {"a": {}, "b": {}},
+                }
+            },
+        }
+    )
+    snapshot = machine.initial_state
+
+    data = serialize_snapshot(snapshot)
+    data["context"]["nested"]["count"] = 99
+    data["value"]["outer"] = "b"
+
+    assert snapshot.context == {"nested": {"count": 1}}
+    assert snapshot.value == {"outer": "a"}
+
+
+def test_serialized_output_is_independent_from_live_snapshot():
+    machine = Machine(
+        {
+            "id": "independent-output",
+            "initial": "done",
+            "states": {
+                "done": {
+                    "type": "final",
+                    "output": {"nested": {"count": 1}},
+                }
+            },
+        }
+    )
+    snapshot = machine.initial_state
+
+    data = serialize_snapshot(snapshot)
+    data["output"]["nested"]["count"] = 99
+
+    assert snapshot.output == {"nested": {"count": 1}}
+
+
+def test_restored_context_is_independent_from_serialized_payload():
+    machine = Machine(
+        {
+            "id": "independent-restore",
+            "context": {"nested": {"count": 1}},
+            "initial": "active",
+            "states": {"active": {}},
+        }
+    )
+    data = serialize_snapshot(machine.initial_state)
+
+    restored = deserialize_snapshot(machine, data)
+    data["context"]["nested"]["count"] = 99
+
+    assert restored.context == {"nested": {"count": 1}}
+
+
+def test_mutating_state_value_does_not_change_transition_configuration():
+    machine = Machine(
+        {
+            "id": "configuration-authority",
+            "initial": "outer",
+            "states": {
+                "outer": {
+                    "initial": "a",
+                    "states": {"a": {}, "b": {}},
+                }
+            },
+        }
+    )
+    snapshot = machine.initial_state
+    snapshot.value["outer"] = "b"
+
+    next_snapshot = machine.transition(snapshot, "MISSING")
+
+    assert next_snapshot.value == {"outer": "a"}
+
+
+@dataclass(frozen=True, slots=True)
+class DataclassContext:
+    count: int
+
+
+def test_dataclass_context_round_trip_uses_explicit_codec():
+    machine = Machine(
+        {
+            "id": "dataclass-persistence",
+            "context": DataclassContext(count=3),
+            "initial": "active",
+            "states": {"active": {}},
+        },
+        context_adapter=dataclass_context(),
+    )
+
+    data = serialize_snapshot(machine.initial_state, context_serializer=asdict)
+    encoded = json.loads(json.dumps(data))
+    restored = deserialize_snapshot(
+        machine,
+        encoded,
+        context_deserializer=lambda value: DataclassContext(**value),
+    )
+
+    assert restored.context == DataclassContext(count=3)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/typing/positive.py
+++ b/tests/typing/positive.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncIterable, Callable
-from typing import Any, Literal, TypedDict, assert_type
+from typing import Any, Literal, TypedDict, assert_type, cast
 
 from xstate import (
     ActionHandler,
@@ -32,6 +32,7 @@ from xstate import (
     SubscriptionProtocol,
     TransitionTrace,
     create_actor,
+    deserialize_snapshot,
     from_callback,
     from_observable,
     from_promise,
@@ -39,6 +40,7 @@ from xstate import (
     get_microsteps,
     interpret,
     interpret_async,
+    serialize_snapshot,
     setup,
     to_promise,
 )
@@ -120,6 +122,14 @@ state = machine.transition(state, {"type": "INCREMENT", "by": 2})
 assert_type(state.context, Context)
 assert_type(state.output, Output | None)
 assert_type(state.event, Event[AppEvent | Output | BaseException] | None)
+serialized = serialize_snapshot(state, context_serializer=dict)
+assert_type(serialized, dict[str, Any])
+restored = deserialize_snapshot(
+    machine,
+    serialized,
+    context_deserializer=lambda value: cast(Context, value),
+)
+assert_type(restored, State[Context, AppEvent, Output])
 finish_event: FinishEvent = {"type": "FINISH"}
 assert_type(
     get_microsteps(machine, state, finish_event),


### PR DESCRIPTION
## Summary

This PR fixes confirmed runtime lifecycle, snapshot isolation, timer resource,
and transition performance defects found during a fresh audit of master at
`18d6ea972a1dafb4cae29af6b2c6d1aaaf38b3ef`.

It preserves the public `Machine(config, ...)` boundary, run-to-completion
ordering, immutable structural snapshot fields, XState-shaped configuration,
and zero runtime dependencies.

## What changed

### Correctness and lifecycle

- Serialize independent copies of snapshot value, context, and output data.
- Add optional typed context serializer and deserializer callbacks for custom
  context types such as immutable dataclasses.
- Use the immutable snapshot configuration as the transition authority so
  mutating the derived `state.value` cannot change execution.
- Prevent actor stop from racing late invocation reconciliation and leaving a
  running child.
- Serialize child creation with parent lifecycle changes and avoid registering
  a child spawned after its parent stopped.
- Make sync and async interpreter stop terminal. A stopped interpreter cannot
  restart and later events remain dropped.
- Make async stop wait for owned timer task cancellation to settle.
- Prevent later interpreter-owned actions from scheduling new work when stop
  occurs during an awaited async action.

### Performance and resources

- Skip trace-only microstep context snapshots unless a trace helper or an
  interpreter inspector requests them.
- Reuse each transition exit set during parallel conflict resolution.
- Transition from `state.configuration` instead of rebuilding configuration
  from `state.value`.
- Replace one `threading.Timer` per timeout with one on-demand daemon scheduler
  thread per `ThreadClock`. The worker exits after the final timer fires or is
  canceled.

### Typing and maintainability

- Complete full strict MyPy coverage for all 23 source files.
- Add concrete generic task, registry, timeout, and guard mapping annotations.
- Add regression tests for each corrected behavior and update public guidance
  and the unreleased changelog.

## Compatibility

- No package dependency, distribution name, import path, or machine
  configuration boundary changes.
- Snapshot context codec parameters are optional keyword-only additions.
- Trace helpers and inspectors retain their existing snapshots and trace
  ordering.
- Stopped direct interpreters are now terminal, matching stopped actor behavior.
  Code that intentionally restarted the same interpreter must create a new
  interpreter instead.
- `ThreadClock` still gives each clock its own worker; it does not introduce a
  process-global scheduler.
- An async action already awaiting at stop is not forcibly canceled. It may
  finish in its caller's send task, but later runtime actions are skipped.

## Performance evidence

The temporary standard-library-only harness ran outside the repository on
macOS without coverage instrumentation. Each result aggregates seven fresh
processes with three warmups and 21 samples per process. It records median,
p95, process median absolute deviation, operations per second, peak
`tracemalloc` memory, and task or thread counts. Each case verifies its expected
snapshot before timing.

Representative median results:

| Workload | CPython 3.13 before | CPython 3.13 after | CPython 3.14 before | CPython 3.14 after |
|---|---:|---:|---:|---:|
| Ignored transition | 23.59 us | 15.02 us | 23.97 us | 12.84 us |
| Eventless chain, 1,000 | 87.94 ms | 11.40 ms | 87.29 ms | 11.19 ms |
| Dictionary context, 1,000 | 630.83 us | 322.73 us | 274.98 us | 143.24 us |
| Parallel conflicts, 64 regions | 44.05 ms | 3.35 ms | 43.49 ms | 3.09 ms |
| Sync interpreter, no subscribers | 31.01 us | 20.75 us | 30.68 us | 18.38 us |
| Async interpreter, 100 callers | 39.19 us | 30.45 us | 38.30 us | 26.65 us |
| Invoke reconciliation, 100 children | 5.77 ms | 4.60 ms | 5.76 ms | 4.12 ms |
| Thread timer lifecycle, 50 timers | 2.31 ms, 50 threads | 0.134 ms, 1 thread | 2.44 ms, 50 threads | 0.122 ms, 1 thread |
| Snapshot round trip, context 1,000 | 19.62 us | 647.25 us | 21.08 us | 266.53 us |

The snapshot round-trip regression is intentional and material. The old path
returned aliased data and restored shallow context copies, so its timing did
not include the isolation promised by persistence. The new path performs the
required defensive copies. That cost scales with context size and is documented
rather than hidden behind a score.

Profiling after the change confirms that default context `deepcopy` remains the
dominant cost for large mutable dictionary contexts. Exit-set computation is
now once per enabled transition during conflict filtering, trace-only context
copies are absent from ordinary transitions, and 50 real timers use one worker.

These are local macOS measurements, not a service SLO or competitor ranking.
Ubuntu CI proves functionality, not equivalent performance. Cross-platform
performance remains unverified.

The harness and JSON profiles remain in `/private/tmp` and are not tracked.
Generated `dist/` artifacts are ignored and are not part of this PR.

## Validation

Exact branch commit: `10b6d3f5248cba365c70bb501c70955e398b79a9`

- `poetry run python scripts/release_preflight.py v0.7.1 --target-ref HEAD --master-ref HEAD`
  - 496 primary tests passed.
  - 57 configured SCXML cases passed.
  - Ruff format and lint passed.
  - Repository MyPy passed for 23 source files.
  - Metadata and lock checks passed.
  - The sdist and wheel built.
  - Isolated wheel validation and actor smoke passed.
- `poetry run mypy --strict src/xstate/` passed for all 23 source files.
- `poetry run python -m pytest tests/ --ignore=tests/test_scxml.py --cov --cov-report=term`
  passed with 91.34 percent branch coverage against the 90 percent gate.
- A separate CPython 3.13 isolated environment installed the wheel with no
  dependencies and passed a live actor transition and snapshot serialization
  smoke test.
- The complete performance matrix and cProfile plus tracemalloc probes passed
  on CPython 3.13.1 and 3.14.7 at the exact branch commit.
- `git diff --check` passed, added lines are ASCII, and the worktree was clean
  before push.

## Risk and rollback

The highest-risk changes are actor lifecycle locking, the shared timer worker,
terminal interpreter stop behavior, and conflict filtering. Targeted regression
tests cover their failure mechanisms, and the complete SCXML suite protects
run-to-completion behavior.

If rollback is required, revert this single commit. There are no data migrations,
new dependencies, publication changes, or external state changes.

## Review focus

- Lock ordering between parent stop, child stop, spawn, and invocation
  reconciliation.
- Timer heap cleanup and worker exit after cancellation.
- Trace equivalence when inspectors are enabled and trace work is skipped when
  they are absent.
- The explicit snapshot isolation versus serialization cost tradeoff.
- Terminal stop behavior for direct sync and async interpreter users.
